### PR TITLE
fix: update the model name and the deploy document

### DIFF
--- a/configs/config.yml
+++ b/configs/config.yml
@@ -31,7 +31,7 @@ llms:
   # Update if you are deploying differently or using hosted NVIDIA NIM microservices.
   instruct_llm:
     _type: nim
-    model_name: meta-llama/llama-3.3-70b-instruct
+    model_name: meta/llama-3.3-70b-instruct
     temperature: 0.0
     base_url: ${INSTRUCT_LLM_BASE_URL:-http://aira-instruct-llm:8000/v1}
     max_tokens: 20000

--- a/configs/eval_config.yml
+++ b/configs/eval_config.yml
@@ -58,7 +58,7 @@ llms:
   # Update if you are deploying differently or using hosted NVIDIA NIM microservices.
   instruct_llm:
     _type: nim
-    model_name: meta-llama/llama-3.3-70b-instruct
+    model_name: meta/llama-3.3-70b-instruct
     temperature: 0.0
     base_url: ${INSTRUCT_LLM_BASE_URL:-http://aira-instruct-llm:8000/v1}
     max_tokens: 20000

--- a/deploy/helm/aiq-aira/values.yaml
+++ b/deploy/helm/aiq-aira/values.yaml
@@ -33,7 +33,7 @@ service:
   port: 3838
 
 backendEnvVars:
-  INSTRUCT_MODEL_NAME: "meta-llama/llama-3.3-70b-instruct"
+  INSTRUCT_MODEL_NAME: "meta/llama-3.3-70b-instruct"
   INSTRUCT_MODEL_TEMP: "0.0"
   NEMOTRON_MAX_TOKENS: "5000"
   INSTRUCT_MAX_TOKENS: "20000"
@@ -65,7 +65,7 @@ nim-llm:
       value: ""  # Empty for automatic selection, or specify tensorrt_llm profile
   model:
     ngcAPIKey: ""
-    name: "meta-llama/llama-3.3-70b-instruct"
+    name: "meta/llama-3.3-70b-instruct"
 
 # -----------------------------------------------------------
 # The following values are for the AIQ AIRA frontend service.

--- a/docs/get-started/get-started-docker-compose.md
+++ b/docs/get-started/get-started-docker-compose.md
@@ -177,7 +177,7 @@ USERID=$(id -u) docker run --rm --gpus all \
 Using the list of model profiles from the previous step, set the NIM_MODEL_PROFILE. It is ideal to select one of the tensorrt_llm profiles for best performance. Here is an example of selecting one of these profiles for two H100 GPUs:
 
 ```bash
-export NIM_MODEL_PROFILE="tensorrt_llm-h100-fp8-tp2-pp1-throughput-2330:10de-bedaf1e0ba87272295f4fcb590e781436120751026098f448fd8bc4d711ba5d7-4"
+export NIM_MODEL_PROFILE="tensorrt_llm-h100-fp8-tp2-pp1-throughput-2330:10de-0013e870ea929584ec13dad6948450024cdc6c2f03a865f1b050fb08b9f64312-2"
 ```
 
 #### Hardware-Specific Profiles
@@ -186,27 +186,27 @@ The following tensorrt_llm profiles are optimized for different common GPU confi
 
 ##### 2xH100 NVL
 ```
-tensorrt_llm-h100_nvl-fp8-tp2-pp1-throughput-2321:10de-5e20634213cb4c32e86f048dbc274eb8bff74720af81fe400d8924e766f3e723-4
+tensorrt_llm-h100_nvl-fp8-tp2-pp1-throughput-2321:10de-3035d73242fb579040fb3f341adc36a7073f780419e73dd97edb7ce35cb0f550-2
 ```
 
 ##### 2xH100 SXM
 ```
-tensorrt_llm-h100-fp8-tp2-pp1-throughput-2330:10de-bedaf1e0ba87272295f4fcb590e781436120751026098f448fd8bc4d711ba5d7-4
+tensorrt_llm-h100-fp8-tp2-pp1-throughput-2330:10de-0013e870ea929584ec13dad6948450024cdc6c2f03a865f1b050fb08b9f64312-2
 ```
 
 ##### 4xA100
 ```
-tensorrt_llm-a100-bf16-tp4-pp1-throughput-20b2:10de-8dfffd86cd28a6ea7086f8d3d33f0d60c66df738652cea44c722766b77508b5c-4
+tensorrt_llm-a100-bf16-tp4-pp1-throughput-20b2:10de-f14e1bad1a0e78da150aeedfee7919ab3ef21def09825caffef460b93fdde9b7-4
 ```
 
 ##### 2xRTX PRO 6000
 ```
-tensorrt_llm-rtx6000_blackwell_sv-nvfp4-tp2-pp1-latency-2bb5:10de-b5d32ce12a99b422e2c5a9a772bfd29493467cd5f22248ed936e2d43c5747771-2
+tensorrt_llm-rtx6000_blackwell_sv-fp8-tp2-pp1-throughput-2bb5:10de-77ab630b949b0a58ad580a22ea055bc392a30fbf57357d6398814e00775aab8c-2
 ```
 
 ##### 2xB200
 ```
-tensorrt_llm-b200-bf16-tp2-pp1-latency-2901:10de-d89dfd90f9f326864bc6051f45b5aca8e758fdb009b1da43d93b1d5a2236026e-2
+tensorrt_llm-b200-bf16-tp2-pp1-throughput-2901:10de-6d1452af26f860b53df112c90f6b92f22a41156c09dafa2582c2c1194e56a673-2
 ```
 
 More information about model profile selection can be found [here](https://docs.nvidia.com/nim/large-language-models/latest/profiles.html#profile-selection) in the NVIDIA NIM for Large Language Models (LLMs) documentation.

--- a/docs/get-started/get-started-helm.md
+++ b/docs/get-started/get-started-helm.md
@@ -106,7 +106,7 @@ Using the list of model profiles from the previous step, set the NIM_MODEL_PROFI
 ```
 env:
  - name: NIM_MODEL_PROFILE
-   value: "tensorrt_llm-h100-fp8-tp2-pp1-throughput-2330:10de-bedaf1e0ba87272295f4fcb590e781436120751026098f448fd8bc4d711ba5d7-4"
+   value: "tensorrt_llm-h100-fp8-tp2-pp1-throughput-2330:10de-0013e870ea929584ec13dad6948450024cdc6c2f03a865f1b050fb08b9f64312-2"
 ```
 
 If using A100s, the `nim-llm` section will also have to be updated to allocate four GPUs instead of two:
@@ -124,27 +124,27 @@ The following tensorrt_llm profiles are optimized for different common GPU confi
 
 ###### 2xH100 NVL
 ```
-tensorrt_llm-h100_nvl-fp8-tp2-pp1-throughput-2321:10de-5e20634213cb4c32e86f048dbc274eb8bff74720af81fe400d8924e766f3e723-4
+tensorrt_llm-h100_nvl-fp8-tp2-pp1-throughput-2321:10de-3035d73242fb579040fb3f341adc36a7073f780419e73dd97edb7ce35cb0f550-2
 ```
 
 ###### 2xH100 SXM
 ```
-tensorrt_llm-h100-fp8-tp2-pp1-throughput-2330:10de-bedaf1e0ba87272295f4fcb590e781436120751026098f448fd8bc4d711ba5d7-4
+tensorrt_llm-h100-fp8-tp2-pp1-throughput-2330:10de-0013e870ea929584ec13dad6948450024cdc6c2f03a865f1b050fb08b9f64312-2
 ```
 
 ###### 4xA100
 ```
-tensorrt_llm-a100-bf16-tp4-pp1-throughput-20b2:10de-8dfffd86cd28a6ea7086f8d3d33f0d60c66df738652cea44c722766b77508b5c-4
+tensorrt_llm-a100-bf16-tp4-pp1-throughput-20b2:10de-f14e1bad1a0e78da150aeedfee7919ab3ef21def09825caffef460b93fdde9b7-4
 ```
 
 ###### 2xRTX PRO 6000
 ```
-tensorrt_llm-rtx6000_blackwell_sv-nvfp4-tp2-pp1-latency-2bb5:10de-b5d32ce12a99b422e2c5a9a772bfd29493467cd5f22248ed936e2d43c5747771-2
+tensorrt_llm-rtx6000_blackwell_sv-fp8-tp2-pp1-throughput-2bb5:10de-77ab630b949b0a58ad580a22ea055bc392a30fbf57357d6398814e00775aab8c-2
 ```
 
 ###### 2xB200
 ```
-tensorrt_llm-b200-bf16-tp2-pp1-latency-2901:10de-d89dfd90f9f326864bc6051f45b5aca8e758fdb009b1da43d93b1d5a2236026e-2
+tensorrt_llm-b200-bf16-tp2-pp1-throughput-2901:10de-6d1452af26f860b53df112c90f6b92f22a41156c09dafa2582c2c1194e56a673-2
 ```
 
 More information about model profile selection can be found [here](https://docs.nvidia.com/nim/large-language-models/latest/profiles.html#profile-selection) in the NVIDIA NIM for Large Language Models (LLMs) documentation.


### PR DESCRIPTION
## Summary
This PR fixes critical bugs related to model naming and updates documentation with correct model profiles for NIM version 1.14.0.

## Issues Fixed

### 1. Incorrect Model Name (500 Internal Server Error)
**Root Cause:** The model name `meta-llama/llama-3.3-70b-instruct` does not match the actual NIM container model identifier `meta/llama-3.3-70b-instruct` for `nvcr.io/nim/meta/llama-3.3-70b-instruct:1.14.0`.

**Impact:** The `artifact_qa` API returned 500 Internal Server Error with: