### PR TITLE
Add helm deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ CUDA version - 12.6 or later
 
 Use | Service(s)| Recommended GPU* 
 --- | --- | --- 
-Nemo Retriever Microservices for multi-modal document ingest | `graphic-elements`, `table-structure`, `paddle-ocr`, `nv-ingest`, `embedqa` | 1 x H100 80GB*  <br /> 1 x A100 80GB <br /> 1 x B200 
-Reasoning Model for Report Generation and RAG Q&A Retrieval | `llama-3.3-nemotron-super-49b-v1` with a FP8 profile  | 1 x H100 80 GB* <br /> 2 x A100 80GB <br /> 1 x B200
-Instruct Model for Report Generation | `llama-3.3-70b-instruct` | 2 x H100 80GB* <br /> 4 x A100 80GB <br /> 1 x B200
+Nemo Retriever Microservices for multi-modal document ingest | `graphic-elements`, `table-structure`, `paddle-ocr`, `nv-ingest`, `embedqa` | 1 x H100 80GB*  <br /> 1 x A100 80GB 
+Reasoning Model for Report Generation and RAG Q&A Retrieval | `llama-3.3-nemotron-super-49b-v1` with a FP8 profile  | 1 x H100 80 GB* <br /> 2 x A100 80GB 
+Instruct Model for Report Generation | `llama-3.3-70b-instruct` | 2 x H100 80GB* <br /> 4 x A100 80GB 
 --- | -- | -- 
