### PR TITLE
fix artifact_qa by appending sources to updated reports

### DIFF
--- a/aira/src/aiq_aira/artifact_utils.py
+++ b/aira/src/aiq_aira/artifact_utils.py
@@ -120,17 +120,17 @@ async def artifact_chat_handler(llm, input_data: ArtifactQAInput) -> ArtifactQAO
 
     # 1) If user specifically wants a rewrite:
     if input_data.rewrite_mode:
-
         if rewrite_mode == ArtifactRewriteMode.ENTIRE:
-
             updated = await do_entire_artifact_rewrite(llm, current_artifact,
                                                        add_context_to_user_message(user_message))
+            # add sources to the updated report if they exist
+            if hasattr(input_data, 'sources') and input_data.sources:
+                updated = updated + "\n\n" + input_data.sources
 
             return ArtifactQAOutput(
                 updated_artifact=updated,
                 assistant_reply="Here is the updated artifact (entire rewrite)."
             )
-
         else:
             # Unrecognized rewrite mode
             return ArtifactQAOutput(
@@ -179,7 +179,12 @@ async def artifact_chat_handler(llm, input_data: ArtifactQAInput) -> ArtifactQAO
 
     assistant_reply = answer_buf.strip()
 
+    # Add sources if they exist
+    final_artifact = current_artifact
+    if hasattr(input_data, 'sources') and input_data.sources:
+        final_artifact = current_artifact + "\n\n" + input_data.sources
+    
     return ArtifactQAOutput(
-        updated_artifact=current_artifact,
+        updated_artifact=final_artifact,
         assistant_reply=assistant_reply
     )

--- a/aira/src/aiq_aira/functions/artifact_qa.py
+++ b/aira/src/aiq_aira/functions/artifact_qa.py
@@ -114,8 +114,6 @@ async def artifact_qa_fn(config: ArtifactQAConfig, aiq_builder: Builder):
             [rag_citation], [rag_answer], [relevancy], [web_answer], [gen_query]
         )
 
-        logger.info(f"Artifact QA Query message: {query_message}")
-
         return await artifact_chat_handler(llm, query_message)
 
     async def _artifact_qa_streaming(query_message: ArtifactQAInput) -> AsyncGenerator[ArtifactQAOutput, None]:
@@ -173,8 +171,6 @@ async def artifact_qa_fn(config: ArtifactQAConfig, aiq_builder: Builder):
         query_message.question += "\n\n --- ADDITIONAL CONTEXT --- \n" + deduplicate_and_format_sources(
             [rag_citation], [rag_answer], [relevancy], [web_answer], [gen_query]
         )
-
-        logger.info(f"Artifact QA Query message: {query_message}")
 
         yield await artifact_chat_handler(llm, query_message)
 


### PR DESCRIPTION
- Modified `artifact_chat_handler` to include sources in the updated artifact if they exist.
- Updated the final artifact output to reflect the inclusion of sources, improving the completeness of responses.
- Removed unnecessary logging of query messages in `artifact_qa_fn` for cleaner code.