### PR TITLE
Pin llama version

### DIFF
--- a/deploy/compose/docker-compose.yaml
+++ b/deploy/compose/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   aira-instruct-llm:
     container_name: aira-instruct-llm
-    image: nvcr.io/nim/meta/llama-3.3-70b-instruct:latest
+    image: nvcr.io/nim/meta/llama-3.3-70b-instruct:1.10.1
     runtime: nvidia
     volumes:
     - ${MODEL_DIRECTORY:-./}:/opt/nim/.cache

--- a/deploy/workbench/docker-compose.yaml
+++ b/deploy/workbench/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   aira-instruct-llm:
     container_name: aira-instruct-llm
-    image: nvcr.io/nim/meta/llama-3.3-70b-instruct:latest
+    image: nvcr.io/nim/meta/llama-3.3-70b-instruct:1.10.1
     volumes:
     - ${MODEL_DIRECTORY:-/tmp}:/opt/nim/.cache
     user: "${USERID}"


### PR DESCRIPTION
The latest version of `nvcr.io/nim/meta/llama-3.3-70b-instruct` (1.12.0) is having deployment issues. This PR pins it to the last tested working version