### PR TITLE
Fix AIQ Dependency

### DIFF
--- a/aira/pyproject.toml
+++ b/aira/pyproject.toml
@@ -81,9 +81,6 @@ dev = [
     "pytest-dotenv>=0.5.2",
 ]
 
-[tool.uv.sources]
-aiq = { path = "../ai-query-engine", editable = true }
-
 [tool.uv]
 managed = true
 


### PR DESCRIPTION
Removed uv override in `pyproject.toml` that caused the aiq dependency to be read from a non-existant local directory. Now aiq library is pulled from Pypi.