-**Total** | Entire AI-Q Research Blueprint | 4 x H100 80GB* <br /> 7 x A100 80GB <br /> 3 x B200
+**Total** | Entire AI-Q Research Blueprint | 4 x H100 80GB* <br /> 7 x A100 80GB 
 
 *This recommendation is based off of the configuration used to test the blueprint. For alternative configurations, view the [RAG blueprint documentation](https://github.com/NVIDIA-AI-Blueprints/rag?tab=readme-ov-file#minimum-system-requirements).
 

--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ CUDA version - 12.6 or later
 
 Use | Service(s)| Recommended GPU* 
 --- | --- | --- 
-Nemo Retriever Microservices for multi-modal document ingest | `graphic-elements`, `table-structure`, `paddle-ocr`, `nv-ingest`, `embedqa` | 1 x H100 80GB*  <br /> 1 x A100 80GB
-Reasoning Model for Report Generation and RAG Q&A Retrieval | `llama-3.3-nemotron-super-49b-v1` with a FP8 profile  | 1 x H100 80 GB* <br /> 2 x A100 80GB
-Instruct Model for Report Generation | `llama-3.3-70b-instruct` | 2 x H100 80GB* <br /> 4 x A100 80GB
+Nemo Retriever Microservices for multi-modal document ingest | `graphic-elements`, `table-structure`, `paddle-ocr`, `nv-ingest`, `embedqa` | 1 x H100 80GB*  <br /> 1 x A100 80GB <br /> 1 x B200 
+Reasoning Model for Report Generation and RAG Q&A Retrieval | `llama-3.3-nemotron-super-49b-v1` with a FP8 profile  | 1 x H100 80 GB* <br /> 2 x A100 80GB <br /> 1 x B200
+Instruct Model for Report Generation | `llama-3.3-70b-instruct` | 2 x H100 80GB* <br /> 4 x A100 80GB <br /> 1 x B200
 --- | -- | -- 
-**Total** | Entire AI-Q Research Blueprint | 4 x H100 80GB* <br /> 7 x A100 80GB
+**Total** | Entire AI-Q Research Blueprint | 4 x H100 80GB* <br /> 7 x A100 80GB <br /> 3 x B200
 
 *This recommendation is based off of the configuration used to test the blueprint. For alternative configurations, view the [RAG blueprint documentation](https://github.com/NVIDIA-AI-Blueprints/rag?tab=readme-ov-file#minimum-system-requirements).
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Additionally, the blueprint uses these components:
 
 ## Technical Diagram  
 
-![Architecture Diagram](https://assets.ngc.nvidia.com/products/api-catalog/aiq/diagram.jpg)
+![Architecture Diagram](https://assets.ngc.nvidia.com/products/api-catalog/aiq/diagram.jpg?)
 
 ## Minimum System Requirements 
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Ubuntu 22.04
 ### Deploy Options 
 
 [Docker Compose](/docs/get-started/get-started-docker-compose.md)  
+[Kubernetes with Helm](/docs/get-started/get-started-helm.md)
 
 ### Drivers
 

--- a/data/readme.md
+++ b/data/readme.md
@@ -21,7 +21,7 @@ docker run \
   -e PYTHONUNBUFFERED=1 \
   -v /tmp:/tmp-data \
   --network nvidia-rag \
-  nvcr.io/nvidia/blueprint/aira-load-files:v1.0.0
+  nvcr.io/nvidia/blueprint/aira-load-files:v1.1.0
 ```
 
 ## Bulk Upload via Python 

--- a/deploy/compose/docker-compose.yaml
+++ b/deploy/compose/docker-compose.yaml
@@ -2,6 +2,7 @@ services:
   aira-instruct-llm:
     container_name: aira-instruct-llm
     image: nvcr.io/nim/meta/llama-3.3-70b-instruct:latest
+    runtime: nvidia
     volumes:
     - ${MODEL_DIRECTORY:-./}:/opt/nim/.cache
     user: "${USERID}"
@@ -31,7 +32,8 @@ services:
 
   aira-backend:
     container_name: aira-backend
-    image: nvcr.io/nvidia/blueprint/aira-backend:v1.0.0
+    image: nvcr.io/nvidia/blueprint/aira-backend:v1.1.0
+    runtime: nvidia
     build:
       context: ../../
       dockerfile: aira/Dockerfile
@@ -73,7 +75,7 @@ services:
     
   aira-frontend:
     container_name: aira-frontend
-    image: nvcr.io/nvidia/blueprint/aira-frontend:v1.0.0
+    image: nvcr.io/nvidia/blueprint/aira-frontend:v1.1.0
     ports:
       - "3001:3001"
     expose:

--- a/deploy/helm/aiq-aira/Chart.yaml
+++ b/deploy/helm/aiq-aira/Chart.yaml
@@ -4,7 +4,7 @@ dependencies:
     repository: file://charts/nginx
     version: 0.1.0
 
-  - condition: instruct-llm.enabled
+  - condition: nim-llm.enabled
     name: nim-llm
     repository: https://helm.ngc.nvidia.com/nim
     version: 1.7.0

--- a/deploy/helm/aiq-aira/Chart.yaml
+++ b/deploy/helm/aiq-aira/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     repository: https://helm.ngc.nvidia.com/nim
     version: 1.7.0
 
-description: A Helm chart for NVIDIA AI Research Assistant Blueprint
+description: A Helm chart for NVIDIA AI-Q Research Assistant Blueprint
 name: aiq-aira
 type: application
-version: v1.0.0
+version: v1.1.0

--- a/deploy/helm/aiq-aira/Chart.yaml
+++ b/deploy/helm/aiq-aira/Chart.yaml
@@ -3,6 +3,12 @@ dependencies:
   - name: nginx
     repository: file://charts/nginx
     version: 0.1.0
+
+  - condition: instruct-llm.enabled
+    name: nim-llm
+    repository: https://helm.ngc.nvidia.com/nim
+    version: 1.7.0
+
 description: A Helm chart for NVIDIA AI Research Assistant Blueprint
 name: aiq-aira
 type: application

--- a/deploy/helm/aiq-aira/Chart.yaml
+++ b/deploy/helm/aiq-aira/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+dependencies:
+  - name: nginx
+    repository: file://charts/nginx
+    version: 0.1.0
+description: A Helm chart for NVIDIA AI Research Assistant Blueprint
+name: aiq-aira
+type: application
+version: v1.0.0

--- a/deploy/helm/aiq-aira/charts/nginx/.helmignore
+++ b/deploy/helm/aiq-aira/charts/nginx/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/aiq-aira/charts/nginx/Chart.yaml
+++ b/deploy/helm/aiq-aira/charts/nginx/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 1.16.0
+description: A Helm chart for Kubernetes
+name: nginx
+type: application
+version: 0.1.0

--- a/deploy/helm/aiq-aira/charts/nginx/templates/_helpers.tpl
+++ b/deploy/helm/aiq-aira/charts/nginx/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nginx.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nginx.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nginx.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "nginx.labels" -}}
+helm.sh/chart: {{ include "nginx.chart" . }}
+{{ include "nginx.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nginx.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nginx.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "nginx.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "nginx.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/aiq-aira/charts/nginx/templates/nginx-configmap.yaml
+++ b/deploy/helm/aiq-aira/charts/nginx/templates/nginx-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  nginx.conf: |-
+    {{ .Values.nginx_config.conf | nindent 4 }}
+kind: ConfigMap
+metadata:
+  name: {{ .Values.nginx_config.name }}

--- a/deploy/helm/aiq-aira/charts/nginx/templates/nginx-proxy-deployment.yaml
+++ b/deploy/helm/aiq-aira/charts/nginx/templates/nginx-proxy-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nginx.fullname" . }}
+  labels:
+    {{- include "nginx.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "nginx.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "nginx.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      imagePullSecrets:
+        - name: {{ .Values.global.ngcImagePullSecretName | default .Values.imagePullSecret.name }}
+      containers:
+      - name: {{ .Chart.Name }}
+        {{- if and .Values.nginxImage.ngcImageRegistry .Values.nginxImage.ngcImageRegistryPath }}
+        image: "{{ .Values.nginxImage.ngcImageRegistry }}/{{ .Values.nginxImage.ngcImageRegistryPath }}/{{ .Values.nginxImage.name }}:{{ .Values.nginxImage.tag }}"
+        {{- else }}
+        image: "{{ .Values.nginxImage.name }}:{{ .Values.nginxImage.tag }}"
+        {{- end }}
+        imagePullPolicy: {{ .Values.nginxImage.imagePullPolicy }}
+        ports:
+          - name: inference
+            containerPort: {{ .Values.service.port }}
+            protocol: TCP
+        {{- with .Values.volumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+        

--- a/deploy/helm/aiq-aira/charts/nginx/templates/nginx-proxy-service.yaml
+++ b/deploy/helm/aiq-aira/charts/nginx/templates/nginx-proxy-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nginx.fullname" . }}
+  labels:
+    {{- include "nginx.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      protocol: TCP
+  selector:
+    {{- include "nginx.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/aiq-aira/charts/nginx/values.yaml
+++ b/deploy/helm/aiq-aira/charts/nginx/values.yaml
@@ -1,0 +1,126 @@
+# Default values for nginx.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+
+global:
+  ngcImagePullSecretName: ""
+
+imagePullSecret:
+   name: "pull-secret"
+
+nginxImage:
+  ngcImageRegistry: "nvcr.io"    # set it to empty string "" if want to use dockerhub nginx image
+  ngcImageRegistryPath: "goirlvsxnepa/blueprints"  # set it to empty string "" if want to use dockerhub nginx image
+  name: "nginx"
+  tag: "1.27.0"
+  pullPolicy: Always
+
+nginx_config:    # under conf: |- update values for proxy_pass at 3 places according to target host. 
+  name: "nginx-config"
+  conf: |-
+    worker_processes auto;
+
+    events {
+        worker_connections 1024;
+    }
+
+    http {
+        proxy_ssl_server_name on;
+
+        proxy_cache_path /server_cache_llm levels=1:2 keys_zone=llm_cache:10m max_size=20g inactive=14d use_temp_path=off;
+
+        proxy_cache_path /server_cache_intel levels=1:2 keys_zone=intel_cache:10m max_size=20g inactive=14d use_temp_path=off;
+
+        error_log /dev/stdout info;
+
+        log_format upstream_time '$remote_addr - $remote_user [$time_local] '
+                                '"$request" $status $body_bytes_sent '
+                                '"$http_referer" "$http_user_agent"'
+                                'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"';
+
+        log_format cache_log '[$time_local] ($upstream_cache_status) "$request" $status - $body_bytes_sent bytes {$remote_addr} "$http_user_agent" $request_time - $connection_requests. Auth: $http_authorization';
+
+        log_format no_cache_log '[$time_local] (BYPASSED) "$request" $status - $body_bytes_sent bytes {$remote_addr} "$http_user_agent" $request_time - $connection_requests. Auth: $http_authorization';
+
+        log_format mirror_log '[$time_local] (MIRROR) "$request" $status - $body_bytes_sent bytes {$remote_addr} "$http_user_agent" $request_time - $connection_requests. Auth: $http_authorization';
+
+        log_format nvai_cache_log '[$time_local] ($upstream_cache_status) "$request" $status - $body_bytes_sent bytes {$remote_addr} "$http_user_agent" $request_time - $connection_requests. Auth: $http_authorization. $upstream_addr';
+
+        map $http_cache_control $cache_bypass {
+            no-cache   1;
+        }
+
+        # Log to stdout and a file for searchability
+        access_log /dev/stdout cache_log;
+        access_log /var/log/nginx/access.log cache_log;
+
+        error_log /dev/stdout info;
+        error_log /var/log/nginx/error.log info;
+
+        server {
+            listen 8000;
+            server_name localhost;
+
+            location /v1/files {
+                proxy_pass <replace-with-vdb-base-url>/v1/documents;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_pass_request_headers on;
+            }
+
+            location /v1/collections {
+                limit_except POST DELETE {
+                    deny all;
+                }
+                proxy_pass <replace-with-vdb-base-url>/v1/collections;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_pass_request_headers on;
+            }
+
+            location / {
+                proxy_pass <replace-with-aira-base-url>;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_read_timeout 300s;
+                proxy_pass_request_headers on;
+            }
+
+            error_page 500 502 503 504 /50x.html;
+            location = /50x.html {
+                root /usr/share/nginx/html;
+            }
+        }
+    }
+
+service:
+  type: ClusterIP
+  port: 8000
+
+# same configmap name should be should while mounting it as volumes.
+# configmap_name: nginx-config
+
+# Additional volumes on the output Deployment definition.
+volumes: 
+      - name: nginx-config
+        configMap:
+          name: nginx-config
+          defaultMode: 0755
+          items:
+            - key: nginx.conf
+              path: nginx.conf
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts:
+      - name: nginx-config
+        mountPath: /etc/nginx/nginx.conf
+        subPath: nginx.conf
+        readOnly: true
+

--- a/deploy/helm/aiq-aira/templates/_helpers.tpl
+++ b/deploy/helm/aiq-aira/templates/_helpers.tpl
@@ -67,3 +67,17 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create secret to access NGC Api
+*/}}
+{{- define "ngcApiSecret" }}
+{{- printf "%s" .Values.ngcApiSecret.password | b64enc }}
+{{- end }}
+
+{{/*
+Generate DockerConfigJson for image pull secrets
+*/}}
+{{- define "imagePullSecret" }}
+{{- printf "{\"auths\":{\"%s\":{\"auth\":\"%s\"}}}" .Values.imagePullSecret.registry (printf "%s:%s" .Values.imagePullSecret.username .Values.imagePullSecret.password | b64enc) | b64enc }}
+{{- end }}

--- a/deploy/helm/aiq-aira/templates/_helpers.tpl
+++ b/deploy/helm/aiq-aira/templates/_helpers.tpl
@@ -1,0 +1,69 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "aiq-aira.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "aiq-aira.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "aiq-aira.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Generate DockerConfigJson for image pull secrets
+*/}}
+{{- define "createImagePullSecret" }}
+{{- printf "{\"auths\":{\"%s\":{\"auth\":\"%s\"}}}" .Values.imagePullSecret.registry (printf "%s:%s" .Values.imagePullSecret.username .Values.imagePullSecret.password | b64enc) | b64enc }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "aiq-aira.labels" -}}
+helm.sh/chart: {{ include "aiq-aira.chart" . }}
+{{ include "aiq-aira.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "aiq-aira.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "aiq-aira.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "aiq-aira.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "aiq-aira.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/aiq-aira/templates/configmap.yaml
+++ b/deploy/helm/aiq-aira/templates/configmap.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "aiq-aira.fullname" . }}-config
+data:
+  config.yml: |+
+    general:
+      use_uvloop: true
+      front_end:
+        _type: fastapi
+        cors:
+          allow_origins: ['*']
+        endpoints:
+          - path: /generate_query
+            method: POST
+            description: Creates the query
+            function_name: generate_query
+          - path: /generate_summary
+            method: POST
+            description: Generates the summary
+            function_name: generate_summary
+          - path: /artifact_qa
+            method: POST
+            description: Q/A or chat about a previously generated artifact
+            function_name: artifact_qa
+          - path: /aiqhealth
+            method: GET
+            description: Health check for the AIQ AIRA service
+            function_name: health_check
+          - path: /default_collections
+            method: GET
+            description: Get the default collections
+            function_name: default_collections
+    llms:
+      instruct_llm:
+        _type: openai
+        model_name: {{ .Values.config.instruct_model_name }}
+        temperature: {{ .Values.config.instruct_temperature }}
+        api_key: {{ .Values.config.instruct_api_key }}
+        base_url: {{ .Values.config.instruct_base_url }}
+      nemotron:
+        _type: openai
+        model_name: {{ .Values.config.nemotron_model_name }}
+        temperature: {{ .Values.config.nemotron_temperature }}
+        base_url: {{ .Values.config.nemotron_base_url }}
+        max_tokens: {{ .Values.config.nemotron_max_tokens }}
+        stream: {{ .Values.config.nemotron_stream }}
+        api_key: {{ .Values.config.nemotron_api_key }}
+    functions:
+      generate_query:
+        _type: generate_queries
+      generate_summary:
+        _type: generate_summaries
+        rag_url: {{ .Values.config.rag_url }}
+      artifact_qa:
+        _type: artifact_qa
+        llm_name: instruct_llm
+        rag_url: {{ .Values.config.rag_url }}
+      health_check:
+        _type: health_check
+      default_collections:
+        _type: default_collections
+        collections:
+          - name: "Biomedical_Dataset"
+            topic: "Biomedical"
+            report_organization: "You are a medical researcher who specializes in cystic fibrosis. Create a report analyzing how CFTR modulators can be used to restore CFTR protein functions. Include a 150-200 word abstract and a methods, results, and discussion section. Format your answer in paragraphs. Consider all (and only) relevant data. Give a factual report with cited sources."
+          - name: "Financial_Dataset"
+            topic: "Financial"
+            report_organization: "You are a financial analyst who specializes in financial statement analysis. Write a financial report analyzing the 2023 financial performance of Amazon. Identify trends in revenue growth, net income, and total assets. Discuss how these trends affected Amazon's yearly financial performance for 2023. Your output should be organized into a brief introduction, as many sections as necessary to create a comprehensive report, and a conclusion. Format your answer in paragraphs. Use factual sources such as Amazon's quarterly meeting releases for 2023. Cross analyze the sources to draw original and sound conclusions and explain your reasoning for arriving at conclusions. Do not make any false or unverifiable claims. I want a factual report with cited sources."
+    workflow:
+      _type: ai_researcher
+      

--- a/deploy/helm/aiq-aira/templates/configmap.yaml
+++ b/deploy/helm/aiq-aira/templates/configmap.yaml
@@ -6,6 +6,14 @@ data:
   config.yml: |+
     general:
       use_uvloop: true
+      {{- if .Values.phoenix.enabled }}
+      telemetry:
+        tracing:
+          phoenix:
+            _type: phoenix
+            endpoint: http://{{ .Release.Name }}-phoenix.{{ .Release.Namespace }}.svc.cluster.local:6006/v1/traces
+            project: ai_researcher
+      {{- end }}
       front_end:
         _type: fastapi
         cors:

--- a/deploy/helm/aiq-aira/templates/deployment.yaml
+++ b/deploy/helm/aiq-aira/templates/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-aira-backend
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: aira-backend
+  template:
+    metadata:
+      labels:
+        app: aira-backend
+    spec:
+      imagePullSecrets:
+        - name: {{ .Values.ngcImagePullSecretName }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ include "aiq-aira.fullname" . }}-config
+      containers:
+        - name: aira-backend
+          command:
+            - /bin/bash
+            - -c
+            - {{ .Values.command }} --config_file /etc/config/config.yml
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: TAVILY_API_KEY
+              value: {{ .Values.config.tavily_api_key | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP

--- a/deploy/helm/aiq-aira/templates/deployment.yaml
+++ b/deploy/helm/aiq-aira/templates/deployment.yaml
@@ -23,10 +23,10 @@ spec:
           command:
             - /bin/bash
             - -c
-            - {{ .Values.command }} --config_file /etc/config/config.yml
+            - {{ .Values.command }}
           volumeMounts:
             - name: config-volume
-              mountPath: /etc/config
+              mountPath: /app/configs
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:

--- a/deploy/helm/aiq-aira/templates/frontend-service.yaml
+++ b/deploy/helm/aiq-aira/templates/frontend-service.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.frontend.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-aira-frontend
+spec:
+  type: {{ .Values.frontend.service.type }}
+  ports:
+    - port: {{ .Values.frontend.service.port }}
+      targetPort: {{ .Values.frontend.service.targetPort }}
+      protocol: TCP
+  selector:
+    app: aira-frontend
+{{- end }}

--- a/deploy/helm/aiq-aira/templates/frontend.yaml
+++ b/deploy/helm/aiq-aira/templates/frontend.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.frontend.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-aira-frontend
+spec:
+  replicas: {{ .Values.frontend.replicaCount }}
+  selector:
+    matchLabels:
+      app: aira-frontend
+  template:
+    metadata:
+      labels:
+        app: aira-frontend
+    spec:
+      imagePullSecrets:
+        - name: {{ .Values.ngcImagePullSecretName }}
+      containers:
+        - name: aira-frontend
+          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
+          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.frontend.service.port }}
+              protocol: TCP
+          env:
+            - name: INFERENCE_ORIGIN
+              value: {{ .Values.frontend.proxyUrl }}
+{{- end }}

--- a/deploy/helm/aiq-aira/templates/job.yaml
+++ b/deploy/helm/aiq-aira/templates/job.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.loadFiles.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: load-files-nv-ingest
+  namespace: {{ .Release.Namespace }}
+spec:
+  template:
+    spec:
+      imagePullSecrets:
+      - name: {{ .Values.ngcImagePullSecretName }}
+      containers:
+      - name: load-files-nv-ingest
+        image: {{ .Values.loadFiles.image.repository }}:{{ .Values.loadFiles.image.tag }}
+        imagePullPolicy: {{ .Values.loadFiles.image.pullPolicy }}
+        env:
+        - name: MILVUS_HOST
+          value: {{ .Values.config.milvus_host | quote }}
+        - name: MILVUS_PORT
+          value: {{ .Values.config.milvus_port | quote }}
+        - name: RAG_INGEST_URL
+          value: {{ .Values.config.rag_ingest_url | quote }}
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        volumeMounts:
+        - name: tempdata
+          mountPath: /tmp-data
+      volumes:
+      - name: tempdata
+        emptyDir: {}
+
+      restartPolicy: OnFailure 
+{{- end }}

--- a/deploy/helm/aiq-aira/templates/phoenix-tracing.yaml
+++ b/deploy/helm/aiq-aira/templates/phoenix-tracing.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.phoenix.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-phoenix
+  labels:
+    app: phoenix
+    {{- include "aiq-aira.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: phoenix
+      {{- include "aiq-aira.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        app: phoenix
+        {{- include "aiq-aira.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: phoenix
+          image: "{{ .Values.phoenix.image.repository }}:{{ .Values.phoenix.image.tag }}"
+          imagePullPolicy: {{ .Values.phoenix.image.pullPolicy }}
+          ports:
+            - name: ui-otlp-http
+              containerPort: 6006
+              protocol: TCP
+            - name: otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.phoenix.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-phoenix
+  labels:
+    {{- include "aiq-aira.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6006
+      targetPort: ui-otlp-http
+      protocol: TCP
+      name: ui-otlp-http
+    - port: 4317
+      targetPort: otlp-grpc
+      protocol: TCP
+      name: otlp-grpc
+  selector:
+    app: phoenix
+    {{- include "aiq-aira.selectorLabels" . | nindent 4 }}
+{{- end }} 

--- a/deploy/helm/aiq-aira/templates/secrets.yaml
+++ b/deploy/helm/aiq-aira/templates/secrets.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.imagePullSecret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.imagePullSecret.name }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ include "createImagePullSecret" . | quote }}
+{{- end }}

--- a/deploy/helm/aiq-aira/templates/secrets.yaml
+++ b/deploy/helm/aiq-aira/templates/secrets.yaml
@@ -7,3 +7,25 @@ type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ include "createImagePullSecret" . | quote }}
 {{- end }}
+
+{{ if and .Values.ngcApiSecret.create -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.ngcApiSecret.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  NGC_CLI_API_KEY: {{ include "ngcApiSecret" . | quote }}
+  NGC_API_KEY: {{ include "ngcApiSecret" . | quote }}
+  NVIDIA_API_KEY: {{ include "ngcApiSecret" . | quote }}
+{{- end }}

--- a/deploy/helm/aiq-aira/templates/service.yaml
+++ b/deploy/helm/aiq-aira/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-aira-backend
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+  selector:
+    app: aira-backend

--- a/deploy/helm/aiq-aira/values.yaml
+++ b/deploy/helm/aiq-aira/values.yaml
@@ -7,11 +7,11 @@ replicaCount: 1
 # The name of the image pull secret to use for the AIQ container images.
 # Either create the secret manually and update the name here
 # or update the imagePullSecret.password with your NGC API key
-ngcImagePullSecretName: "pull-secret"
+ngcImagePullSecretName: "ngc-secret"
 
 imagePullSecret:
   create: true
-  name: "pull-secret"
+  name: "ngc-secret"
   registry: "nvcr.io"
   username: "$oauthtoken"
   password: "" #UPDATE THIS
@@ -32,7 +32,7 @@ config:
   instruct_model_name: "meta/llama-3.3-70b-instruct"
   instruct_temperature: "0.0"
   instruct_api_key: "not-needed" 
-  instruct_base_url: "http://aira-instruct-llm.aira.svc.cluster.local:8000/v1"
+  instruct_base_url: "http://nim-llm.aira.svc.cluster.local:8000/v1"
   # The nemotron_ settings are for the reasoning LLM
   nemotron_api_key: "not-needed" # not needed as we use the nemotron service from the RAG deployment which does not require an API key
   nemotron_model_name: "nvidia/llama-3.3-nemotron-super-49b-v1"
@@ -58,12 +58,17 @@ command: "/entrypoint.sh"
 # The nemotron llm is assumed to be deployed via the RAG helm chart
 # ------------------------------------------------------------
 
-instruct-llm:
+ngcApiSecret:
+  name: "ngc-api"
+  password: "" # UPDATE THIS
+  create: true
+
+nim-llm:
   enabled: true
   service:
-    name: "aira-instruct-llm"
+    name: "nim-llm"
   image:
-      repository: nvcr.io/nim/meta/llama-3.3-70b-instruct:1.8.5
+      repository: nvcr.io/nim/meta/llama-3.3-70b-instruct
       pullPolicy: IfNotPresent
       tag: "1.8.5"
   resources:
@@ -72,7 +77,6 @@ instruct-llm:
     requests:
       nvidia.com/gpu: 2
   model:
-    ngcAPIKey: "" # UPDATE THIS
     name: "meta/llama-3.3-70b-instruct"
 
 

--- a/deploy/helm/aiq-aira/values.yaml
+++ b/deploy/helm/aiq-aira/values.yaml
@@ -19,7 +19,7 @@ imagePullSecret:
 # The image repository and tag for the AIQ AIRA backend service.
 image:  
   repository: nvcr.io/nvidia/blueprint/aira-backend
-  tag: v1.0.0
+  tag: v1.1.0
   pullPolicy: IfNotPresent
 
 # The service type and port for the main AIQ AIRA backend service
@@ -252,7 +252,7 @@ frontend:
 
   image:
     repository: nvcr.io/nvidia/blueprint/aira-frontend
-    tag: v1.0.0
+    tag: v1.1.0
     pullPolicy: IfNotPresent
 
   replicaCount: 1
@@ -268,7 +268,7 @@ loadFiles:
   enabled: true
   image:
     repository: nvcr.io/nvidia/blueprint/aira-load-files
-    tag: v1.0.0
+    tag: v1.1.0
     pullPolicy: IfNotPresent
 
 # Enables the Phoenix tracing service

--- a/deploy/helm/aiq-aira/values.yaml
+++ b/deploy/helm/aiq-aira/values.yaml
@@ -1,0 +1,247 @@
+
+# ------------------------------------------------------------
+# The following values are for the AIQ AIRA backend service.
+# ------------------------------------------------------------
+
+replicaCount: 1
+
+# The name of the image pull secret to use for the AIQ container images.
+# Either create the secret manually and update the name here
+# or update the imagePullSecret.password with your NGC API key
+ngcImagePullSecretName: "pull-secret"
+
+imagePullSecret:
+  create: true
+  name: "pull-secret"
+  registry: "nvcr.io"
+  username: "$oauthtoken"
+  password: "" #UPDATE THIS
+
+# The image repository and tag for the AIQ AIRA backend service.
+image:  
+  repository: nvcr.io/nvidia/blueprint/aira-backend
+  tag: v1.0.0
+  pullPolicy: IfNotPresent
+
+# The service type and port for the main AIQ AIRA backend service
+service:
+  port: 3838
+
+# Update each value according to your desired configuration.
+config:
+  # The instruct_ settings are for the general purpose Q&A LLM
+  instruct_model_name: "meta/llama-3.3-70b-instruct"
+  instruct_temperature: "0.0"
+  instruct_api_key: "" #UPDATE THIS
+  instruct_base_url: "https://integrate.api.nvidia.com/v1"
+  # The nemotron_ settings are for the reasoning LLM
+  nemotron_api_key: "not-needed" # not needed as we use the nemotron service from the RAG deployment which does not require an API key
+  nemotron_model_name: "nvidia/llama-3.3-nemotron-super-49b-v1"
+  nemotron_temperature: "0.5"
+  nemotron_base_url: "http://nim-llm.rag.svc.cluster.local:8000/v1" # provided by the RAG deployment 
+  nemotron_max_tokens: "5000"
+  nemotron_stream: "true"
+  # Enter your Tavily API key here to enable web search
+  tavily_api_key: "" #UPDATE THIS
+  # Enter the IP address of the RAG services
+  rag_ingest_url: "http://ingestor-server.rag.svc.cluster.local:8082" # provided by the RAG deployment 
+  rag_url: "http://rag-server.rag.svc.cluster.local:8081" # provided by the RAG deployment 
+  rag_api_key: "" #Typically not required
+  milvus_host: "milvus.rag.svc.cluster.local" # provided by the RAG deployment 
+  milvus_port: "19530"
+
+# Do not update this command. It is the default command to launch the AI-Q backend service.
+command: "entrypoint.sh"
+
+# ------------------------------------------------------------
+# The following values are for the nginx proxy that enables the AIQ frontend
+# to interact with both the AIQ AIRA backend service and the RAG service
+# 
+# You may need to update the RAG service IP address if you have not deployed RAG via helm on the same cluster
+# ------------------------------------------------------------
+
+nginx:
+  
+  nginxImage:
+    ngcImageRegistry: "" 
+    ngcImageRegistryPath: ""
+    name: "nginx"
+    tag: "1.27.0"
+    pullPolicy: Always
+
+  service:
+    port: 8051
+
+  nginx_config: 
+    conf: |-
+      worker_processes auto;
+
+      events {
+          worker_connections 1024;
+      }
+
+      http {
+          proxy_ssl_server_name on;
+
+          proxy_cache_path /server_cache_llm levels=1:2 keys_zone=llm_cache:10m max_size=20g inactive=14d use_temp_path=off;
+
+          proxy_cache_path /server_cache_intel levels=1:2 keys_zone=intel_cache:10m max_size=20g inactive=14d use_temp_path=off;
+
+          error_log /dev/stdout info;
+
+          log_format upstream_time '$remote_addr - $remote_user [$time_local] '
+                                  '"$request" $status $body_bytes_sent '
+                                  '"$http_referer" "$http_user_agent"'
+                                  'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"';
+
+          log_format cache_log '[$time_local] ($upstream_cache_status) "$request" $status - $body_bytes_sent bytes {$remote_addr} "$http_user_agent" $request_time - $connection_requests. Auth: $http_authorization';
+
+          log_format no_cache_log '[$time_local] (BYPASSED) "$request" $status - $body_bytes_sent bytes {$remote_addr} "$http_user_agent" $request_time - $connection_requests. Auth: $http_authorization';
+
+          log_format mirror_log '[$time_local] (MIRROR) "$request" $status - $body_bytes_sent bytes {$remote_addr} "$http_user_agent" $request_time - $connection_requests. Auth: $http_authorization';
+
+          log_format nvai_cache_log '[$time_local] ($upstream_cache_status) "$request" $status - $body_bytes_sent bytes {$remote_addr} "$http_user_agent" $request_time - $connection_requests. Auth: $http_authorization. $upstream_addr';
+
+          map $http_cache_control $cache_bypass {
+              no-cache   1;
+          }
+
+          # Log to stdout and a file for searchability
+          access_log /dev/stdout cache_log;
+          access_log /var/log/nginx/access.log cache_log;
+
+          error_log /dev/stdout info;
+          error_log /var/log/nginx/error.log info;
+
+          server {
+            listen 8051;
+            server_name _;
+
+            # Common proxy settings
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_pass_request_headers on;
+
+            # Common buffer settings
+            large_client_header_buffers 4 32k;
+            client_header_buffer_size 4k;
+
+            # Common timeout settings
+            client_body_timeout 900s;
+            client_header_timeout 900s;
+
+            # Common settings for document-related endpoints
+            proxy_read_timeout 600s;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 600s;
+            client_max_body_size 100M;
+            proxy_max_temp_file_size 0;
+            proxy_buffering on;
+            proxy_buffer_size 1M;
+            proxy_buffers 100 1M;
+            proxy_busy_buffers_size 2M;
+
+            # Original routes
+            location ~ ^/v1/(status|documents|collections) {
+                proxy_pass http://ingestor-server.rag.svc.cluster.local:8082/$1$is_args$args;
+                proxy_set_header Host http://ingestor-server.rag.svc.cluster.local:8082;
+            }
+
+            # Protected routes
+            location ~ ^/v2/protected/aiq/v1/(status|documents|collections) {
+                proxy_pass http://ingestor-server.rag.svc.cluster.local:8082/$1$is_args$args;
+                proxy_set_header Host http://ingestor-server.rag.svc.cluster.local:8082;
+            }
+
+            # Special case for files route
+            location /v2/protected/aiq/v1/files {
+                proxy_pass http://ingestor-server.rag.svc.cluster.local:8082/v1/documents;
+                proxy_set_header Host http://ingestor-server.rag.svc.cluster.local:8082;
+            }
+
+            # Protected routes AIRA v1 
+            location ~ ^/v2/protected/aiq/v1/((generate_query|generate_summary|artifact_qa|default_collections)(/stream)?)$ {
+                proxy_pass http://aira-aira-backend.aira.svc.cluster.local:3838/$1$is_args$args;
+                proxy_set_header Host http://aira-aira-backend.aira.svc.cluster.local:3838;
+            }
+
+            # Health routes
+            location /v2/protected/aiq/keepalive {
+                default_type text/plain;
+                return 200 "OK";         
+            }
+
+            location /v2/protected/aiq/health {
+                default_type text/plain;
+                return 200 "OK";         
+            }
+            
+            location = /health {
+                default_type text/plain;
+                return 200 "OK";
+            }
+
+            location = /keepalive {
+                default_type text/plain;
+                return 200 "OK";
+            }
+
+
+            # Catch-all for other protected routes
+            location /v2/protected/aiq/ {
+                rewrite ^/v2/protected/aiq/(.*) /$1 break;
+                proxy_pass http://aira-aira-backend.aira.svc.cluster.local:3838;
+                proxy_set_header Host $host;
+            }
+
+            # Default location for all other routes
+            location / {
+                proxy_pass http://aira-aira-backend.aira.svc.cluster.local:3838;
+                proxy_set_header Host $host;
+            }
+
+            error_page 500 502 503 504 /50x.html;
+            location = /50x.html {
+                root /usr/share/nginx/html;
+            }
+        }
+
+
+      }
+
+# ------------------------------------------------------------
+# The following values are for the AIQ AIRA frontend service.
+# ------------------------------------------------------------
+
+# The frontend application is a React web app. We recommend a NodePort so the frontend will be accessible at <your-node-ip>:3001
+frontend:
+  enabled: true
+  # Update the value below to the IP address and port of the nginx service
+  proxyUrl: http://aira-nginx.aira.svc.cluster.local:8051
+  service:
+    port: 3001
+    targetPort: 3001
+
+  image:
+    repository: nvcr.io/nvidia/blueprint/aira-frontend
+    tag: v1.0.0
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+# ------------------------------------------------------------
+# The following values are optional utility services
+# ------------------------------------------------------------
+
+# Creates two default milvus collections with sample PDFs
+# This job, if enabled, can take ~60 minutes to complete after helm inst
+# During this time manual uploads from the frontend may not work
+loadFiles:
+  enabled: true
+  image:
+    repository: nvcr.io/nvidia/blueprint/aira-load-files
+    tag: v1.0.0
+    pullPolicy: IfNotPresent
+
+

--- a/deploy/helm/aiq-aira/values.yaml
+++ b/deploy/helm/aiq-aira/values.yaml
@@ -244,4 +244,17 @@ loadFiles:
     tag: v1.0.0
     pullPolicy: IfNotPresent
 
-
+# Enables the Phoenix tracing service
+phoenix:
+  enabled: true
+  image:
+    repository: arizephoenix/phoenix
+    tag: latest
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 200m
+      memory: 256Mi

--- a/deploy/helm/aiq-aira/values.yaml
+++ b/deploy/helm/aiq-aira/values.yaml
@@ -51,7 +51,7 @@ config:
   milvus_port: "19530"
 
 # Do not update this command. It is the default command to launch the AI-Q backend service.
-command: "entrypoint.sh"
+command: "/entrypoint.sh"
 
 # ------------------------------------------------------------
 # The following values are for the nginx proxy that enables the AIQ frontend

--- a/deploy/helm/aiq-aira/values.yaml
+++ b/deploy/helm/aiq-aira/values.yaml
@@ -1,4 +1,3 @@
-
 # ------------------------------------------------------------
 # The following values are for the AIQ AIRA backend service.
 # ------------------------------------------------------------
@@ -32,8 +31,8 @@ config:
   # The instruct_ settings are for the general purpose Q&A LLM
   instruct_model_name: "meta/llama-3.3-70b-instruct"
   instruct_temperature: "0.0"
-  instruct_api_key: "" #UPDATE THIS
-  instruct_base_url: "https://integrate.api.nvidia.com/v1"
+  instruct_api_key: "not-needed" 
+  instruct_base_url: "http://aira-instruct-llm.aira.svc.cluster.local:8000/v1"
   # The nemotron_ settings are for the reasoning LLM
   nemotron_api_key: "not-needed" # not needed as we use the nemotron service from the RAG deployment which does not require an API key
   nemotron_model_name: "nvidia/llama-3.3-nemotron-super-49b-v1"
@@ -52,6 +51,30 @@ config:
 
 # Do not update this command. It is the default command to launch the AI-Q backend service.
 command: "/entrypoint.sh"
+
+
+# ------------------------------------------------------------
+# The following values are for the instruct LLM service
+# The nemotron llm is assumed to be deployed via the RAG helm chart
+# ------------------------------------------------------------
+
+instruct-llm:
+  enabled: true
+  service:
+    name: "aira-instruct-llm"
+  image:
+      repository: nvcr.io/nim/meta/llama-3.3-70b-instruct:1.8.5
+      pullPolicy: IfNotPresent
+      tag: "1.8.5"
+  resources:
+    limits:
+      nvidia.com/gpu: 2
+    requests:
+      nvidia.com/gpu: 2
+  model:
+    ngcAPIKey: "" # UPDATE THIS
+    name: "meta/llama-3.3-70b-instruct"
+
 
 # ------------------------------------------------------------
 # The following values are for the nginx proxy that enables the AIQ frontend

--- a/docs/get-started/get-started-docker-compose.md
+++ b/docs/get-started/get-started-docker-compose.md
@@ -214,7 +214,7 @@ docker run \
   -e PYTHONUNBUFFERED=1 \
   -v /tmp:/tmp-data \
   --network nvidia-rag \
-  nvcr.io/nvidia/blueprint/aira-load-files:v1.0.0
+  nvcr.io/nvidia/blueprint/aira-load-files:v1.1.0
 ```
 
 This command will populate the default collections with sample documents. Note that this process can take up to 60 minutes to complete, during which time manual uploads from the frontend may not work properly.

--- a/docs/get-started/get-started-docker-compose.md
+++ b/docs/get-started/get-started-docker-compose.md
@@ -76,7 +76,7 @@ export MODEL_DIRECTORY=~/.cache/model-cache
 Before deploying the AI-Q Research Assistant, deploy RAG by following [these instructions](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/quickstart.md#start-using-on-prem-models).
 
 ```bash
-git clone https://github.com/NVIDIA-AI-Blueprints/rag.git -b v2.1.0
+git clone https://github.com/NVIDIA-AI-Blueprints/rag.git
 ```
 
 Deploy the RAG NVIDIA NIM microservices, including the LLM. *This step can take up to 45 minutes*.

--- a/docs/get-started/get-started-helm.md
+++ b/docs/get-started/get-started-helm.md
@@ -140,7 +140,7 @@ loadFiles:
   enabled: true
   image:
     repository: nvcr.io/nvstaging/blueprint/aira-load-files
-    tag: v1.0.0
+    tag: v1.1.0
     pullPolicy: IfNotPresent
 ```
 

--- a/docs/get-started/get-started-helm.md
+++ b/docs/get-started/get-started-helm.md
@@ -117,10 +117,25 @@ phoenix:
 
 ### Deploy 
 
+Set environment variables:
+
+```bash
+export NGC_API_KEY=nvapi-xxx # your API key
+export TAVILY_API_KEY=yyy # your Tavily API key, optional for web search
+```
+
 Create a namespace:
 
 ```bash
 kubectl create namespace aira
+```
+
+Update the chart dependencies:
+
+```bash
+helm repo add nvidia-nim https://helm.ngc.nvidia.com/nim/nvidia/ --username='$oauthtoken' --password=$NGC_API_KEY
+helm repo add nim https://helm.ngc.nvidia.com/nim/ --username='$oauthtoken' --password=$NGC_API_KEY
+helm dependency update deploy/helm/aiq-aira
 ```
 
 Deploy the chart:

--- a/docs/get-started/get-started-helm.md
+++ b/docs/get-started/get-started-helm.md
@@ -48,6 +48,31 @@ Create a namespace:
 kubectl create namespace aira
 ```
 
+### Deploy the chart:
+
+```bash
+helm upgrade --install aira -n aira https://helm.ngc.nvidia.com/nvidia/blueprint/charts/aiq-aira-v1.1.0.tgz \
+  --username='$oauthtoken'  \
+  --password=$NGC_API_KEY \
+  --set imagePullSecret.password=$NGC_API_KEY \
+  --set ngcApiSecret.password=$NGC_API_KEY \
+  --set config.tavily_api_key=$TAVILY_API_KEY
+```
+
+To make the frontend available, you will want to add a node port, for example: 
+
+```bash
+kubectl patch svc aira-aira-frontend -n aira -p '{"spec": {"type": "NodePort", "ports": [{"name": "http", "port": 3001, "nodePort": 30001}]}}'
+```
+
+If you have enabled phoenix tracing, add a node port for the phoenix service as well:
+
+```bash
+kubectl patch svc aira-phoenix -n aira -p '{"spec": {"type": "NodePort", "ports": [{"port": 6006, "nodePort": 30006}]}}'
+```
+
+#### Deploy from source
+
 Update the chart dependencies:
 
 ```bash
@@ -55,6 +80,7 @@ helm repo add nvidia-nim https://helm.ngc.nvidia.com/nim/nvidia/ --username='$oa
 helm repo add nim https://helm.ngc.nvidia.com/nim/ --username='$oauthtoken' --password=$NGC_API_KEY
 helm dependency update deploy/helm/aiq-aira
 ```
+
 
 Deploy the chart:
 
@@ -172,12 +198,12 @@ To stop all services, run the following commands:
 
 1. Delete the AIRA deployment:
 ```bash
-helm uninstall aira -n aira
+helm delete aira -n aira
 ```
 
 2. Delete the RAG deployment:
 ```bash
-helm uninstall rag -n rag
+helm delete rag -n rag
 ```
 
 3. Delete the namespaces:

--- a/docs/get-started/get-started-helm.md
+++ b/docs/get-started/get-started-helm.md
@@ -24,22 +24,40 @@ The system includes the following components:
 
 ## Deployment
 
-### Configure your my-values.yaml
+### Deploy RAG
+
+Follow the [NVIDIA RAG blueprint deployment guide](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/quickstart.md#deploy-with-helm-chart) to deploy the RAG blueprint. **The configuration of the AI-Q Research Assistant assumes you have deployed RAG with the default settings into the `rag` namespace.**
+
+### Configure your `my-values.yaml`
 
 The `values.yaml` file is located at `deploy/helm/aiq-aira/values.yaml`. Create a copy of this file called `my-values.yaml` and update the configuration sections according to your environment. 
 
-The required configuration values include:
-
 - Update the `imagePullSecret.password` with your NGC API key
+- Update `tavily_api_key` with your Tavily API key if you want to enable web search
+
+**Using a build endpoint**
+
+If you want to use a NVIDIA build endpoint for the Llama 3.3 70B Instruct model:
+
+- Update the value `instruct_api_key` with your NVIDIA API key 
+
+**Using a separate NIM**
+
+If you want to locally host the Llama 3.3 70B Instruct model:
+
+- Deploy the model on a *separate server* following the [NIM deployment guides](https://docs.nvidia.com/nim/large-language-models/latest/deployment-guide.html)
+- Update the value `instruct_base_url` to the base url for your deployed NIM
+
+
+**Other options**
+
+The following configuration values have appropriate defaults, but may require updates depending on your Kubernetes provider or desired deployment.
 
 - In the section `config`, update:
-  - [ ] `nim_model_name`: the model to use for general purpose Q&A, default is meta/llama-3.3-70b-instruct
-  - [ ] `nim_base_url`: the base url for the nim model
-  - [ ] `nim_api_key`: the api key for the nim model
+  - [ ] `instruct_model_name`: the model to use for general purpose Q&A, default is meta/llama-3.3-70b-instruct
   - [ ] `nemotron_model_name`: the model to use for reasoning, default is `nvidia/llama-3.3-nemotron-super-49b-v1` 
   - [ ] `nemotron_base_url`: the base url for the nemotron model, default is to use a RAG deployment local NIM
   - [ ] `nemotron_api_key`: the api key for the nemotron model, not needed if using a local NIM
-  - [ ] `tavily_api_key`: your Tavily api key, used for web search
   - [ ] `rag_ingest_url`: the full address to the RAG ingest-server, default is to use the RAG local service address 
   - [ ] `rag_url`: the full address to the rag-server,  default is to use the RAG local service address 
 
@@ -55,9 +73,9 @@ The required configuration values include:
   
   These values are correct if you have deployed the RAG service using helm onto the same Kubernetes cluster, and your cluster supports local DNS resolution. If you deployed RAG differently, or your cluster does not support local DNS, update the RAG ingestion service and the AIRA backend service URLs. Include the entirety of the nginx configuration in your values.yaml file, but make updates to these specific lines:
 
-  Update the value `ingestor-server.rag.svc.cluster.local:8082` to the IP address and port of the RAG ingestor server. This address must be DNS resolvable by the nginx proxy.
+  Update each occurence of `ingestor-server.rag.svc.cluster.local:8082` to the IP address and port of the RAG ingestor server. This address must be DNS resolvable by the nginx proxy.
 
-  Update the value `aira-aira-backend.aira.svc.cluster.local:3838` to the IP address and port that the AIRA backend server will have after your deployment is complete. This address must be DNS resolvable by the nginx proxy.
+  Update each occurence of `aira-aira-backend.aira.svc.cluster.local:3838` to the IP address and port that the AIRA backend server will have after your deployment is complete. This address must be DNS resolvable by the nginx proxy.
 
 
 - Similarly, the default value of the configuration `frontend.proxyURL` is `http://aira-nginx.aira.svc.cluster.local:8051` which is the local DNS address of the backend proxy used to configure the frontend service. In most cases you do not need to update this value. However, if your cluster does not support local DNS resolution, update the value the IP address and port of the AIRA nginx proxy service.
@@ -79,26 +97,52 @@ loadFiles:
 
 **When this job is enabled, it will begin a file upload process during deployment that could take upwards of 60 minutes. During this period, manual file uploads through the AIRA frontend may not work.**
 
+### Enable Phoenix Tracing
+
+The configuration section `phoenix` determines whether or not to deploy and configure a Phoenix service for collecting trace logs.
+
+```
+phoenix:
+  enabled: true
+  image:
+    repository: arizephoenix/phoenix
+    tag: latest
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 200m
+      memory: 256Mi
+```
+
 ### Deploy 
 
 Create a namespace:
 
-```
+```bash
 kubectl create namespace aira
 ```
 
 Deploy the chart:
 
-```
+```bash
 helm install aira -n aira deploy/helm/aiq-aira -f deploy/helm/aiq-aira/my-values.yaml
 ```
 
 To make the frontend available you will want to add a node port, for example: 
 
-```
-# frontend
+```bash
 kubectl patch svc aira-aira-frontend -n aira -p '{"spec": {"type": "NodePort", "ports": [{"name": "http", "port": 3001, "nodePort": 30001}]}}'
 ```
+
+If you have enabled phoenix tracing, add a node port for the phoenix service as well:
+
+```bash
+kubectl patch svc aira-phoenix -n aira -p '{"spec": {"type": "NodePort", "ports": [{"port": 6006, "nodePort": 30006}]}}
+```
+
 
 ## Stopping Services
 

--- a/docs/get-started/get-started-helm.md
+++ b/docs/get-started/get-started-helm.md
@@ -128,7 +128,7 @@ Deploy the chart:
 ```bash
 helm upgrade --install aira -n aira deploy/helm/aiq-aira \
   --set imagePullSecret.password=$NGC_API_KEY \
-  --set instruct-llm.model.ngcAPIKey=$NGC_API_KEY \
+  --set ngcApiSecret.password=$NGC_API_KEY \
   --set config.tavily_api_key=$TAVILY_API_KEY
 ```
 

--- a/docs/get-started/get-started-helm.md
+++ b/docs/get-started/get-started-helm.md
@@ -1,0 +1,121 @@
+# NVIDIA AI Research Assistant Deployment with Helm
+
+This guide provides instructions for deploying the NVIDIA AI-Q Research Assistant blueprint using Helm on a Kubernetes cluster.
+
+## Components
+
+The system includes the following components:
+
+- AI-Q Research Assistant Backend
+- AI-Q Demo Frontend
+- NGINX Proxy
+
+*Note*: The demo frontend is provided as a pre-built docker container containing a fully functional web application. The source code for this web application is not distributed.
+
+## Prerequisites
+
+- A NGC API key that is able to access the AI-Q blueprint images.  
+- Deploy the [NVIDIA RAG blueprint](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/quickstart.md#deploy-with-helm-chart). This blueprint requires NVIDIA NIM microservices that are either running on-premise or hosted by NVIDIA. For a full on-premise deployment, 8xH100 or 8xA100 GPUs are required.  
+- Access to a Llama 3.3 Nemotron Super 49B with an associated API key, or a RAG deployment that includes a local Nemotron Super 49B NIM.
+- Access to a Llama 3.3 Instruct 70B model with an associated API key. **Note, by default a helm RAG deployment will use all 8 GPUs, and so it is not possible to run the instruct model on the same server. You MUST either deploy the instruct model on a separate server or use a hosted NVIDIA NIM endpoint. In either case, be sure to follow the instructions below to update the AIRA configuration with the appropriate base URL for the instruct model**.  
+- Kubernetes and Helm with [NVIDIA GPU Operator installed](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html#operator-install-guide)
+- [Optional] A Tavily API key to support web search.
+
+
+## Deployment
+
+### Configure your my-values.yaml
+
+The `values.yaml` file is located at `deploy/helm/aiq-aira/values.yaml`. Create a copy of this file called `my-values.yaml` and update the configuration sections according to your environment. 
+
+The required configuration values include:
+
+- Update the `imagePullSecret.password` with your NGC API key
+
+- In the section `config`, update:
+  - [ ] `nim_model_name`: the model to use for general purpose Q&A, default is meta/llama-3.3-70b-instruct
+  - [ ] `nim_base_url`: the base url for the nim model
+  - [ ] `nim_api_key`: the api key for the nim model
+  - [ ] `nemotron_model_name`: the model to use for reasoning, default is `nvidia/llama-3.3-nemotron-super-49b-v1` 
+  - [ ] `nemotron_base_url`: the base url for the nemotron model, default is to use a RAG deployment local NIM
+  - [ ] `nemotron_api_key`: the api key for the nemotron model, not needed if using a local NIM
+  - [ ] `tavily_api_key`: your Tavily api key, used for web search
+  - [ ] `rag_ingest_url`: the full address to the RAG ingest-server, default is to use the RAG local service address 
+  - [ ] `rag_url`: the full address to the rag-server,  default is to use the RAG local service address 
+
+- In the nginx configuration section, the following values are used to direct traffic to the AI research assistant backend and RAG backend.
+
+  ```
+    ... 
+    proxy_pass http://ingestor-server.rag.svc.cluster.local:8082
+    ...
+    proxy_pass http://aira-aira-backend.aira.svc.cluster.local:3838
+    ....
+  ```
+  
+  These values are correct if you have deployed the RAG service using helm onto the same Kubernetes cluster, and your cluster supports local DNS resolution. If you deployed RAG differently, or your cluster does not support local DNS, update the RAG ingestion service and the AIRA backend service URLs. Include the entirety of the nginx configuration in your values.yaml file, but make updates to these specific lines:
+
+  Update the value `ingestor-server.rag.svc.cluster.local:8082` to the IP address and port of the RAG ingestor server. This address must be DNS resolvable by the nginx proxy.
+
+  Update the value `aira-aira-backend.aira.svc.cluster.local:3838` to the IP address and port that the AIRA backend server will have after your deployment is complete. This address must be DNS resolvable by the nginx proxy.
+
+
+- Similarly, the default value of the configuration `frontend.proxyURL` is `http://aira-nginx.aira.svc.cluster.local:8051` which is the local DNS address of the backend proxy used to configure the frontend service. In most cases you do not need to update this value. However, if your cluster does not support local DNS resolution, update the value the IP address and port of the AIRA nginx proxy service.
+
+
+### Create default collections
+
+The AI research assistant demo web application requires two default collections. One collection supports a biomedical research prompt and contains reports on Cystic Fibrosis. The second supports a financial research prompt and contains public financial documents from Alphabet, Meta, and Amazon. To include these default collections in your deployment, include this section in your custom values file:
+
+
+```
+loadFiles:
+  enabled: true
+  image:
+    repository: nvcr.io/nvstaging/blueprint/aira-load-files
+    tag: v1.0.0
+    pullPolicy: IfNotPresent
+```
+
+**When this job is enabled, it will begin a file upload process during deployment that could take upwards of 60 minutes. During this period, manual file uploads through the AIRA frontend may not work.**
+
+### Deploy 
+
+Create a namespace:
+
+```
+kubectl create namespace aira
+```
+
+Deploy the chart:
+
+```
+helm install aira -n aira deploy/helm/aiq-aira -f deploy/helm/aiq-aira/my-values.yaml
+```
+
+To make the frontend available you will want to add a node port, for example: 
+
+```
+# frontend
+kubectl patch svc aira-aira-frontend -n aira -p '{"spec": {"type": "NodePort", "ports": [{"name": "http", "port": 3001, "nodePort": 30001}]}}'
+```
+
+## Stopping Services
+
+To stop all services, run the following commands:
+
+1. Delete the AIRA deployment:
+```bash
+helm uninstall aira -n aira
+```
+
+2. Delete the RAG deployment:
+```bash
+helm uninstall rag -n rag
+```
+
+3. Delete the namespaces:
+```bash
+kubectl delete namespace aira
+kubectl delete namespace rag
+```

--- a/docs/get-started/get-started-helm.md
+++ b/docs/get-started/get-started-helm.md
@@ -15,107 +15,25 @@ The system includes the following components:
 ## Prerequisites
 
 - A NGC API key that is able to access the AI-Q blueprint images.  
-- Deploy the [NVIDIA RAG blueprint](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/quickstart.md#deploy-with-helm-chart). **In order to deploy the NVIDIA RAG blueprint and the AI-Q research assistant blueprint on one 8 GPU system you MUST deploy RAG following the [MIG deployment guide](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/mig-deployment.md).**
 - Kubernetes and Helm with [NVIDIA GPU Operator installed](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html#operator-install-guide)
 - [Optional] A Tavily API key to support web search.
-
 
 ## Deployment
 
 ### Deploy RAG
 
-Follow the [NVIDIA RAG blueprint MIG deployment guide](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/mig-deployment.md) to deploy the RAG blueprint. 
+The [NVIDIA RAG blueprint Helm deployment guide](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/quickstart.md#deploy-with-helm-chart) provides a few options for deploying the RAG blueprint. *How you deploy the RAG blueprint will impact how you deploy the AI-Q research assistant blueprint*. 
 
-**The configuration of the AI-Q Research Assistant assumes you have deployed RAG following the MIG deployment guide into the `rag` namespace. The RAG deployment will include a deployment of a service named nim-llm which provides a Llama Nemotron Super 49B reasoning model. This model is re-used by the AI-Q research assistant**
+The following table provides the main alternatives:
 
-### Optional: Configure your `my-values.yaml`
-
-The `values.yaml` file is located at `deploy/helm/aiq-aira/values.yaml`. Create a copy of this file called `my-values.yaml` and update any configuration sections according to your environment. 
-
-**Optional: Using a build endpoint**
-
-If you want to use a NVIDIA build endpoint for the Llama 3.3 70B instruct model:
-
-- Update the value `config.instruct_api_key` with your NVIDIA API key 
-- Update the value `config.instruct_base_url` to be `https://integrate.api.nvidia.com/v1`
-
-**Optional: Using NIM LLMs on separate nodes**
-
-If you want to deploy the Llama 3.3 70B instruct model separately from the AI-Q research assistant deployment:
-
-- Deploy the model on a *separate server* following the [NIM deployment guides](https://docs.nvidia.com/nim/large-language-models/latest/deployment-guide.html)
-- Update the value `config.instruct_base_url` to the base url for your deployed NIM
+Hardware | RAG Deployment | AIRA Deployment
+--- | --- | ---
+1 GPU | [Use Hosted NIM Microservices](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/quickstart.md#start-using-nvidia-hosted-models) | [Configure for Hosted NIM Microservices](#deploying-with-nvidia-hosted-build-endpoints)
+8x GPU | [Use MIG sharing](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/mig-deployment.md) | [Default Deployment](#deploy-the-ai-q-research-assistant) 
+Multi-node 8x GPU system (total of at least 10 GPUs) | [Default Deployment](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/docs/quickstart.md#deploy-with-helm-chart) | [Default Deployment](#deploy-the-ai-q-research-assistant)
 
 
-**Other options**
-
-The following configuration values have appropriate defaults, but may require updates depending on your Kubernetes provider or desired deployment.
-
-- In the section `config`, update:
-  - [ ] `instruct_model_name`: the model to use for general purpose Q&A, default is `meta/llama-3.3-70b-instruct`
-  - [ ] `nemotron_model_name`: the model to use for reasoning, default is `nvidia/llama-3.3-nemotron-super-49b-v1` 
-  - [ ] `nemotron_base_url`: the base url for the nemotron model, default is to use a RAG deployment local NIM
-  - [ ] `nemotron_api_key`: the api key for the nemotron model, not needed if using a local NIM
-  - [ ] `rag_ingest_url`: the full address to the RAG ingest-server, default is to use the RAG local service address 
-  - [ ] `rag_url`: the full address to the rag-server,  default is to use the RAG local service address 
-
-- In the nginx configuration section, the following values are used to direct traffic to the AI-Q research assistant backend and RAG backend.
-
-  ```
-    ... 
-    proxy_pass http://ingestor-server.rag.svc.cluster.local:8082
-    ...
-    proxy_pass http://aira-aira-backend.aira.svc.cluster.local:3838
-    ....
-  ```
-  
-  These values are correct if you have deployed the RAG service using helm onto the same Kubernetes cluster, and your cluster supports local DNS resolution. If you deployed RAG differently, or your cluster does not support local DNS, update the RAG ingestion service and the AIRA backend service URLs. Include the entirety of the nginx configuration in your values.yaml file, but make updates to these specific lines:
-
-  Update each occurence of `ingestor-server.rag.svc.cluster.local:8082` to the IP address and port of the RAG ingestor server. This address must be DNS resolvable by the nginx proxy.
-
-  Update each occurence of `aira-aira-backend.aira.svc.cluster.local:3838` to the IP address and port that the AIRA backend server will have after your deployment is complete. This address must be DNS resolvable by the nginx proxy.
-
-
-- Similarly, the default value of the configuration `frontend.proxyURL` is `http://aira-nginx.aira.svc.cluster.local:8051` which is the local DNS address of the backend proxy used to configure the frontend service. In most cases you do not need to update this value. However, if your cluster does not support local DNS resolution, update the value the IP address and port of the AIRA nginx proxy service.
-
-
-### Create default collections
-
-The AI research assistant demo web application requires two default collections. One collection supports a biomedical research prompt and contains reports on Cystic Fibrosis. The second supports a financial research prompt and contains public financial documents from Alphabet, Meta, and Amazon. To include these default collections in your deployment, include this section in your custom values file:
-
-
-```
-loadFiles:
-  enabled: true
-  image:
-    repository: nvcr.io/nvstaging/blueprint/aira-load-files
-    tag: v1.0.0
-    pullPolicy: IfNotPresent
-```
-
-**When this job is enabled, it will begin a file upload process during deployment that could take upwards of 60 minutes. During this period, manual file uploads through the AIRA frontend may not work.**
-
-### Enable Phoenix Tracing
-
-The configuration section `phoenix` determines whether or not to deploy and configure a Phoenix service for collecting trace logs.
-
-```
-phoenix:
-  enabled: true
-  image:
-    repository: arizephoenix/phoenix
-    tag: latest
-    pullPolicy: IfNotPresent
-  resources:
-    limits:
-      cpu: 500m
-      memory: 512Mi
-    requests:
-      cpu: 200m
-      memory: 256Mi
-```
-
-### Deploy 
+### Deploy the AI-Q research assistant
 
 Set environment variables:
 
@@ -147,7 +65,7 @@ helm upgrade --install aira -n aira deploy/helm/aiq-aira \
   --set config.tavily_api_key=$TAVILY_API_KEY
 ```
 
-To make the frontend available you will want to add a node port, for example: 
+To make the frontend available, you will want to add a node port, for example: 
 
 ```bash
 kubectl patch svc aira-aira-frontend -n aira -p '{"spec": {"type": "NodePort", "ports": [{"name": "http", "port": 3001, "nodePort": 30001}]}}'
@@ -156,9 +74,97 @@ kubectl patch svc aira-aira-frontend -n aira -p '{"spec": {"type": "NodePort", "
 If you have enabled phoenix tracing, add a node port for the phoenix service as well:
 
 ```bash
-kubectl patch svc aira-phoenix -n aira -p '{"spec": {"type": "NodePort", "ports": [{"port": 6006, "nodePort": 30006}]}}
+kubectl patch svc aira-phoenix -n aira -p '{"spec": {"type": "NodePort", "ports": [{"port": 6006, "nodePort": 30006}]}}'
 ```
 
+
+## Optional Configurations
+
+### Create a `my-values.yaml` file
+
+The default `values.yaml` file is located at `deploy/helm/aiq-aira/values.yaml`. Create a copy of this file called `my-values.yaml` and update any configuration sections according to your environment.
+
+
+### Deploying with NVIDIA hosted build endpoints
+
+Ensure the NVIDIA RAG blueprint has been deployed using hosted endpoints. Then:
+
+If you want to use a NVIDIA build endpoint for the Llama 3.3 70B instruct model:
+
+- Update the value `config.instruct_api_key` with your NVIDIA API key 
+- Update the value `config.nemotron_api_key` with your NVIDIA API key 
+- Update the value `config.instruct_base_url` to be `https://integrate.api.nvidia.com/v1`
+- Update the value `config.nemotron_base_url` to be `https://integrate.api.nvidia.com/v1`
+
+### Other options
+
+The following configuration values have appropriate defaults, but may require updates depending on your Kubernetes provider or desired deployment.
+
+- In the section `config`, update:
+  - [ ] `instruct_model_name`: the model to use for general purpose Q&A, default is `meta/llama-3.3-70b-instruct`
+  - [ ] `instruct_base_url`: the model to use for general purpose Q&A, default is a local NIM deployed as part of the AIRA helm chart
+  - [ ] `instruct_api_key`: the api key for the instruct model, not needed if using a local NIM
+  - [ ] `nemotron_model_name`: the model to use for reasoning, default is `nvidia/llama-3.3-nemotron-super-49b-v1` 
+  - [ ] `nemotron_base_url`: the base URL for the nemotron model, default is to use a local NIM deployed as part of the RAG helm chart
+  - [ ] `nemotron_api_key`: the API key for the nemotron model, not needed if using a local NIM
+  - [ ] `rag_ingest_url`: the full address to the RAG ingest-server, default is to use the RAG local service address 
+  - [ ] `rag_url`: the full address to the rag-server, default is to use the RAG local service address 
+
+- In the nginx configuration section, the following values are used to direct traffic to the AI-Q research assistant backend and RAG backend.
+
+  ```
+    ... 
+    proxy_pass http://ingestor-server.rag.svc.cluster.local:8082
+    ...
+    proxy_pass http://aira-aira-backend.aira.svc.cluster.local:3838
+    ....
+  ```
+  
+  These values are correct if you have deployed the RAG service using helm onto the same Kubernetes cluster, and your cluster supports local DNS resolution. If you deployed RAG differently, or your cluster does not support local DNS, update the RAG ingestion service and the AIRA backend service URLs. Include the entirety of the nginx configuration in your values.yaml file, but make updates to these specific lines:
+
+  Update each occurrence of `ingestor-server.rag.svc.cluster.local:8082` to the IP address and port of the RAG ingestor server. This address must be DNS resolvable by the nginx proxy.
+
+  Update each occurrence of `aira-aira-backend.aira.svc.cluster.local:3838` to the IP address and port that the AIRA backend server will have after your deployment is complete. This address must be DNS resolvable by the nginx proxy.
+
+
+- Similarly, the default value of the configuration `frontend.proxyURL` is `http://aira-nginx.aira.svc.cluster.local:8051` which is the local DNS address of the backend proxy used to configure the frontend service. In most cases you do not need to update this value. However, if your cluster does not support local DNS resolution, update the value to the IP address and port of the AIRA nginx proxy service.
+
+
+## Create default collections
+
+The AI research assistant demo web application requires two default collections. One collection supports a biomedical research prompt and contains reports on Cystic Fibrosis. The second supports a financial research prompt and contains public financial documents from Alphabet, Meta, and Amazon. To include these default collections in your deployment, include this section in your custom values file:
+
+
+```
+loadFiles:
+  enabled: true
+  image:
+    repository: nvcr.io/nvstaging/blueprint/aira-load-files
+    tag: v1.0.0
+    pullPolicy: IfNotPresent
+```
+
+**When this job is enabled, it will begin a file upload process during deployment that could take upwards of 60 minutes. During this period, manual file uploads through the AIRA frontend may not work.**
+
+## Enable phoenix tracing
+
+The configuration section `phoenix` determines whether or not to deploy and configure a Phoenix service for collecting trace logs.
+
+```
+phoenix:
+  enabled: true
+  image:
+    repository: arizephoenix/phoenix
+    tag: latest
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 200m
+      memory: 256Mi
+```
 
 ## Stopping Services
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -47,7 +47,7 @@ docker run \
 ```bash
 docker run \
   -e INFERENCE_ORIGIN=http://localhost:8051 \
-  nvcr.io/nvidia/blueprint/aira-frontend:v1.0.0
+  nvcr.io/nvidia/blueprint/aira-frontend:v1.1.0
 ```
 
 ## Unit Tests


### PR DESCRIPTION
⚠️ WARNING: this branch is experimental. The Helm chart has not been published as an artifact and should be used from source. The chart may require updates on your system. ⚠️ 

This PR adds a helm chart to deploy the AI-Q research assistant including the backend, demo frontend, nginx proxy, and file load utility. 

It assumes the NVIDIA RAG blueprint helm chart has been deployed following the default instructions. See the get-started-helm.md README for details.