### PR TITLE
Add data source registry and update related configurations

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -259,7 +259,7 @@
         "filename": "tests/aiq_agent/common/test_common_init.py",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 205
+        "line_number": 218
       }
     ],
     "tests/knowledge_layer_tests/run_llamaindex.py": [
@@ -290,5 +290,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-31T18:26:03Z"
+  "generated_at": "2026-04-03T21:43:00Z"
 }

--- a/configs/config_cli_default.yml
+++ b/configs/config_cli_default.yml
@@ -63,7 +63,21 @@ llms:
   #     enable_thinking: true
 
 functions:
-  # Data source display metadata for the UI
+  # =========================================================================
+  # Data Source Registry
+  # =========================================================================
+  # Central registry that controls:
+  #   1. UI toggles — each source appears as an on/off switch in the frontend
+  #   2. Per-message filtering — users can select active sources per request
+  #   3. Tool auto-inheritance — agents with no explicit `tools` list receive
+  #      every tool listed here (use `exclude_tools` on agents to specialize)
+  #
+  # Source entry fields:
+  #   id, name, description, tools, requires_auth (default: false),
+  #   default_enabled (default: true)
+  #
+  # See docs/source/customization/tools-and-sources.md for full details.
+  # =========================================================================
   data_sources:
     _type: data_source_registry
     sources:
@@ -96,17 +110,18 @@ functions:
   #   max_results: 5
   #   serper_api_key: ${SERPER_API_KEY}
 
+  # =========================================================================
+  # Agents — inherit all registry tools; use exclude_tools to specialize
+  # =========================================================================
   intent_classifier:
     _type: intent_classifier
     llm: nemotron_llm_intent
     # llm_timeout: 90  # optional; seconds for intent LLM call (default 90)
-    # tools: omitted -> inherits all from data_source_registry
 
   clarifier_agent:
     _type: clarifier_agent
     llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
     planner_llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
-    # tools: omitted -> inherits all from data_source_registry
     max_turns: 3
     enable_plan_approval: true
     log_response_max_chars: 2000

--- a/configs/config_cli_default.yml
+++ b/configs/config_cli_default.yml
@@ -116,12 +116,16 @@ functions:
   intent_classifier:
     _type: intent_classifier
     llm: nemotron_llm_intent
+    # tools: omitted -> inherits all from data_source_registry
+    # exclude_tools: []
     # llm_timeout: 90  # optional; seconds for intent LLM call (default 90)
 
   clarifier_agent:
     _type: clarifier_agent
     llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
     planner_llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
+    # tools: omitted -> inherits all from data_source_registry
+    # exclude_tools: []
     max_turns: 3
     enable_plan_approval: true
     log_response_max_chars: 2000
@@ -130,6 +134,7 @@ functions:
   shallow_research_agent:
     _type: shallow_research_agent
     llm: nemotron_nano_llm
+    # tools: omitted -> inherits all from data_source_registry
     exclude_tools:
       - advanced_web_search_tool
     max_llm_turns: 10

--- a/configs/config_cli_default.yml
+++ b/configs/config_cli_default.yml
@@ -63,6 +63,22 @@ llms:
   #     enable_thinking: true
 
 functions:
+  # Data source display metadata for the UI
+  data_sources:
+    _type: data_source_registry
+    sources:
+      - id: web_search
+        name: "Web Search"
+        description: "Search the web for real-time information."
+        tools:
+          - web_search_tool
+          - advanced_web_search_tool
+      # - id: paper_search
+      #   name: "Academic Papers"
+      #   description: "Search academic papers and scientific publications."
+      #   tools:
+      #     - paper_search_tool
+
   web_search_tool:
     _type: tavily_web_search
     max_results: 5
@@ -84,16 +100,13 @@ functions:
     _type: intent_classifier
     llm: nemotron_llm_intent
     # llm_timeout: 90  # optional; seconds for intent LLM call (default 90)
-    tools:
-      - web_search_tool
-      # - paper_search_tool  # Uncomment if SERPER_API_KEY is set
+    # tools: omitted -> inherits all from data_source_registry
 
   clarifier_agent:
     _type: clarifier_agent
     llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
     planner_llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
-    tools:
-      - web_search_tool
+    # tools: omitted -> inherits all from data_source_registry
     max_turns: 3
     enable_plan_approval: true
     log_response_max_chars: 2000
@@ -102,8 +115,8 @@ functions:
   shallow_research_agent:
     _type: shallow_research_agent
     llm: nemotron_nano_llm
-    tools:
-      - web_search_tool
+    exclude_tools:
+      - advanced_web_search_tool
     max_llm_turns: 10
     max_tool_iterations: 5
 
@@ -113,9 +126,8 @@ functions:
     researcher_llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
     planner_llm: gpt_oss_llm
     max_loops: 2
-    tools:
-      # - paper_search_tool  # Uncomment if SERPER_API_KEY is set
-      - advanced_web_search_tool
+    exclude_tools:
+      - web_search_tool
 
 workflow:
   _type: chat_deepresearcher_agent

--- a/configs/config_web_default_llamaindex.yml
+++ b/configs/config_web_default_llamaindex.yml
@@ -103,7 +103,32 @@ llms:
     max_tokens: 100
 
 functions:
-  # Data source display metadata for the UI
+  # =========================================================================
+  # Data Source Registry
+  # =========================================================================
+  # Central registry that controls:
+  #   1. UI toggles — each source appears as an on/off switch in the frontend
+  #   2. Per-message filtering — users can select active sources per request
+  #   3. Tool auto-inheritance — agents with no explicit `tools` list receive
+  #      every tool listed here (use `exclude_tools` on agents to specialize)
+  #
+  # Adding a new tool or MCP function group? Just add it here — all agents
+  # pick it up automatically. No per-agent config changes needed.
+  #
+  # Source entry fields:
+  #   id            — Unique key used in API payloads and filtering
+  #   name          — Display name shown in the UI
+  #   description   — Human-readable description shown in the UI
+  #   tools         — List of NAT function names or function group names
+  #   requires_auth — (default: false) If true, the UI greys out this source
+  #                   until the user signs in. Use for sources that need
+  #                   user-level OAuth tokens (e.g., enterprise SSO).
+  #                   Sources using backend API keys (Tavily, Serper) should
+  #                   leave this false.
+  #   default_enabled — (default: true) Whether enabled by default
+  #
+  # See docs/source/customization/tools-and-sources.md for full details.
+  # =========================================================================
   data_sources:
     _type: data_source_registry
     sources:
@@ -118,7 +143,6 @@ functions:
         description: "Search uploaded documents and files."
         tools:
           - knowledge_search
-      # Uncomment when paper_search_tool is enabled (requires SERPER_API_KEY)
       - id: paper_search
         name: "Academic Papers"
         description: "Search academic papers and scientific publications."
@@ -153,17 +177,23 @@ functions:
     max_results: 5
     serper_api_key: ${SERPER_API_KEY}
 
+  # =========================================================================
+  # Agents
+  # =========================================================================
+  # Tool inheritance: agents with no `tools` list inherit ALL tools from the
+  # data_source_registry above. Use `exclude_tools` to remove specific tools
+  # from an agent (e.g., give shallow the basic search, deep the advanced).
+  # To bypass auto-inherit entirely, set an explicit `tools` list.
+  # =========================================================================
   intent_classifier:
     _type: intent_classifier
     llm: nemotron_llm_intent
     verbose: true
-    # tools: omitted -> inherits all from data_source_registry
 
   clarifier_agent:
     _type: clarifier_agent
     llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
     planner_llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
-    # tools: omitted -> inherits all from data_source_registry
     max_turns: 3
     enable_plan_approval: true
     log_response_max_chars: 2000
@@ -173,7 +203,7 @@ functions:
     _type: shallow_research_agent
     llm: nemotron_nano_llm
     verbose: true
-    exclude_tools:
+    exclude_tools:                     # Remove advanced variant; shallow uses web_search_tool
       - advanced_web_search_tool
     max_llm_turns: 10
     max_tool_iterations: 5
@@ -185,7 +215,7 @@ functions:
     planner_llm: gpt_oss_llm
     max_loops: 2
     verbose: true
-    exclude_tools:
+    exclude_tools:                     # Remove basic variant; deep uses advanced_web_search_tool
       - web_search_tool
 
 workflow:

--- a/configs/config_web_default_llamaindex.yml
+++ b/configs/config_web_default_llamaindex.yml
@@ -143,11 +143,12 @@ functions:
         description: "Search uploaded documents and files."
         tools:
           - knowledge_search
-      - id: paper_search
-        name: "Academic Papers"
-        description: "Search academic papers and scientific publications."
-        tools:
-          - paper_search_tool
+      # Uncomment when paper_search_tool is enabled (requires SERPER_API_KEY)
+      # - id: paper_search
+      #   name: "Academic Papers"
+      #   description: "Search academic papers and scientific publications."
+      #   tools:
+      #     - paper_search_tool
 
   web_search_tool:
     _type: tavily_web_search
@@ -172,10 +173,10 @@ functions:
 
   # Paper Search (optional - requires SERPER_API_KEY)
   # Uncomment the block below and set SERPER_API_KEY to enable academic paper search.
-  paper_search_tool:
-    _type: paper_search
-    max_results: 5
-    serper_api_key: ${SERPER_API_KEY}
+  # paper_search_tool:
+  #   _type: paper_search
+  #   max_results: 5
+  #   serper_api_key: ${SERPER_API_KEY}
 
   # =========================================================================
   # Agents
@@ -188,12 +189,16 @@ functions:
   intent_classifier:
     _type: intent_classifier
     llm: nemotron_llm_intent
+    # tools: omitted -> inherits all from data_source_registry
+    # exclude_tools: []
     verbose: true
 
   clarifier_agent:
     _type: clarifier_agent
     llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
     planner_llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
+    # tools: omitted -> inherits all from data_source_registry
+    # exclude_tools: []
     max_turns: 3
     enable_plan_approval: true
     log_response_max_chars: 2000
@@ -202,9 +207,10 @@ functions:
   shallow_research_agent:
     _type: shallow_research_agent
     llm: nemotron_nano_llm
-    verbose: true
+    # tools: omitted -> inherits all from data_source_registry
     exclude_tools:                     # Remove advanced variant; shallow uses web_search_tool
       - advanced_web_search_tool
+    verbose: true
     max_llm_turns: 10
     max_tool_iterations: 5
 
@@ -213,10 +219,11 @@ functions:
     orchestrator_llm: gpt_oss_llm
     researcher_llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
     planner_llm: gpt_oss_llm
-    max_loops: 2
-    verbose: true
+    # tools: omitted -> inherits all from data_source_registry
     exclude_tools:                     # Remove basic variant; deep uses advanced_web_search_tool
       - web_search_tool
+    max_loops: 2
+    verbose: true
 
 workflow:
   _type: chat_deepresearcher_agent

--- a/configs/config_web_default_llamaindex.yml
+++ b/configs/config_web_default_llamaindex.yml
@@ -118,11 +118,12 @@ functions:
         description: "Search uploaded documents and files."
         tools:
           - knowledge_search
-      # - id: paper_search
-      #   name: "Academic Papers"
-      #   description: "Search academic papers and scientific publications."
-      #   tools:
-      #     - paper_search_tool
+      # Uncomment when paper_search_tool is enabled (requires SERPER_API_KEY)
+      - id: paper_search
+        name: "Academic Papers"
+        description: "Search academic papers and scientific publications."
+        tools:
+          - paper_search_tool
 
   web_search_tool:
     _type: tavily_web_search
@@ -147,10 +148,10 @@ functions:
 
   # Paper Search (optional - requires SERPER_API_KEY)
   # Uncomment the block below and set SERPER_API_KEY to enable academic paper search.
-  # paper_search_tool:
-  #   _type: paper_search
-  #   max_results: 5
-  #   serper_api_key: ${SERPER_API_KEY}
+  paper_search_tool:
+    _type: paper_search
+    max_results: 5
+    serper_api_key: ${SERPER_API_KEY}
 
   intent_classifier:
     _type: intent_classifier

--- a/configs/config_web_default_llamaindex.yml
+++ b/configs/config_web_default_llamaindex.yml
@@ -103,6 +103,27 @@ llms:
     max_tokens: 100
 
 functions:
+  # Data source display metadata for the UI
+  data_sources:
+    _type: data_source_registry
+    sources:
+      - id: web_search
+        name: "Web Search"
+        description: "Search the web for real-time information."
+        tools:
+          - web_search_tool
+          - advanced_web_search_tool
+      - id: knowledge_layer
+        name: "Knowledge Base"
+        description: "Search uploaded documents and files."
+        tools:
+          - knowledge_search
+      # - id: paper_search
+      #   name: "Academic Papers"
+      #   description: "Search academic papers and scientific publications."
+      #   tools:
+      #     - paper_search_tool
+
   web_search_tool:
     _type: tavily_web_search
     max_results: 5
@@ -135,18 +156,13 @@ functions:
     _type: intent_classifier
     llm: nemotron_llm_intent
     verbose: true
-    tools:
-      - web_search_tool
-      # - paper_search_tool  # Uncomment if SERPER_API_KEY is set
-      - knowledge_search
+    # tools: omitted -> inherits all from data_source_registry
 
   clarifier_agent:
     _type: clarifier_agent
     llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
     planner_llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
-    tools:
-      - web_search_tool
-      - knowledge_search
+    # tools: omitted -> inherits all from data_source_registry
     max_turns: 3
     enable_plan_approval: true
     log_response_max_chars: 2000
@@ -156,9 +172,8 @@ functions:
     _type: shallow_research_agent
     llm: nemotron_nano_llm
     verbose: true
-    tools:
-      - web_search_tool
-      - knowledge_search
+    exclude_tools:
+      - advanced_web_search_tool
     max_llm_turns: 10
     max_tool_iterations: 5
 
@@ -169,11 +184,8 @@ functions:
     planner_llm: gpt_oss_llm
     max_loops: 2
     verbose: true
-    tools:
-      # - paper_search_tool  # Uncomment if SERPER_API_KEY is set
-      - advanced_web_search_tool
-      - knowledge_search
-
+    exclude_tools:
+      - web_search_tool
 
 workflow:
   _type: chat_deepresearcher_agent

--- a/configs/config_web_frag.yml
+++ b/configs/config_web_frag.yml
@@ -96,7 +96,21 @@ llms:
   #     enable_thinking: true
 
 functions:
-  # Data source display metadata for the UI
+  # =========================================================================
+  # Data Source Registry
+  # =========================================================================
+  # Central registry that controls:
+  #   1. UI toggles — each source appears as an on/off switch in the frontend
+  #   2. Per-message filtering — users can select active sources per request
+  #   3. Tool auto-inheritance — agents with no explicit `tools` list receive
+  #      every tool listed here (use `exclude_tools` on agents to specialize)
+  #
+  # Source entry fields:
+  #   id, name, description, tools, requires_auth (default: false),
+  #   default_enabled (default: true)
+  #
+  # See docs/source/customization/tools-and-sources.md for full details.
+  # =========================================================================
   data_sources:
     _type: data_source_registry
     sources:
@@ -139,16 +153,17 @@ functions:
   #   max_results: 5
   #   serper_api_key: ${SERPER_API_KEY}
 
+  # =========================================================================
+  # Agents — inherit all registry tools; use exclude_tools to specialize
+  # =========================================================================
   intent_classifier:
     _type: intent_classifier
     llm: nemotron_llm_intent
-    # tools: omitted -> inherits all from data_source_registry
 
   clarifier_agent:
     _type: clarifier_agent
     llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
     planner_llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
-    # tools: omitted -> inherits all from data_source_registry
     max_turns: 3
     enable_plan_approval: true
     log_response_max_chars: 2000

--- a/configs/config_web_frag.yml
+++ b/configs/config_web_frag.yml
@@ -96,6 +96,22 @@ llms:
   #     enable_thinking: true
 
 functions:
+  # Data source display metadata for the UI
+  data_sources:
+    _type: data_source_registry
+    sources:
+      - id: web_search
+        name: "Web Search"
+        description: "Search the web for real-time information."
+        tools:
+          - web_search_tool
+          - advanced_web_search_tool
+      - id: knowledge_layer
+        name: "Knowledge Base"
+        description: "Search uploaded documents and files."
+        tools:
+          - knowledge_search
+
   web_search_tool:
     _type: tavily_web_search
     max_results: 5
@@ -126,18 +142,13 @@ functions:
   intent_classifier:
     _type: intent_classifier
     llm: nemotron_llm_intent
-    tools:
-      - web_search_tool
-      # - paper_search_tool  # Uncomment if SERPER_API_KEY is set
-      - knowledge_search
+    # tools: omitted -> inherits all from data_source_registry
 
   clarifier_agent:
     _type: clarifier_agent
     llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
     planner_llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
-    tools:
-      - web_search_tool
-      - knowledge_search
+    # tools: omitted -> inherits all from data_source_registry
     max_turns: 3
     enable_plan_approval: true
     log_response_max_chars: 2000
@@ -146,9 +157,8 @@ functions:
   shallow_research_agent:
     _type: shallow_research_agent
     llm: nemotron_nano_llm
-    tools:
-      - web_search_tool
-      - knowledge_search
+    exclude_tools:
+      - advanced_web_search_tool
     max_llm_turns: 10
     max_tool_iterations: 5
 
@@ -158,10 +168,8 @@ functions:
     researcher_llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
     planner_llm: gpt_oss_llm
     max_loops: 2
-    tools:
-      # - paper_search_tool  # Uncomment if SERPER_API_KEY is set
-      - advanced_web_search_tool
-      - knowledge_search
+    exclude_tools:
+      - web_search_tool
 
 workflow:
   _type: chat_deepresearcher_agent

--- a/configs/config_web_frag.yml
+++ b/configs/config_web_frag.yml
@@ -159,11 +159,15 @@ functions:
   intent_classifier:
     _type: intent_classifier
     llm: nemotron_llm_intent
+    # tools: omitted -> inherits all from data_source_registry
+    # exclude_tools: []
 
   clarifier_agent:
     _type: clarifier_agent
     llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
     planner_llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
+    # tools: omitted -> inherits all from data_source_registry
+    # exclude_tools: []
     max_turns: 3
     enable_plan_approval: true
     log_response_max_chars: 2000
@@ -172,6 +176,7 @@ functions:
   shallow_research_agent:
     _type: shallow_research_agent
     llm: nemotron_nano_llm
+    # tools: omitted -> inherits all from data_source_registry
     exclude_tools:
       - advanced_web_search_tool
     max_llm_turns: 10
@@ -182,9 +187,10 @@ functions:
     orchestrator_llm: gpt_oss_llm
     researcher_llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
     planner_llm: gpt_oss_llm
-    max_loops: 2
+    # tools: omitted -> inherits all from data_source_registry
     exclude_tools:
       - web_search_tool
+    max_loops: 2
 
 workflow:
   _type: chat_deepresearcher_agent

--- a/docs/source/customization/mcp-tools.md
+++ b/docs/source/customization/mcp-tools.md
@@ -67,44 +67,38 @@ This connects to the MCP server at the given URL and registers all of its tools 
 - `sse`: Server-Sent Events, supported for backwards compatibility
 - `stdio`: standard input/output for local process communication
 
-### Step 2: Add the function group to each agent's `tools` list
+### Step 2: Register the function group as a data source
 
-The agents will not use the MCP tools unless the function group appears in their `tools` list. Add it to the agents that should have access:
+Add the MCP function group to the `data_source_registry` so all agents inherit it automatically and the UI shows a toggle:
 
 ```yaml
 # (inside the existing functions: section)
-  intent_classifier:
-    _type: intent_classifier
-    tools:
-      - web_search_tool
-      - knowledge_search
-      - mcp_financial_tools
-
-  clarifier_agent:
-    _type: clarifier_agent
-    tools:
-      - web_search_tool
-      - knowledge_search
-      - mcp_financial_tools
-
-  shallow_research_agent:
-    _type: shallow_research_agent
-    tools:
-      - web_search_tool
-      - knowledge_search
-      - mcp_financial_tools
-
-  deep_research_agent:
-    _type: deep_research_agent
-    tools:
-      - advanced_web_search_tool
-      - knowledge_search
-      - mcp_financial_tools
+  data_sources:
+    _type: data_source_registry
+    sources:
+      - id: web_search
+        name: "Web Search"
+        description: "Search the web for real-time information."
+        tools:
+          - web_search_tool
+          - advanced_web_search_tool
+      - id: knowledge_layer
+        name: "Knowledge Base"
+        description: "Search uploaded documents and files."
+        tools:
+          - knowledge_search
+      - id: financial_data
+        name: "Financial Data"
+        description: "Query financial reports and market data."
+        tools:
+          - mcp_financial_tools
 ```
+
+All agents inherit tools from the registry by default -- no per-agent `tools` lists needed. The registry auto-detects that `mcp_financial_tools` is a function group and uses prefix matching for its individual tools (e.g., `mcp_financial_tools__get_stock_quote`).
 
 ### Complete Example Config
 
-Below is a complete config that adds MCP tools to the deep researcher alongside the existing web search and knowledge search tools. This extends `config_web_frag.yml`:
+Below is a complete config that adds MCP tools to the deep researcher alongside the existing web search and knowledge search tools. This extends `config_web_frag.yml`. Note that agents inherit all registry tools automatically -- no per-agent `tools` lists needed:
 
 ```yaml
 general:
@@ -145,7 +139,7 @@ llms:
     chat_template_kwargs:
       enable_thinking: true
 
-  nemotron_llm:
+  nemotron_nano_llm:
     _type: nim
     model_name: nvidia/nemotron-3-nano-30b-a3b
     base_url: "https://integrate.api.nvidia.com/v1"
@@ -166,17 +160,6 @@ llms:
     api_key: ${NVIDIA_API_KEY}
     max_retries: 10
 
-  nemotron_llm_deep:
-    _type: nim
-    model_name: nvidia/nemotron-3-nano-30b-a3b
-    base_url: "https://integrate.api.nvidia.com/v1"
-    temperature: 1.0
-    top_p: 1.0
-    max_tokens: 128000
-    num_retries: 5
-    chat_template_kwargs:
-      enable_thinking: true
-
 # MCP Tools: connect to an external MCP server
 function_groups:
   mcp_financial_tools:
@@ -186,6 +169,27 @@ function_groups:
       url: ${MCP_SERVER_URL:-http://localhost:9901/mcp}
 
 functions:
+  # Registry: single source of truth for tools + UI toggles
+  data_sources:
+    _type: data_source_registry
+    sources:
+      - id: web_search
+        name: "Web Search"
+        description: "Search the web for real-time information."
+        tools:
+          - web_search_tool
+          - advanced_web_search_tool
+      - id: knowledge_layer
+        name: "Knowledge Base"
+        description: "Search uploaded documents and files."
+        tools:
+          - knowledge_search
+      - id: financial_data
+        name: "Financial Data"
+        description: "Query financial reports and market data."
+        tools:
+          - mcp_financial_tools
+
   web_search_tool:
     _type: tavily_web_search
     max_results: 5
@@ -205,22 +209,15 @@ functions:
     ingest_url: ${RAG_INGEST_URL:-http://localhost:8082}
     timeout: 300
 
+  # Agents inherit all registry tools automatically
   intent_classifier:
     _type: intent_classifier
     llm: nemotron_llm_intent
-    tools:
-      - web_search_tool
-      - knowledge_search
-      - mcp_financial_tools
 
   clarifier_agent:
     _type: clarifier_agent
-    llm: gpt_oss_llm
-    planner_llm: nemotron_llm
-    tools:
-      - web_search_tool
-      - knowledge_search
-      - mcp_financial_tools
+    llm: nemotron_nano_llm
+    planner_llm: nemotron_nano_llm
     max_turns: 3
     enable_plan_approval: true
     log_response_max_chars: 2000
@@ -228,24 +225,20 @@ functions:
 
   shallow_research_agent:
     _type: shallow_research_agent
-    llm: gpt_oss_llm
-    tools:
-      - web_search_tool
-      - knowledge_search
-      - mcp_financial_tools
+    llm: nemotron_nano_llm
+    exclude_tools:
+      - advanced_web_search_tool
     max_llm_turns: 10
     max_tool_iterations: 5
 
   deep_research_agent:
     _type: deep_research_agent
     orchestrator_llm: gpt_oss_llm
-    researcher_llm: nemotron_llm_deep
+    researcher_llm: nemotron_nano_llm
     planner_llm: gpt_oss_llm
     max_loops: 2
-    tools:
-      - advanced_web_search_tool
-      - knowledge_search
-      - mcp_financial_tools
+    exclude_tools:
+      - web_search_tool
 
 workflow:
   _type: chat_deepresearcher_agent
@@ -280,9 +273,9 @@ MCP tools that require OAuth2 authentication (for example, corporate Jira, Confl
 
 For non-authenticated MCP servers, or MCP servers that use service account credentials (set through environment variables on the server side), use the `mcp_client` approach described above.
 
-## UI Limitations
+## UI Integration
 
-MCP tools added through the configuration file will be available to the agents at the backend level, but they will not automatically appear in the demo UI. Displaying custom MCP tools in the UI requires changes to both the backend and frontend. Built-in support for this is planned for an upcoming version. In the meantime, the demo UI source code is provided and can be modified to surface additional tools as needed.
+When you register an MCP function group in the `data_source_registry`, it automatically appears as a toggleable data source in the UI via the `GET /v1/data_sources` endpoint. Users can enable or disable it per message using the data source toggles, just like web search or knowledge base.
 
 ## Prompt Tuning
 

--- a/docs/source/customization/tools-and-sources.md
+++ b/docs/source/customization/tools-and-sources.md
@@ -4,55 +4,117 @@ SPDX-License-Identifier: Apache-2.0
 -->
 # Tools and Sources
 
-Some tools and data sources are **enabled** by being listed in the workflow and in each agent's `tools` list. They are **disabled** by omitting them from those lists (you can leave or remove the function definition in `functions`; if nothing references it, it won't be used).
+## Data Source Registry
+
+The `data_source_registry` function is the **single source of truth** for which tools exist and which data source they belong to. It controls the UI toggles, per-message filtering, and -- by default -- which tools each agent receives.
+
+```yaml
+functions:
+  data_sources:
+    _type: data_source_registry
+    sources:
+      - id: web_search
+        name: "Web Search"
+        description: "Search the web for real-time information."
+        tools:
+          - web_search_tool
+          - advanced_web_search_tool
+      - id: knowledge_layer
+        name: "Knowledge Base"
+        description: "Search uploaded documents and files."
+        tools:
+          - knowledge_search
+```
+
+The `GET /v1/data_sources` API endpoint returns these entries, which the UI renders as toggles. When a user sends a message with `data_sources: ["web_search"]`, only tools belonging to that source are active for that request.
+
+Tools not listed in any data source entry (e.g., utility tools like "think") are always included regardless of filtering.
+
+## Auto-Inherit: Agents Get All Registry Tools by Default
+
+When an agent's `tools` list is **empty** (the default), it automatically inherits every tool registered in `data_source_registry`. This means adding a new tool or data source requires only **one config change** -- adding it to the registry.
+
+```yaml
+functions:
+  # Add a tool to the registry -- all agents get it automatically
+  data_sources:
+    _type: data_source_registry
+    sources:
+      - id: web_search
+        name: "Web Search"
+        tools:
+          - web_search_tool
+          - advanced_web_search_tool
+      - id: knowledge_layer
+        name: "Knowledge Base"
+        tools:
+          - knowledge_search
+
+  # Agents with no tools list inherit all registry tools
+  intent_classifier:
+    _type: intent_classifier
+    llm: nemotron_llm_intent
+
+  clarifier_agent:
+    _type: clarifier_agent
+    llm: nemotron_llm
+
+  # Use exclude_tools for per-agent specialization
+  shallow_research_agent:
+    _type: shallow_research_agent
+    llm: nemotron_llm
+    exclude_tools:
+      - advanced_web_search_tool    # shallow uses regular web search
+
+  deep_research_agent:
+    _type: deep_research_agent
+    orchestrator_llm: nemotron_llm_deep
+    exclude_tools:
+      - web_search_tool             # deep uses advanced web search
+```
+
+### Per-Agent Specialization with `exclude_tools`
+
+Use `exclude_tools` to remove specific tools from the inherited set. This is useful when different agents need different variants of a tool (e.g., shallow research uses `web_search_tool` while deep research uses `advanced_web_search_tool`).
+
+### Explicit Override (Backward Compatible)
+
+If an agent specifies an explicit `tools` list, it uses exactly those tools and ignores the registry. This preserves backward compatibility with existing configs:
+
+```yaml
+  # Explicit tools list -- registry is NOT used for this agent
+  shallow_research_agent:
+    _type: shallow_research_agent
+    llm: nemotron_llm
+    tools:
+      - web_search_tool
+      - knowledge_search
+```
 
 ## Disabling a Tool
 
-**Example: disabling the paper search tool**
-
-To disable the paper search tool (for example, to avoid Serper/API usage or to restrict agents to web search only), remove `paper_search_tool` from every `tools` list that references it. For example, in `config_cli_default.yml` you would:
-
-1. Remove `paper_search_tool` from `intent_classifier.tools` (orchestration node).
-2. Remove `paper_search_tool` from `deep_research_agent.tools`.
-3. Optionally comment out or remove the `paper_search_tool` function block in `functions` so the config is clearer.
-
-**Before (paper search enabled):**
+To disable a tool (for example, to avoid API usage or restrict agents to specific sources), remove it from the `data_source_registry`:
 
 ```yaml
 functions:
-  intent_classifier:
-    _type: intent_classifier
-    tools:
-      - web_search_tool
-      - paper_search_tool
-
-  deep_research_agent:
-    _type: deep_research_agent
-    tools:
-      - paper_search_tool
-      - advanced_web_search_tool
+  data_sources:
+    _type: data_source_registry
+    sources:
+      - id: web_search
+        name: "Web Search"
+        tools:
+          - web_search_tool
+          - advanced_web_search_tool
+      # paper_search removed -- no agent will receive it
 ```
 
-**After (paper search disabled):**
+Since agents inherit from the registry, removing a tool from the registry removes it from all agents. No per-agent config changes needed.
 
-```yaml
-functions:
-  intent_classifier:
-    _type: intent_classifier
-    tools:
-      - web_search_tool
-
-  deep_research_agent:
-    _type: deep_research_agent
-    tools:
-      - advanced_web_search_tool
-```
-
-The same idea applies to any other tool or data source: include it in the relevant `tools` lists to enable it, remove it to disable it.
+Optionally comment out or remove the tool's function definition in `functions` so the config is clearer.
 
 ## Adding New Tools or Data Sources
 
 For guidance on implementing and registering new tools or data sources, refer to:
 
 - [Adding a Tool](../extending/adding-a-tool.md) -- How to create and register a new tool with the NeMo Agent Toolkit.
-- [Adding a Data Source](../extending/adding-a-data-source.md) -- How to add a new data source or knowledge layer backend.
+- [Adding a Data Source](../extending/adding-a-data-source.md) -- How to add a new data source, register it with the data source registry, and use MCP tools as data sources.

--- a/docs/source/customization/tools-and-sources.md
+++ b/docs/source/customization/tools-and-sources.md
@@ -91,6 +91,45 @@ If an agent specifies an explicit `tools` list, it uses exactly those tools and 
       - knowledge_search
 ```
 
+## Adding MCP Tools as Data Sources
+
+MCP tools (via `mcp_client` function groups) work with the registry the same way as any other tool. Add the group name to a registry source entry and all agents get it automatically:
+
+```yaml
+# Connect to an external MCP server
+function_groups:
+  mcp_financial_tools:
+    _type: mcp_client
+    server:
+      transport: streamable-http
+      url: ${MCP_SERVER_URL:-http://localhost:9901/mcp}
+
+functions:
+  data_sources:
+    _type: data_source_registry
+    sources:
+      - id: web_search
+        name: "Web Search"
+        tools:
+          - web_search_tool
+          - advanced_web_search_tool
+      - id: knowledge_layer
+        name: "Knowledge Base"
+        tools:
+          - knowledge_search
+      - id: financial_data
+        name: "Financial Data"
+        description: "Query financial reports and market data via MCP."
+        tools:
+          - mcp_financial_tools         # function group name
+```
+
+That's it -- one registry entry. Every agent automatically gets the MCP tools. The UI shows a "Financial Data" toggle. Per-request `data_sources` filtering works.
+
+The registry auto-detects that `mcp_financial_tools` is a function group and uses NAT's group separator (`__`) for prefix matching. All tools exposed by the MCP server (e.g., `mcp_financial_tools__get_stock_quote`, `mcp_financial_tools__get_earnings`) map to the `financial_data` data source.
+
+For details on MCP server setup, transport options, tool overrides, and prompt tuning, see [MCP Tools](./mcp-tools.md).
+
 ## Disabling a Tool
 
 To disable a tool (for example, to avoid API usage or restrict agents to specific sources), remove it from the `data_source_registry`:

--- a/docs/source/customization/tools-and-sources.md
+++ b/docs/source/customization/tools-and-sources.md
@@ -24,11 +24,28 @@ functions:
         description: "Search uploaded documents and files."
         tools:
           - knowledge_search
+      - id: enterprise_search
+        name: "Enterprise Search"
+        description: "Search Confluence, Google Drive, and more."
+        requires_auth: true
+        tools:
+          - eci
 ```
 
 The `GET /v1/data_sources` API endpoint returns these entries, which the UI renders as toggles. When a user sends a message with `data_sources: ["web_search"]`, only tools belonging to that source are active for that request.
 
 Tools not listed in any data source entry (e.g., utility tools like "think") are always included regardless of filtering.
+
+### Source Entry Fields
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `id` | string | *required* | Unique key used in API payloads and filtering (e.g., `web_search`) |
+| `name` | string | *required* | Display name shown in the UI |
+| `description` | string | `""` | Human-readable description shown in the UI |
+| `tools` | list[string] | `[]` | NAT function names or function group names belonging to this source |
+| `requires_auth` | bool | `false` | If `true`, the UI greys out this source until the user signs in. Use for sources that need user-level OAuth tokens (e.g., enterprise SSO). Sources that use backend API keys (Tavily, Serper) should leave this `false`. |
+| `default_enabled` | bool | `true` | Whether the source is enabled by default when a user first loads the UI |
 
 ## Auto-Inherit: Agents Get All Registry Tools by Default
 

--- a/docs/source/extending/adding-a-data-source.md
+++ b/docs/source/extending/adding-a-data-source.md
@@ -317,6 +317,7 @@ The `data_source_registry` provides:
 - **`GET /v1/data_sources`** API endpoint returns the registered sources (the UI renders these as toggles)
 - **Per-message filtering** via `data_sources: ["web_search"]` in the chat payload -- only tools belonging to selected sources are active
 - **Display metadata** (name, description) shown in the UI
+- **Auth gating** -- set `requires_auth: true` on a source to grey it out in the UI until the user signs in (e.g., enterprise sources that need OAuth tokens)
 - **Auto-inheritance** -- all agents get every registered tool by default (use `exclude_tools` on an agent for per-agent specialization)
 
 If a tool isn't listed in any `data_source_registry` source entry, it is always included regardless of filtering (e.g., utility tools like "think" or "calculator").

--- a/docs/source/extending/adding-a-data-source.md
+++ b/docs/source/extending/adding-a-data-source.md
@@ -317,10 +317,21 @@ The `data_source_registry` provides:
 - **`GET /v1/data_sources`** API endpoint returns the registered sources (the UI renders these as toggles)
 - **Per-message filtering** via `data_sources: ["web_search"]` in the chat payload -- only tools belonging to selected sources are active
 - **Display metadata** (name, description) shown in the UI
-- **Auth gating** -- set `requires_auth: true` on a source to grey it out in the UI until the user signs in (e.g., enterprise sources that need OAuth tokens)
+- **Auth gating** -- set `requires_auth: true` on a source to grey it out in the UI until the user signs in (e.g., enterprise sources that need user-level OAuth tokens). Sources using backend API keys (Tavily, Serper) should leave this `false` (the default).
 - **Auto-inheritance** -- all agents get every registered tool by default (use `exclude_tools` on an agent for per-agent specialization)
 
 If a tool isn't listed in any `data_source_registry` source entry, it is always included regardless of filtering (e.g., utility tools like "think" or "calculator").
+
+### Source Entry Field Reference
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `id` | string | *required* | Unique key used in API payloads and filtering |
+| `name` | string | *required* | Display name shown in the UI |
+| `description` | string | `""` | Human-readable description for the UI |
+| `tools` | list | `[]` | NAT function or function group names belonging to this source |
+| `requires_auth` | bool | `false` | Grey out in UI until user signs in (for user-token sources) |
+| `default_enabled` | bool | `true` | Whether enabled by default in the UI |
 
 ---
 

--- a/docs/source/extending/adding-a-data-source.md
+++ b/docs/source/extending/adding-a-data-source.md
@@ -274,29 +274,93 @@ uv pip install -e ./sources/my_data_source
 
 ---
 
-## Step 5: Use in a YAML Config
+## Step 5: Register as a Data Source in YAML
+
+To make your data source appear in the UI as a toggleable source with per-message filtering, add it to the `data_source_registry` in your config. Agents automatically inherit all registry tools, so **this is the only config change needed**:
 
 ```yaml
 functions:
+  # Register data sources for UI toggles and filtering
+  data_sources:
+    _type: data_source_registry
+    sources:
+      - id: web_search
+        name: "Web Search"
+        description: "Search the web for real-time information."
+        tools:
+          - web_search_tool
+      - id: patent_search
+        name: "Patent Search"
+        description: "Search patent databases for intellectual property filings."
+        tools:
+          - patent_tool
+
+  # Define the tool instances
   patent_tool:
     _type: patent_search
     max_results: 5
     timeout: 15
 
-  web_search:
+  web_search_tool:
     _type: tavily_web_search
     max_results: 3
 
+  # Agents inherit all registry tools automatically --
+  # no need to list tools per-agent unless you want to exclude specific ones
   shallow_research_agent:
     _type: shallow_research_agent
     llm: research_llm
-    tools:
-      - patent_tool
-      - web_search
-
-workflow:
-  _type: shallow_research_workflow
 ```
+
+The `data_source_registry` provides:
+
+- **`GET /v1/data_sources`** API endpoint returns the registered sources (the UI renders these as toggles)
+- **Per-message filtering** via `data_sources: ["web_search"]` in the chat payload -- only tools belonging to selected sources are active
+- **Display metadata** (name, description) shown in the UI
+- **Auto-inheritance** -- all agents get every registered tool by default (use `exclude_tools` on an agent for per-agent specialization)
+
+If a tool isn't listed in any `data_source_registry` source entry, it is always included regardless of filtering (e.g., utility tools like "think" or "calculator").
+
+---
+
+## Using MCP Tools as Data Sources
+
+NAT MCP client tools are function groups. They work with the data source registry the same way as any other function group -- just reference the group name in `tools`:
+
+```yaml
+function_groups:
+  mcp_docs_search:
+    _type: mcp_client
+    server:
+      transport: streamable-http
+      url: "http://localhost:9901/mcp"
+
+functions:
+  data_sources:
+    _type: data_source_registry
+    sources:
+      - id: web_search
+        name: "Web Search"
+        description: "Search the web for real-time information."
+        tools:
+          - web_search_tool
+      - id: docs_search
+        name: "Internal Docs"
+        description: "Search internal documentation via MCP."
+        tools:
+          - mcp_docs_search
+
+  web_search_tool:
+    _type: tavily_web_search
+
+  deep_research_agent:
+    _type: deep_research_agent
+    tools:
+      - web_search_tool
+      - mcp_docs_search
+```
+
+The registry auto-detects that `mcp_docs_search` is a function group and uses NAT's group separator (`__`) for prefix matching. All tools exposed by the MCP server (e.g., `mcp_docs_search__find_pages`, `mcp_docs_search__get_page`) will map to the `docs_search` data source.
 
 ---
 
@@ -378,26 +442,6 @@ async def search(self, query: str) -> str:
 
 ---
 
-## Integrating with Source Hierarchy
-
-The shallow researcher's prompt template detects data sources by tool name patterns. If you want your data source to appear in the source hierarchy, name it so the template can detect it:
-
-```python
-# From the shallow researcher's Jinja2 template:
-{% set t_name = tool.name.lower() %}
-{% if 'knowledge' in t_name or 'document' in t_name or 'internal' in t_name %}
-  {# Internal knowledge source #}
-{% elif 'paper' in t_name or 'academic' in t_name or 'arxiv' in t_name %}
-  {# Academic source #}
-{% elif 'web' in t_name or 'tavily' in t_name %}
-  {# Web search source #}
-{% endif %}
-```
-
-To have your tool recognized by the source hierarchy, include a keyword like `patent`, `academic`, or `web` in its registered function name, or extend the template to recognize your tool type.
-
----
-
 ## Existing Data Source Reference
 
 | Data Source | `_type` | Package | Description |
@@ -418,6 +462,7 @@ To have your tool recognized by the source hierarchy, include a keyword like `pa
 - [ ] Optional search parameters with descriptions for the LLM
 - [ ] Proper error handling and retries
 - [ ] Entry point in `pyproject.toml`
+- [ ] Added to `data_source_registry` in YAML config for UI integration
 - [ ] Installed and tested with `nat run`
 
 ---
@@ -426,4 +471,4 @@ To have your tool recognized by the source hierarchy, include a keyword like `pa
 
 - [Adding a Tool](./adding-a-tool.md) -- General tool creation guide
 - [Knowledge Layer SDK](../reference/knowledge-layer-sdk.md) -- Build custom retrieval backends
-- [Prompts](../customization/prompts.md) -- Modify source hierarchy detection
+- [Prompts](../customization/prompts.md) -- Modify agent behavior

--- a/frontends/aiq_api/src/aiq_api/jobs/runner.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/runner.py
@@ -304,7 +304,20 @@ async def run_agent_job(
             if llm is None and hasattr(fn_config, "llm") and fn_config.llm:
                 llm = await builder.get_llm(fn_config.llm, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
 
-            tools = await builder.get_tools(tool_names=fn_config.tools, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+            # Resolve tools: use explicit list or auto-inherit from data_source_registry
+            tool_refs = fn_config.tools
+            if not tool_refs:
+                from aiq_agent.common import get_all_tool_refs
+
+                tool_refs = get_all_tool_refs()
+
+            tools = await builder.get_tools(tool_names=tool_refs, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+
+            # Apply per-agent exclusions (e.g. deep_research excludes web_search_tool)
+            if hasattr(fn_config, "exclude_tools") and fn_config.exclude_tools:
+                excluded = set(fn_config.exclude_tools)
+                tools = [t for t in tools if getattr(t, "name", "") not in excluded]
+
             if data_sources is not None:
                 from aiq_agent.common import filter_tools_by_sources
 

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -147,6 +147,7 @@ class DataSource(BaseModel):
     id: str = Field(..., description="Unique identifier for the data source")
     name: str = Field(..., description="Display name")
     description: str | None = Field(default=None, description="Human-readable description")
+    requires_auth: bool = Field(default=False, description="Whether user authentication is required")
 
 
 async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: FastApiFrontEndPluginWorker) -> None:
@@ -196,7 +197,13 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
     async def list_data_sources() -> list[DataSource]:
         """List available data sources dynamically from the registry."""
         return [
-            DataSource(id=source.id, name=source.name, description=source.description) for source in get_all_sources()
+            DataSource(
+                id=source.id,
+                name=source.name,
+                description=source.description,
+                requires_auth=source.requires_auth,
+            )
+            for source in get_all_sources()
         ]
 
     logger.info("Registered /v1/data_sources and /v1/jobs/async/agents routes")

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -149,23 +149,6 @@ class DataSource(BaseModel):
     description: str | None = Field(default=None, description="Human-readable description")
 
 
-def _collect_tool_names(builder: WorkflowBuilder) -> set[str]:
-    """Collect tool names from workflow functions that declare tools (for data source list)."""
-    tool_names: set[str] = set()
-    # intent_classifier (orchestration) and research agents may have tools; meta_chatter/depth_router no longer exist
-    for fn_name in ("deep_research_agent", "shallow_research_agent", "intent_classifier"):
-        try:
-            fn_config = builder.get_function_config(fn_name)
-        except (KeyError, ValueError):
-            continue
-        tools = getattr(fn_config, "tools", None)
-        if not tools:
-            continue
-        for tool in tools:
-            tool_names.add(getattr(tool, "name", str(tool)))
-    return tool_names
-
-
 async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: FastApiFrontEndPluginWorker) -> None:
     """
     Register agent-agnostic async job routes.
@@ -176,10 +159,18 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
     import logging as std_logging
     import os
 
+    from aiq_agent.common.data_source_registry import get_all_sources
     from nat.front_ends.fastapi.async_jobs.job_store import JobStatus
 
     from ..jobs import EventStore
     from ..jobs.runner import run_agent_job
+
+    if not get_all_sources():
+        logger.warning(
+            "No data sources registered. Add a 'data_sources' function with "
+            "_type: data_source_registry to your YAML config to enable "
+            "data source toggles in the UI."
+        )
 
     @app.get(
         "/v1/jobs/async/agents",
@@ -203,28 +194,10 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         summary="List data sources",
     )
     async def list_data_sources() -> list[DataSource]:
-        """List available data sources with metadata."""
-        data_sources = [
-            DataSource(
-                id="web_search",
-                name="Web Search",
-                description="Search the web for real-time information.",
-            )
+        """List available data sources dynamically from the registry."""
+        return [
+            DataSource(id=source.id, name=source.name, description=source.description) for source in get_all_sources()
         ]
-
-        tool_names = _collect_tool_names(builder)
-
-        knowledge_configured = any("knowledge" in name.lower() or name == "knowledge_search" for name in tool_names)
-        if knowledge_configured:
-            data_sources.append(
-                DataSource(
-                    id="knowledge_layer",
-                    name="Knowledge Base",
-                    description="Search uploaded documents and files.",
-                )
-            )
-
-        return data_sources
 
     logger.info("Registered /v1/data_sources and /v1/jobs/async/agents routes")
 

--- a/frontends/ui/src/adapters/api/data-sources-client.ts
+++ b/frontends/ui/src/adapters/api/data-sources-client.ts
@@ -30,6 +30,8 @@ export interface DataSourceFromAPI {
   category?: 'web' | 'enterprise' | 'storage' | 'collaboration'
   /** Whether the source is enabled by default */
   default_enabled?: boolean
+  /** Whether the source requires user authentication */
+  requires_auth?: boolean
 }
 
 export interface DataSourcesResponse {

--- a/frontends/ui/src/features/chat/store.spec.ts
+++ b/frontends/ui/src/features/chat/store.spec.ts
@@ -9,7 +9,7 @@ const STORAGE_KEY = 'aiq-chat-store'
 const mockLayoutState = vi.hoisted(() => ({
   closeRightPanel: vi.fn(),
   enabledDataSourceIds: ['web_search'],
-  availableDataSources: [{ id: 'web_search' }, { id: 'knowledge_base' }],
+  availableDataSources: [{ id: 'web_search' }, { id: 'knowledge_base', requires_auth: true }],
   setEnabledDataSources: vi.fn(),
 }))
 const mockDeepResearchApi = vi.hoisted(() => ({
@@ -36,7 +36,7 @@ describe('useChatStore', () => {
     mockLayoutState.closeRightPanel.mockClear()
     mockLayoutState.setEnabledDataSources.mockClear()
     mockLayoutState.enabledDataSourceIds = ['web_search']
-    mockLayoutState.availableDataSources = [{ id: 'web_search' }, { id: 'knowledge_base' }]
+    mockLayoutState.availableDataSources = [{ id: 'web_search' }, { id: 'knowledge_base', requires_auth: true }]
     mockDeepResearchApi.getJobStatus.mockReset()
     mockDeepResearchApi.cancelJob.mockReset()
     // Reset store to initial state before each test

--- a/frontends/ui/src/features/chat/store.ts
+++ b/frontends/ui/src/features/chat/store.ts
@@ -52,7 +52,6 @@ import {
 import { pruneMessageForStorage } from './lib/prune-message-for-storage'
 import { ensureStorageCapacity, checkStorageHealth } from './lib/storage-manager'
 import { useLayoutStore } from '@/features/layout/store'
-import { WEB_SEARCH_SOURCE_ID } from '@/features/layout/data-sources'
 
 const isQuotaExceededError = (error: unknown): boolean => {
   if (!(error instanceof Error)) return false
@@ -239,7 +238,7 @@ const getDefaultEnabledDataSourceIds = (): string[] => {
   const layoutStore = useLayoutStore.getState()
   return (
     layoutStore.availableDataSources
-      ?.filter((source) => source.id === WEB_SEARCH_SOURCE_ID)
+      ?.filter((source) => !source.requires_auth)
       .map((source) => source.id) ?? []
   )
 }

--- a/frontends/ui/src/features/layout/components/DataConnectionCard.spec.tsx
+++ b/frontends/ui/src/features/layout/components/DataConnectionCard.spec.tsx
@@ -13,6 +13,7 @@ const mockSource: DataSource = {
   description: 'Bug Tracking System',
   category: 'enterprise',
   defaultEnabled: true,
+  requiresAuth: false,
 }
 
 describe('DataConnectionCard', () => {
@@ -120,12 +121,13 @@ describe('DataConnectionCard', () => {
 })
 
 describe('DataConnectionCard - Busy Session State', () => {
-  const mockSource = {
+  const mockSource: DataSource = {
     id: 'bug_tracker',
     name: 'Bug Tracker',
     description: 'Search bug database',
-    category: 'enterprise' as const,
+    category: 'enterprise',
     defaultEnabled: false,
+    requiresAuth: false,
   }
 
   test('disables switch when session is busy', () => {

--- a/frontends/ui/src/features/layout/components/DataConnectionsTab.tsx
+++ b/frontends/ui/src/features/layout/components/DataConnectionsTab.tsx
@@ -47,6 +47,7 @@ export const DataConnectionsTab: FC<DataConnectionsTabProps> = ({
       description: source.description ?? '',
       category: source.category ?? 'enterprise',
       defaultEnabled: true,
+      requiresAuth: source.requires_auth ?? false,
     }))
   }, [availableDataSources])
 

--- a/frontends/ui/src/features/layout/components/DataSourcesPanel.spec.tsx
+++ b/frontends/ui/src/features/layout/components/DataSourcesPanel.spec.tsx
@@ -15,9 +15,9 @@ const mockSetEnabledDataSources = vi.fn()
 const mockFetchDataSources = vi.fn()
 
 const mockDataSources = [
-  { id: 'web_search', name: 'Web Search', description: 'Search the web' },
-  { id: 'knowledge_base', name: 'Knowledge Base', description: 'Wiki docs' },
-  { id: 'bug_tracker', name: 'Bug Tracker', description: 'Bug tracking' },
+  { id: 'web_search', name: 'Web Search', description: 'Search the web', requires_auth: false },
+  { id: 'knowledge_base', name: 'Knowledge Base', description: 'Wiki docs', requires_auth: true },
+  { id: 'bug_tracker', name: 'Bug Tracker', description: 'Bug tracking', requires_auth: true },
 ]
 
 vi.mock('../store', () => ({

--- a/frontends/ui/src/features/layout/components/DataSourcesPanel.tsx
+++ b/frontends/ui/src/features/layout/components/DataSourcesPanel.tsx
@@ -16,7 +16,7 @@ import { Globe, LoadingSpinner } from '@/adapters/ui/icons'
 import { useAuth } from '@/adapters/auth'
 import { useLayoutStore } from '../store'
 import { useIsCurrentSessionBusy, useChatStore } from '@/features/chat'
-import { type DataSource, WEB_SEARCH_SOURCE_ID } from '../data-sources'
+import type { DataSource } from '../data-sources'
 import { DataConnectionCard } from './DataConnectionCard'
 import { FileSourcesTab } from './FileSourcesTab'
 import { UploadOrchestrator } from '@/features/documents'
@@ -76,12 +76,13 @@ export const DataSourcesPanel: FC<DataSourcesPanelProps> = ({ onSourceToggle, on
       description: source.description ?? '',
       category: source.category ?? 'enterprise',
       defaultEnabled: true,
+      requiresAuth: source.requires_auth ?? false,
     }))
   }, [availableDataSources])
 
-  // Check if there are authenticated sources (sources other than web_search that require auth)
+  // Check if any sources require authentication
   const hasAuthenticatedSources = useMemo(() => {
-    return displaySources.some((source) => source.id !== WEB_SEARCH_SOURCE_ID)
+    return displaySources.some((source) => source.requiresAuth)
   }, [displaySources])
 
   const handleOpenChange = useCallback(
@@ -123,10 +124,10 @@ export const DataSourcesPanel: FC<DataSourcesPanelProps> = ({ onSourceToggle, on
     [setDataSourcesPanelTab]
   )
 
-  // Get only available sources (web_search always available, other sources need auth)
+  // Sources are available unless they require auth and the user has no token
   const availableSources = useMemo(() => {
     return displaySources.filter(
-      (source) => source.id === WEB_SEARCH_SOURCE_ID || hasValidToken
+      (source) => !source.requiresAuth || hasValidToken
     )
   }, [displaySources, hasValidToken])
 
@@ -290,9 +291,7 @@ export const DataSourcesPanel: FC<DataSourcesPanelProps> = ({ onSourceToggle, on
           ) : (
             <Flex direction="col" gap="2">
               {displaySources.map((source) => {
-                // Authenticated sources require sign-in - web_search works without auth
-                const isAuthenticatedSource = source.id !== WEB_SEARCH_SOURCE_ID
-                const isSourceAvailable = !isAuthenticatedSource || hasValidToken
+                const isSourceAvailable = !source.requiresAuth || hasValidToken
                 return (
                   <DataConnectionCard
                     key={source.id}

--- a/frontends/ui/src/features/layout/data-sources.ts
+++ b/frontends/ui/src/features/layout/data-sources.ts
@@ -23,10 +23,6 @@ export interface DataSource {
   category: DataSourceCategory
   /** Whether the source is enabled by default */
   defaultEnabled: boolean
+  /** Whether the source requires user authentication */
+  requiresAuth: boolean
 }
-
-/**
- * Default data source ID that works without authentication.
- * Web search uses backend API keys (Tavily), not user tokens.
- */
-export const WEB_SEARCH_SOURCE_ID = 'web_search'

--- a/frontends/ui/src/features/layout/index.ts
+++ b/frontends/ui/src/features/layout/index.ts
@@ -63,7 +63,6 @@ export {
 
 // Data Sources Types
 export type { DataSource, DataSourceCategory } from './data-sources'
-export { WEB_SEARCH_SOURCE_ID } from './data-sources'
 
 // Store
 export { useLayoutStore } from './store'

--- a/frontends/ui/src/features/layout/store.ts
+++ b/frontends/ui/src/features/layout/store.ts
@@ -19,7 +19,6 @@ import type {
   ThemeMode,
 } from './types'
 import { createDataSourcesClient, type DataSourceFromAPI } from '@/adapters/api'
-import { WEB_SEARCH_SOURCE_ID } from './data-sources'
 
 const initialState: LayoutState = {
   isSessionsPanelOpen: false,
@@ -89,10 +88,9 @@ export const useLayoutStore = create<LayoutStore>()(
           const client = createDataSourcesClient({ authToken })
           const response = await client.getDataSources()
 
-          // data_sources is already filtered (knowledge_layer removed) by the client
-          // Only enable web_search by default - user must manually enable other sources
+          // Enable sources that don't require auth by default
           const enabledIds = response.data_sources
-            .filter((source) => source.id === WEB_SEARCH_SOURCE_ID)
+            .filter((source) => !source.requires_auth)
             .map((source) => source.id)
 
           set(
@@ -119,15 +117,16 @@ export const useLayoutStore = create<LayoutStore>()(
         }
       },
 
-      disableNonWebSources: () =>
+      disableAuthRequiredSources: () =>
         set(
           (state) => ({
-            enabledDataSourceIds: state.enabledDataSourceIds.filter(
-              (id) => id === WEB_SEARCH_SOURCE_ID
-            ),
+            enabledDataSourceIds: state.enabledDataSourceIds.filter((id) => {
+              const source = state.availableDataSources?.find((s) => s.id === id)
+              return !source?.requires_auth
+            }),
           }),
           false,
-          'disableNonWebSources'
+          'disableAuthRequiredSources'
         ),
 
       setAvailableDataSources: (sources: DataSourceFromAPI[]) =>

--- a/frontends/ui/src/features/layout/types.ts
+++ b/frontends/ui/src/features/layout/types.ts
@@ -75,8 +75,8 @@ export interface LayoutActions {
   setTheme: (theme: ThemeMode) => void
   /** Fetch data sources from API. Only web_search is enabled by default */
   fetchDataSources: (authToken?: string) => Promise<void>
-  /** Disable all non-web sources (keep only web_search enabled) */
-  disableNonWebSources: () => void
+  /** Disable sources that require authentication */
+  disableAuthRequiredSources: () => void
   /** Set available data sources (from API) */
   setAvailableDataSources: (sources: DataSourceFromAPI[]) => void
   /** Set knowledge layer availability */

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ aiq_shallow_researcher = "aiq_agent.agents.shallow_researcher.register"
 aiq_deep_researcher = "aiq_agent.agents.deep_researcher.register"
 aiq_fastapi_extensions = "aiq_agent.fastapi_extensions.register"
 aiq_clarifier = "aiq_agent.agents.clarifier.register"
+aiq_data_source_registry = "aiq_agent.common.data_source_registry"
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "sources/**/tests"]

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -61,7 +61,14 @@ class IntentClassifierConfig(FunctionBaseConfig, name="intent_classifier"):
     """Configuration for the combined orchestration node (intent + meta response + depth)."""
 
     llm: LLMRef = Field(..., description="LLM to use")
-    tools: list[FunctionRef | FunctionGroupRef] = Field(default_factory=list)
+    tools: list[FunctionRef | FunctionGroupRef] = Field(
+        default_factory=list,
+        description="Explicit tool list. Empty = inherit all from data_source_registry.",
+    )
+    exclude_tools: list[str] = Field(
+        default_factory=list,
+        description="Tool names to exclude when inheriting from registry.",
+    )
     verbose: bool = Field(default=False)
     llm_timeout: float = Field(
         default=90,
@@ -75,7 +82,20 @@ async def intent_classifier(config: IntentClassifierConfig, builder: Builder):
     from .nodes import IntentClassifier
 
     llm = await builder.get_llm(config.llm, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
-    tools = await builder.get_tools(tool_names=config.tools, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+
+    if config.tools:
+        tool_refs = config.tools
+    else:
+        from aiq_agent.common import get_all_tool_refs
+
+        tool_refs = get_all_tool_refs()
+
+    tools = await builder.get_tools(tool_names=tool_refs, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+
+    if config.exclude_tools:
+        excluded = set(config.exclude_tools)
+        tools = [t for t in tools if getattr(t, "name", "") not in excluded]
+
     verbose = is_verbose(config.verbose)
     callbacks = [VerboseTraceCallback()] if verbose else []
 
@@ -190,9 +210,16 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
 
     # Get deep research tools for early validation
     deep_research_config = builder.get_function_config("deep_research_agent")
-    deep_research_tools = await builder.get_tools(
-        tool_names=deep_research_config.tools, wrapper_type=LLMFrameworkEnum.LANGCHAIN
-    )
+    if deep_research_config.tools:
+        deep_tool_refs = deep_research_config.tools
+    else:
+        from aiq_agent.common import get_all_tool_refs
+
+        deep_tool_refs = get_all_tool_refs()
+    deep_research_tools = await builder.get_tools(tool_names=deep_tool_refs, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+    if deep_research_config.exclude_tools:
+        excluded = set(deep_research_config.exclude_tools)
+        deep_research_tools = [t for t in deep_research_tools if getattr(t, "name", "") not in excluded]
 
     # Create a validation function to check if deep research tools are available
     def validate_deep_research_tools(data_sources: list[str] | None) -> tuple[bool, str]:

--- a/src/aiq_agent/agents/clarifier/register.py
+++ b/src/aiq_agent/agents/clarifier/register.py
@@ -79,7 +79,11 @@ class ClarifierConfig(FunctionBaseConfig, name="clarifier_agent"):
     )
     tools: list[FunctionRef | FunctionGroupRef] = Field(
         default_factory=list,
-        description="Tools available for clarification context",
+        description="Explicit tool list. Empty = inherit all from data_source_registry.",
+    )
+    exclude_tools: list[str] = Field(
+        default_factory=list,
+        description="Tool names to exclude when inheriting from registry.",
     )
     max_turns: int = Field(
         default=3,
@@ -137,10 +141,21 @@ async def clarifier_agent(config: ClarifierConfig, builder: Builder):
             config.planner_llm,
             wrapper_type=LLMFrameworkEnum.LANGCHAIN,
         )
+    if config.tools:
+        tool_refs = config.tools
+    else:
+        from aiq_agent.common import get_all_tool_refs
+
+        tool_refs = get_all_tool_refs()
+
     tools = await builder.get_tools(
-        tool_names=config.tools,
+        tool_names=tool_refs,
         wrapper_type=LLMFrameworkEnum.LANGCHAIN,
     )
+
+    if config.exclude_tools:
+        excluded = set(config.exclude_tools)
+        tools = [t for t in tools if getattr(t, "name", "") not in excluded]
 
     provider = LLMProvider()
     provider.set_default(llm)

--- a/src/aiq_agent/agents/deep_researcher/register.py
+++ b/src/aiq_agent/agents/deep_researcher/register.py
@@ -48,7 +48,14 @@ class DeepResearchAgentConfig(FunctionBaseConfig, name="deep_research_agent"):
     orchestrator_llm: LLMRef = Field(..., description="LLM for orchestrator")
     researcher_llm: LLMRef | None = Field(default=None, description="LLM for researcher")
     planner_llm: LLMRef | None = Field(default=None, description="LLM for planner")
-    tools: list[FunctionRef | FunctionGroupRef] = Field(default_factory=list)
+    tools: list[FunctionRef | FunctionGroupRef] = Field(
+        default_factory=list,
+        description="Explicit tool list. Empty = inherit all from data_source_registry.",
+    )
+    exclude_tools: list[str] = Field(
+        default_factory=list,
+        description="Tool names to exclude when inheriting from registry.",
+    )
     max_loops: int = Field(default=2)
     verbose: bool = Field(default=True)
 
@@ -56,7 +63,19 @@ class DeepResearchAgentConfig(FunctionBaseConfig, name="deep_research_agent"):
 @register_function(config_type=DeepResearchAgentConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
 async def deep_research_agent(config: DeepResearchAgentConfig, builder: Builder):
     """Deep research agent using multi-phase workflow."""
-    tools = await builder.get_tools(tool_names=config.tools, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+    if config.tools:
+        tool_refs = config.tools
+    else:
+        from aiq_agent.common import get_all_tool_refs
+
+        tool_refs = get_all_tool_refs()
+
+    tools = await builder.get_tools(tool_names=tool_refs, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+
+    if config.exclude_tools:
+        excluded = set(config.exclude_tools)
+        tools = [t for t in tools if getattr(t, "name", "") not in excluded]
+
     llm = await builder.get_llm(config.orchestrator_llm, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
 
     provider = LLMProvider()

--- a/src/aiq_agent/agents/shallow_researcher/register.py
+++ b/src/aiq_agent/agents/shallow_researcher/register.py
@@ -45,7 +45,14 @@ class ShallowResearchAgentConfig(FunctionBaseConfig, name="shallow_research_agen
     """Configuration for the shallow research agent."""
 
     llm: LLMRef = Field(..., description="LLM to use")
-    tools: list[FunctionRef | FunctionGroupRef] = Field(default_factory=list, description="Tools to use")
+    tools: list[FunctionRef | FunctionGroupRef] = Field(
+        default_factory=list,
+        description="Explicit tool list. Empty = inherit all from data_source_registry.",
+    )
+    exclude_tools: list[str] = Field(
+        default_factory=list,
+        description="Tool names to exclude when inheriting from registry.",
+    )
     max_llm_turns: int = Field(default=10, description="Maximum number of LLM turns")
     max_tool_iterations: int = Field(default=5, description="Maximum tool-calling iterations before forcing synthesis")
     verbose: bool = Field(default=False, description="Whether to enable verbose logging")
@@ -55,7 +62,19 @@ class ShallowResearchAgentConfig(FunctionBaseConfig, name="shallow_research_agen
 async def shallow_research_agent(config: ShallowResearchAgentConfig, builder: Builder):
     """Shallow research agent with tool-calling capabilities."""
     llm = await builder.get_llm(config.llm, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
-    tools = await builder.get_tools(tool_names=config.tools, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+
+    if config.tools:
+        tool_refs = config.tools
+    else:
+        from aiq_agent.common import get_all_tool_refs
+
+        tool_refs = get_all_tool_refs()
+
+    tools = await builder.get_tools(tool_names=tool_refs, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+
+    if config.exclude_tools:
+        excluded = set(config.exclude_tools)
+        tools = [t for t in tools if getattr(t, "name", "") not in excluded]
 
     provider = LLMProvider()
     provider.set_default(llm)

--- a/src/aiq_agent/common/__init__.py
+++ b/src/aiq_agent/common/__init__.py
@@ -43,6 +43,8 @@ from .citation_verification import reset_session_registry
 from .citation_verification import sanitize_report
 from .citation_verification import set_session_registry
 from .citation_verification import verify_citations
+from .data_source_registry import get_all_tool_refs
+from .data_source_registry import get_source_id_for_tool
 from .data_sources import DEFAULT_DATA_SOURCES
 from .data_sources import extract_messages_and_sources
 from .data_sources import filter_tools_by_sources
@@ -74,8 +76,10 @@ __all__ = [
     "filter_tools_by_sources",
     "format_data_source_tools",
     "format_tool_unavailability_error",
+    "get_all_tool_refs",
     "get_checkpointer",
     "get_or_create_session_registry",
+    "get_source_id_for_tool",
     "get_session_registry",
     "get_latest_user_query",
     "is_postgres_dsn",

--- a/src/aiq_agent/common/data_source_registry.py
+++ b/src/aiq_agent/common/data_source_registry.py
@@ -37,11 +37,12 @@ Example YAML::
             tools:
               - web_search_tool
               - advanced_web_search_tool
-          - id: knowledge_layer
-            name: "Knowledge Base"
-            description: "Search uploaded documents and files."
+          - id: eci
+            name: "Enterprise Search"
+            description: "Search Confluence, Google Drive, and more."
+            requires_auth: true
             tools:
-              - knowledge_search
+              - eci
 """
 
 import logging
@@ -70,6 +71,7 @@ class DataSourceMeta:
     name: str
     description: str
     default_enabled: bool = True
+    requires_auth: bool = False
 
 
 # ── Global state ──
@@ -87,6 +89,7 @@ class DataSourceEntry(BaseModel):
     name: str = Field(..., description="Display name shown in the UI")
     description: str = Field(default="", description="Human-readable description")
     default_enabled: bool = Field(default=True, description="Whether enabled by default")
+    requires_auth: bool = Field(default=False, description="Whether the source requires user authentication")
     tools: list[FunctionRef] = Field(
         default_factory=list,
         description="NAT functions or function groups that belong to this data source",
@@ -122,6 +125,7 @@ def _populate(sources: list[dict], group_names: set[str] | None = None) -> None:
             name=entry.get("name", source_id.replace("_", " ").title()),
             description=entry.get("description", ""),
             default_enabled=entry.get("default_enabled", True),
+            requires_auth=entry.get("requires_auth", False),
         )
         for ref_name in entry.get("tools", []):
             if ref_name in group_names:
@@ -149,6 +153,7 @@ async def data_source_registry_fn(config: DataSourceRegistryConfig, builder: Any
             "name": entry.name,
             "description": entry.description,
             "default_enabled": entry.default_enabled,
+            "requires_auth": entry.requires_auth,
             "tools": [str(ref) for ref in entry.tools],
         }
         for entry in config.sources

--- a/src/aiq_agent/common/data_source_registry.py
+++ b/src/aiq_agent/common/data_source_registry.py
@@ -1,0 +1,244 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Config-driven data source registry.
+
+Data source display metadata and tool→source mappings are loaded from
+a ``data_source_registry`` function in the YAML config.  Each source
+entry declares its display name, description, and which NAT functions
+or function groups belong to it.
+
+Individual functions are matched by exact name.  Function groups are
+matched by prefix using NAT's group separators (``__`` and legacy ``.``).
+The register function auto-detects which refs are groups by checking
+the builder at startup.
+
+Example YAML::
+
+    functions:
+      data_sources:
+        _type: data_source_registry
+        sources:
+          - id: web_search
+            name: "Web Search"
+            description: "Search the web for real-time information."
+            tools:
+              - web_search_tool
+              - advanced_web_search_tool
+          - id: knowledge_layer
+            name: "Knowledge Base"
+            description: "Search uploaded documents and files."
+            tools:
+              - knowledge_search
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel
+from pydantic import Field
+
+from nat.builder.function import FunctionGroup
+from nat.builder.function_info import FunctionInfo
+from nat.cli.register_workflow import register_function
+from nat.data_models.component_ref import FunctionRef
+from nat.data_models.function import FunctionBaseConfig
+
+_GROUP_SEPARATORS = (FunctionGroup.SEPARATOR, FunctionGroup.LEGACY_SEPARATOR)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DataSourceMeta:
+    """Metadata for a registered data source."""
+
+    id: str
+    name: str
+    description: str
+    default_enabled: bool = True
+
+
+# ── Global state ──
+_registry: dict[str, DataSourceMeta] = {}
+_tool_source_map: dict[str, str] = {}  # exact tool name → source ID
+_group_source_map: dict[str, str] = {}  # group prefix → source ID
+_sorted_group_names: list[str] = []  # pre-sorted longest-first for prefix matching
+
+
+# ── Config models ──
+class DataSourceEntry(BaseModel):
+    """A single data source with its display metadata and tool references."""
+
+    id: str = Field(..., description="Source ID used in API and filtering (e.g. 'web_search')")
+    name: str = Field(..., description="Display name shown in the UI")
+    description: str = Field(default="", description="Human-readable description")
+    default_enabled: bool = Field(default=True, description="Whether enabled by default")
+    tools: list[FunctionRef] = Field(
+        default_factory=list,
+        description="NAT functions or function groups that belong to this data source",
+    )
+
+
+class DataSourceRegistryConfig(FunctionBaseConfig, name="data_source_registry"):
+    """Config-driven data source registry with NAT function references."""
+
+    sources: list[DataSourceEntry] = Field(
+        default_factory=list,
+        description="List of data source definitions",
+    )
+
+
+def _populate(sources: list[dict], group_names: set[str] | None = None) -> None:
+    """Shared logic for populating the registry and maps.
+
+    Used by both the NAT register function and the test helper.
+
+    Args:
+        sources: List of dicts with keys: id, name, description, tools.
+        group_names: Ref names to treat as function groups (prefix matching).
+    """
+    group_names = group_names or set()
+    tool_map: dict[str, str] = {}
+    group_map: dict[str, str] = {}
+
+    for entry in sources:
+        source_id = entry["id"]
+        _registry[source_id] = DataSourceMeta(
+            id=source_id,
+            name=entry.get("name", source_id.replace("_", " ").title()),
+            description=entry.get("description", ""),
+            default_enabled=entry.get("default_enabled", True),
+        )
+        for ref_name in entry.get("tools", []):
+            if ref_name in group_names:
+                group_map[ref_name] = source_id
+            else:
+                tool_map[ref_name] = source_id
+
+    set_tool_source_map(tool_map)
+    set_group_source_map(group_map)
+
+
+@register_function(config_type=DataSourceRegistryConfig)
+async def data_source_registry_fn(config: DataSourceRegistryConfig, builder: Any):
+    """Populate the global registry and tool/group maps from YAML config.
+
+    Auto-detects whether each tool ref is a function group (prefix match)
+    or individual function (exact match) by checking the builder.
+    """
+    # builder._function_groups is a dict of registered function groups
+    function_groups = set(getattr(builder, "_function_groups", {}))
+
+    entries = [
+        {
+            "id": entry.id,
+            "name": entry.name,
+            "description": entry.description,
+            "default_enabled": entry.default_enabled,
+            "tools": [str(ref) for ref in entry.tools],
+        }
+        for entry in config.sources
+    ]
+    _populate(entries, group_names=function_groups)
+
+    logger.info(
+        "Loaded %d data source(s): %d tool(s), %d group(s)",
+        len(config.sources),
+        len(_tool_source_map),
+        len(_group_source_map),
+    )
+
+    # NAT requires yielding a FunctionInfo; this is a config-only function
+    async def _noop(query: str) -> str:
+        """Data source registry (config-only, not a tool)."""
+        return "This is a config-only function."
+
+    yield FunctionInfo.from_fn(_noop, description="Data source registry (config-only)")
+
+
+# ── Lookup helpers ──
+def get_all_tool_refs() -> list[str]:
+    """Return all tool refs (individual names + group names) from the registry.
+
+    Used by agents that inherit tools automatically when their ``tools``
+    config list is empty.
+    """
+    refs: set[str] = set()
+    refs.update(_tool_source_map.keys())
+    refs.update(_group_source_map.keys())
+    return sorted(refs)
+
+
+def get_all_sources() -> list[DataSourceMeta]:
+    return list(_registry.values())
+
+
+def get_source(source_id: str) -> DataSourceMeta | None:
+    return _registry.get(source_id)
+
+
+def get_source_id_for_tool(tool_name: str) -> str | None:
+    """Look up source ID for a tool.
+
+    Tries exact match first (individual functions), then group prefix
+    match using NAT's function group separators (``__`` and legacy ``.``).
+    Group names are matched longest-first for deterministic results
+    with overlapping prefixes.
+    """
+    source_id = _tool_source_map.get(tool_name)
+    if source_id is not None:
+        return source_id
+
+    for group_name in _sorted_group_names:
+        if any(tool_name.startswith(group_name + sep) for sep in _GROUP_SEPARATORS):
+            return _group_source_map[group_name]
+
+    return None
+
+
+def set_tool_source_map(mapping: dict[str, str]) -> None:
+    """Set the exact tool→source mapping."""
+    global _tool_source_map
+    _tool_source_map = mapping
+
+
+def set_group_source_map(mapping: dict[str, str]) -> None:
+    """Set the group prefix→source mapping. Pre-sorts by length for lookup."""
+    global _group_source_map, _sorted_group_names
+    _group_source_map = mapping
+    _sorted_group_names = sorted(mapping, key=len, reverse=True)
+
+
+# ── Test helpers ──
+def populate_from_config(sources: list[dict], group_names: set[str] | None = None) -> None:
+    """Populate registry and maps directly (for testing without NAT startup).
+
+    Args:
+        sources: List of dicts with keys: id, name, description, tools (list of str).
+        group_names: Set of tool ref names that should be treated as function groups
+                     (prefix matching). If None, all refs are treated as exact matches.
+    """
+    _populate(sources, group_names=group_names)
+
+
+def reset_registry() -> None:
+    """Reset for testing."""
+    _registry.clear()
+    global _tool_source_map, _group_source_map, _sorted_group_names
+    _tool_source_map = {}
+    _group_source_map = {}
+    _sorted_group_names = []

--- a/src/aiq_agent/common/data_sources.py
+++ b/src/aiq_agent/common/data_sources.py
@@ -20,6 +20,9 @@ from typing import Any
 
 from langchain_core.messages import BaseMessage
 
+from .data_source_registry import get_source
+from .data_source_registry import get_source_id_for_tool
+
 # Default to web_search when no data sources specified
 DEFAULT_DATA_SOURCES: list[str] = ["web_search"]
 
@@ -55,36 +58,31 @@ def parse_data_sources(raw: Any) -> list[str] | None:
 def filter_tools_by_sources(tools: list[Any], data_sources: list[str] | None) -> list[Any]:
     """Filter tools based on selected data sources.
 
-    Knowledge tools are only included when 'knowledge_layer' is in data_sources.
+    Uses the tool->source map built at startup from config ``data_source`` fields.
+    Tools without a mapping (e.g. "think", calculator) are always included.
 
     Args:
         tools: List of LangChain tools.
-        data_sources: List of selected data source IDs, or None for all.
+        data_sources: List of selected data source IDs, None for all, or [] for none.
 
     Returns:
         Filtered list of tools matching the selected data sources.
     """
     if data_sources is None:
         return tools
+    if len(data_sources) == 0:
+        return []
 
-    normalized = {source.lower() for source in data_sources}
-    include_web_search = "web_search" in normalized
-    include_knowledge = "knowledge_layer" in normalized
-
+    selected = {s.lower() for s in data_sources}
     filtered = []
     for tool in tools:
         name = getattr(tool, "name", "")
-        name_lower = name.lower()
-
-        if "web" in name_lower or "tavily" in name_lower:
-            if include_web_search:
-                filtered.append(tool)
-        elif "knowledge" in name_lower or "document" in name_lower or "internal" in name_lower:
-            if include_knowledge:
-                filtered.append(tool)
-        else:
+        source_id = get_source_id_for_tool(name)
+        if source_id is None:
+            # Not a data source tool (e.g., "think", calculator) -> always include
             filtered.append(tool)
-
+        elif source_id.lower() in selected:
+            filtered.append(tool)
     return filtered
 
 
@@ -114,7 +112,8 @@ def extract_messages_and_sources(payload: Any) -> tuple[list[BaseMessage], list[
 def format_data_source_tools(data_sources: list[str]) -> list[dict[str, str]]:
     """Format data sources as tool info for meta chatter.
 
-    Knowledge tools are only included when 'knowledge_layer' is in data_sources.
+    Looks up display metadata from the registry first; falls back to
+    title-cased IDs for unregistered sources.
 
     Args:
         data_sources: List of data source IDs.
@@ -123,11 +122,11 @@ def format_data_source_tools(data_sources: list[str]) -> list[dict[str, str]]:
         List of tool info dicts with 'name' and 'description'.
     """
     tools_info: list[dict[str, str]] = []
-
-    for source in data_sources:
-        if source == "web_search":
-            tools_info.append({"name": "web_search", "description": "Search the web for real-time information."})
+    for source_id in data_sources:
+        meta = get_source(source_id)
+        if meta:
+            tools_info.append({"name": meta.name, "description": meta.description})
         else:
-            tools_info.append({"name": "knowledge_search", "description": "Search uploaded documents and files."})
-
+            label = source_id.replace("_", " ").title()
+            tools_info.append({"name": label, "description": f"Search {source_id.replace('_', ' ')}."})
     return tools_info

--- a/tests/aiq_agent/common/test_common_init.py
+++ b/tests/aiq_agent/common/test_common_init.py
@@ -194,7 +194,20 @@ class TestDataSourcesExports:
         """Test format_data_source_tools is exported and functional."""
         result = format_data_source_tools(["web_search"])
         assert len(result) == 1
-        assert result[0]["name"] == "web_search"
+        # Falls back to title-cased ID when registry is empty
+        assert result[0]["name"] == "Web Search"
+
+    def test_get_all_tool_refs_exported(self):
+        """Test get_all_tool_refs is exported."""
+        from aiq_agent.common import get_all_tool_refs
+
+        assert callable(get_all_tool_refs)
+
+    def test_get_source_id_for_tool_exported(self):
+        """Test get_source_id_for_tool is exported."""
+        from aiq_agent.common import get_source_id_for_tool
+
+        assert callable(get_source_id_for_tool)
 
 
 class TestIsPostgresDsn:

--- a/tests/aiq_agent/common/test_data_source_registry.py
+++ b/tests/aiq_agent/common/test_data_source_registry.py
@@ -1,0 +1,270 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for data_source_registry module."""
+
+import pytest
+
+from aiq_agent.common.data_source_registry import DataSourceMeta
+from aiq_agent.common.data_source_registry import get_all_sources
+from aiq_agent.common.data_source_registry import get_all_tool_refs
+from aiq_agent.common.data_source_registry import get_source
+from aiq_agent.common.data_source_registry import get_source_id_for_tool
+from aiq_agent.common.data_source_registry import populate_from_config
+from aiq_agent.common.data_source_registry import reset_registry
+from aiq_agent.common.data_source_registry import set_group_source_map
+from aiq_agent.common.data_source_registry import set_tool_source_map
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Reset registry before and after each test."""
+    reset_registry()
+    yield
+    reset_registry()
+
+
+class TestPopulateFromConfig:
+    """Tests for populate_from_config (YAML-driven registration)."""
+
+    def test_populates_registry_and_tool_map(self):
+        """Test that populate_from_config loads sources and tool mappings."""
+        populate_from_config(
+            [
+                {
+                    "id": "web_search",
+                    "name": "Web Search",
+                    "description": "Search the web.",
+                    "tools": ["web_search_tool", "advanced_web_search_tool"],
+                },
+                {
+                    "id": "knowledge_layer",
+                    "name": "Knowledge Base",
+                    "description": "Search documents.",
+                    "tools": ["knowledge_search"],
+                },
+            ]
+        )
+
+        assert len(get_all_sources()) == 2
+        meta = get_source("web_search")
+        assert meta is not None
+        assert meta.name == "Web Search"
+
+        assert get_source_id_for_tool("web_search_tool") == "web_search"
+        assert get_source_id_for_tool("advanced_web_search_tool") == "web_search"
+        assert get_source_id_for_tool("knowledge_search") == "knowledge_layer"
+
+    def test_default_enabled_false(self):
+        """Test that default_enabled can be set to False."""
+        populate_from_config(
+            [
+                {"id": "disabled_src", "name": "D", "description": "D", "default_enabled": False},
+            ]
+        )
+
+        meta = get_source("disabled_src")
+        assert meta is not None
+        assert meta.default_enabled is False
+
+    def test_missing_name_uses_title_cased_id(self):
+        """Test that missing name falls back to title-cased ID."""
+        populate_from_config([{"id": "my_custom_search", "description": "Custom search."}])
+
+        meta = get_source("my_custom_search")
+        assert meta.name == "My Custom Search"
+
+    def test_source_without_tools(self):
+        """Test that a source with no tools is registered but has no tool mappings."""
+        populate_from_config([{"id": "empty_src", "name": "Empty", "description": "No tools."}])
+
+        assert get_source("empty_src") is not None
+        assert get_source_id_for_tool("anything") is None
+
+    def test_group_refs_populate_prefix_map(self):
+        """Test that tools listed as group_names enable prefix matching."""
+        populate_from_config(
+            [{"id": "my_group", "name": "My Group", "description": "A group source.", "tools": ["my_group"]}],
+            group_names={"my_group"},
+        )
+
+        assert get_source_id_for_tool("my_group__tool_a") == "my_group"
+        assert get_source_id_for_tool("my_group__tool_b") == "my_group"
+        assert get_source_id_for_tool("web_search_tool") is None
+
+
+class TestGetAllSources:
+    def test_empty_registry(self):
+        assert get_all_sources() == []
+
+    def test_returns_all_registered(self):
+        populate_from_config(
+            [
+                {"id": "a", "name": "A", "description": "A"},
+                {"id": "b", "name": "B", "description": "B"},
+            ]
+        )
+
+        sources = get_all_sources()
+        ids = {s.id for s in sources}
+        assert ids == {"a", "b"}
+
+
+class TestGetSource:
+    def test_returns_none_for_unknown(self):
+        assert get_source("nonexistent") is None
+
+    def test_returns_metadata_for_known(self):
+        populate_from_config([{"id": "known", "name": "Known", "description": "Known source"}])
+
+        meta = get_source("known")
+        assert isinstance(meta, DataSourceMeta)
+        assert meta.name == "Known"
+
+
+class TestToolSourceMap:
+    def test_get_source_id_for_tool_returns_none_when_empty(self):
+        assert get_source_id_for_tool("any_tool") is None
+
+    def test_set_and_get_tool_source_map(self):
+        set_tool_source_map({"web_search_tool": "web_search", "knowledge_search": "knowledge_layer"})
+
+        assert get_source_id_for_tool("web_search_tool") == "web_search"
+        assert get_source_id_for_tool("knowledge_search") == "knowledge_layer"
+        assert get_source_id_for_tool("calculator") is None
+
+    def test_reset_clears_tool_map(self):
+        set_tool_source_map({"tool": "source"})
+        reset_registry()
+        assert get_source_id_for_tool("tool") is None
+
+    def test_group_matches_nat_separator(self):
+        """Function group tools use NAT's __ separator."""
+        set_group_source_map({"my_group": "my_group"})
+
+        assert get_source_id_for_tool("my_group__tool_a") == "my_group"
+        assert get_source_id_for_tool("my_group__tool_b") == "my_group"
+
+    def test_group_matches_legacy_separator(self):
+        """Function group tools also match NAT's legacy . separator."""
+        set_group_source_map({"my_group": "my_group"})
+
+        assert get_source_id_for_tool("my_group.tool_a") == "my_group"
+
+    def test_group_rejects_no_separator(self):
+        """Bare prefix without NAT separator does not match."""
+        set_group_source_map({"my_group": "my_group"})
+
+        assert get_source_id_for_tool("my_group") is None
+        assert get_source_id_for_tool("my_groupfoo") is None
+        assert get_source_id_for_tool("my_group_tool") is None  # single underscore is not a NAT separator
+
+    def test_exact_match_takes_priority_over_group(self):
+        """Exact tool match should win over group prefix match."""
+        set_tool_source_map({"my_group__special": "special_source"})
+        set_group_source_map({"my_group": "my_group"})
+
+        assert get_source_id_for_tool("my_group__special") == "special_source"
+        assert get_source_id_for_tool("my_group__other") == "my_group"
+
+    def test_overlapping_group_prefixes_match_longest(self):
+        """When group prefixes overlap, the longest matching prefix wins."""
+        set_group_source_map({"abc": "source_short", "abc_special": "source_long"})
+
+        assert get_source_id_for_tool("abc_special__tool") == "source_long"
+        assert get_source_id_for_tool("abc__tool") == "source_short"
+
+    def test_unknown_tool_returns_none_with_groups(self):
+        """Tools not matching any exact or prefix mapping return None."""
+        set_tool_source_map({"web_search_tool": "web_search"})
+        set_group_source_map({"my_group": "my_group"})
+
+        assert get_source_id_for_tool("calculator") is None
+
+
+class TestGetAllToolRefs:
+    """Tests for get_all_tool_refs (auto-inherit helper)."""
+
+    def test_empty_registry(self):
+        assert get_all_tool_refs() == []
+
+    def test_returns_individual_tools(self):
+        populate_from_config(
+            [
+                {
+                    "id": "web_search",
+                    "name": "Web Search",
+                    "description": "Search the web.",
+                    "tools": ["web_search_tool", "advanced_web_search_tool"],
+                },
+            ]
+        )
+
+        refs = get_all_tool_refs()
+        assert "web_search_tool" in refs
+        assert "advanced_web_search_tool" in refs
+
+    def test_returns_group_names(self):
+        populate_from_config(
+            [
+                {
+                    "id": "eci",
+                    "name": "Enterprise Search",
+                    "description": "Search enterprise content.",
+                    "tools": ["eci"],
+                },
+            ],
+            group_names={"eci"},
+        )
+
+        refs = get_all_tool_refs()
+        assert "eci" in refs
+
+    def test_returns_both_individual_and_group(self):
+        populate_from_config(
+            [
+                {
+                    "id": "web_search",
+                    "name": "Web Search",
+                    "description": "Search the web.",
+                    "tools": ["web_search_tool"],
+                },
+                {
+                    "id": "eci",
+                    "name": "Enterprise Search",
+                    "description": "Search enterprise content.",
+                    "tools": ["eci"],
+                },
+            ],
+            group_names={"eci"},
+        )
+
+        refs = get_all_tool_refs()
+        assert set(refs) == {"web_search_tool", "eci"}
+
+    def test_returns_sorted(self):
+        populate_from_config(
+            [
+                {
+                    "id": "src",
+                    "name": "Src",
+                    "description": "Src.",
+                    "tools": ["z_tool", "a_tool", "m_tool"],
+                },
+            ]
+        )
+
+        refs = get_all_tool_refs()
+        assert refs == sorted(refs)

--- a/tests/aiq_agent/common/test_data_source_registry.py
+++ b/tests/aiq_agent/common/test_data_source_registry.py
@@ -17,6 +17,7 @@
 
 import pytest
 
+from aiq_agent.common.data_source_registry import DataSourceEntry
 from aiq_agent.common.data_source_registry import DataSourceMeta
 from aiq_agent.common.data_source_registry import get_all_sources
 from aiq_agent.common.data_source_registry import get_all_tool_refs
@@ -78,6 +79,29 @@ class TestPopulateFromConfig:
         meta = get_source("disabled_src")
         assert meta is not None
         assert meta.default_enabled is False
+
+    def test_requires_auth_true(self):
+        """Test that requires_auth is stored on the metadata."""
+        populate_from_config(
+            [
+                {"id": "eci", "name": "ECI", "description": "Enterprise.", "requires_auth": True},
+            ]
+        )
+
+        meta = get_source("eci")
+        assert meta is not None
+        assert meta.requires_auth is True
+
+    def test_requires_auth_defaults_to_false(self):
+        """Test that requires_auth defaults to False when omitted."""
+        populate_from_config(
+            [
+                {"id": "web", "name": "Web", "description": "Web search."},
+            ]
+        )
+
+        meta = get_source("web")
+        assert meta.requires_auth is False
 
     def test_missing_name_uses_title_cased_id(self):
         """Test that missing name falls back to title-cased ID."""
@@ -268,3 +292,15 @@ class TestGetAllToolRefs:
 
         refs = get_all_tool_refs()
         assert refs == sorted(refs)
+
+
+class TestDataSourceEntry:
+    """Tests for the DataSourceEntry pydantic config model."""
+
+    def test_requires_auth_defaults_false(self):
+        entry = DataSourceEntry(id="web", name="Web", description="Web search.")
+        assert entry.requires_auth is False
+
+    def test_requires_auth_set_true(self):
+        entry = DataSourceEntry(id="eci", name="ECI", requires_auth=True)
+        assert entry.requires_auth is True

--- a/tests/aiq_agent/common/test_data_sources.py
+++ b/tests/aiq_agent/common/test_data_sources.py
@@ -20,11 +20,45 @@ from unittest.mock import MagicMock
 import pytest
 from langchain_core.messages import HumanMessage
 
+from aiq_agent.common.data_source_registry import populate_from_config
+from aiq_agent.common.data_source_registry import reset_registry
 from aiq_agent.common.data_sources import DEFAULT_DATA_SOURCES
 from aiq_agent.common.data_sources import extract_messages_and_sources
 from aiq_agent.common.data_sources import filter_tools_by_sources
 from aiq_agent.common.data_sources import format_data_source_tools
 from aiq_agent.common.data_sources import parse_data_sources
+
+
+@pytest.fixture(autouse=True)
+def _setup_registry():
+    """Set up registry with test data sources and tool→source map for all tests."""
+    reset_registry()
+
+    populate_from_config(
+        [
+            {
+                "id": "web_search",
+                "name": "Web Search",
+                "description": "Search the web for real-time information.",
+                "tools": ["web_search_tool", "web_search", "tavily_search"],
+            },
+            {
+                "id": "knowledge_layer",
+                "name": "Knowledge Base",
+                "description": "Search uploaded documents and files.",
+                "tools": ["knowledge_search", "knowledge_retrieval"],
+            },
+            {
+                "id": "paper_search",
+                "name": "Academic Papers",
+                "description": "Search academic papers.",
+                "tools": ["paper_search_tool"],
+            },
+        ]
+    )
+
+    yield
+    reset_registry()
 
 
 class TestParseDataSources:
@@ -194,7 +228,7 @@ class TestFilterToolsBySourcesMixed:
         assert other_tool in result
 
     def test_filter_all_three_source_types(self):
-        """Test filtering with web_search and knowledge_layer sources."""
+        """Test filtering with web_search, knowledge_layer, and ECI sources."""
         web_tool = MagicMock()
         web_tool.name = "tavily_search"
         knowledge_tool = MagicMock()
@@ -219,7 +253,7 @@ class TestFilterToolsBySourcesMixed:
         assert web_tool in result
 
     def test_filter_preserves_other_tools(self):
-        """Test that non-search tools are always included."""
+        """Test that non-search/ECI tools are always included."""
         calculator = MagicMock()
         calculator.name = "calculator"
         code_executor = MagicMock()
@@ -291,58 +325,48 @@ class TestFormatDataSourceTools:
     """Tests for format_data_source_tools function."""
 
     def test_format_web_search_source(self):
-        """Test formatting web_search data source."""
+        """Test formatting web_search data source uses registry display name."""
         result = format_data_source_tools(["web_search"])
 
         assert len(result) == 1
-        assert result[0]["name"] == "web_search"
+        assert result[0]["name"] == "Web Search"
         assert "web" in result[0]["description"].lower()
 
     def test_format_knowledge_layer_source(self):
-        """Test formatting knowledge_layer data source."""
+        """Test formatting knowledge_layer data source uses registry display name."""
         result = format_data_source_tools(["knowledge_layer"])
 
         assert len(result) == 1
-        assert result[0]["name"] == "knowledge_search"
+        assert result[0]["name"] == "Knowledge Base"
         assert "document" in result[0]["description"].lower() or "file" in result[0]["description"].lower()
 
-    def test_format_non_web_source_as_knowledge(self):
-        """Test that non-web sources (e.g. confluence) map to knowledge_search."""
+    def test_format_unknown_source_uses_title_case(self):
+        """Test that unregistered sources fall back to title-cased ID."""
         result = format_data_source_tools(["confluence"])
 
         assert len(result) == 1
-        assert result[0]["name"] == "knowledge_search"
-        assert "document" in result[0]["description"].lower() or "file" in result[0]["description"].lower()
+        assert result[0]["name"] == "Confluence"
 
     def test_format_multiple_sources(self):
-        """Test formatting multiple data sources (web_search and others map to knowledge_search)."""
-        result = format_data_source_tools(["web_search", "sharepoint"])
+        """Test formatting multiple data sources."""
+        result = format_data_source_tools(["web_search", "knowledge_layer"])
 
         assert len(result) == 2
         names = [r["name"] for r in result]
-        assert "web_search" in names
-        assert "knowledge_search" in names
-
-    def test_format_multiple_sources_with_knowledge_layer(self):
-        """Test formatting multiple data sources; non-web sources map to knowledge_search."""
-        result = format_data_source_tools(["web_search", "knowledge_layer", "confluence"])
-
-        assert len(result) == 3
-        names = [r["name"] for r in result]
-        assert "web_search" in names
-        assert names.count("knowledge_search") == 2
+        assert "Web Search" in names
+        assert "Knowledge Base" in names
 
     def test_format_empty_list(self):
         """Test formatting empty list returns empty list."""
         result = format_data_source_tools([])
         assert len(result) == 0
 
-    def test_format_non_web_tool_as_knowledge(self):
-        """Test that non-web sources (e.g. google_drive) map to knowledge_search."""
+    def test_format_underscore_replacement_for_unknown(self):
+        """Test that unregistered sources with underscores get title-cased."""
         result = format_data_source_tools(["google_drive"])
 
         assert len(result) == 1
-        assert result[0]["name"] == "knowledge_search"
+        assert result[0]["name"] == "Google Drive"
 
 
 class TestDefaultDataSources:

--- a/tests/aiq_agent/jobs/test_runner.py
+++ b/tests/aiq_agent/jobs/test_runner.py
@@ -936,69 +936,6 @@ class TestDataSourceModel:
         assert data["description"] == "Enterprise docs."
 
 
-class TestCollectToolNames:
-    """Tests for _collect_tool_names helper function."""
-
-    def test_collect_empty_builder(self):
-        """Test collecting from builder with no functions."""
-        from aiq_api.routes.jobs import _collect_tool_names
-
-        mock_builder = MagicMock()
-        mock_builder.get_function_config.side_effect = KeyError("Not found")
-
-        result = _collect_tool_names(mock_builder)
-        assert result == set()
-
-    def test_collect_with_tools(self):
-        """Test collecting tool names from builder."""
-        from aiq_api.routes.jobs import _collect_tool_names
-
-        mock_tool1 = MagicMock()
-        mock_tool1.name = "tavily_search"
-
-        mock_config = MagicMock()
-        mock_config.tools = [mock_tool1]
-
-        mock_builder = MagicMock()
-        mock_builder.get_function_config.return_value = mock_config
-
-        result = _collect_tool_names(mock_builder)
-        assert "tavily_search" in result
-
-    def test_collect_with_no_tools_attribute(self):
-        """Test collecting when config has no tools attribute."""
-        from aiq_api.routes.jobs import _collect_tool_names
-
-        mock_config = MagicMock(spec=[])
-
-        mock_builder = MagicMock()
-        mock_builder.get_function_config.return_value = mock_config
-
-        result = _collect_tool_names(mock_builder)
-        assert result == set()
-
-    def test_collect_with_mixed_function_availability(self):
-        """Test collecting when some functions don't exist."""
-        from aiq_api.routes.jobs import _collect_tool_names
-
-        mock_tool = MagicMock()
-        mock_tool.name = "test_tool"
-        mock_config = MagicMock()
-        mock_config.tools = [mock_tool]
-
-        mock_builder = MagicMock()
-
-        def get_fn_config(name):
-            if name == "deep_research_agent":
-                return mock_config
-            raise KeyError(f"No function {name}")
-
-        mock_builder.get_function_config.side_effect = get_fn_config
-
-        result = _collect_tool_names(mock_builder)
-        assert "test_tool" in result
-
-
 class TestJobErrorEventEmission:
     """Tests for job.error event emission on job failure."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
@@ -1290,7 +1290,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.24.0" },
-    { name = "nvidia-nat-eval", specifier = ">=1.5.0,<2" },
+    { name = "nvidia-nat-eval", specifier = "==1.5.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
 ]
 


### PR DESCRIPTION
### Add data source registry with auto-inherit, auth gating, and agent exclusions

## Summary

- **Config-driven data source registry** (`data_source_registry`) replaces hardcoded tool-to-source mappings. Each source declares its display metadata, tools, and auth requirements in YAML — one place to add a new tool or MCP function group.
- **Dynamic UI toggles**: The `GET /v1/data_sources` endpoint returns registered sources directly from the registry. The frontend renders each source as an on/off toggle in the Data Sources panel — no frontend changes needed when adding or removing sources.
- **Per-message filtering**: Users select active sources via UI toggles. The selection flows as `data_sources: ["web_search", ...]` in the chat payload, and only tools belonging to selected sources are active for that request.
- **Auto-inherit**: Agents with an empty `tools` list automatically receive every tool from the registry. Use `exclude_tools` for per-agent specialization (e.g., shallow gets `web_search_tool`, deep gets `advanced_web_search_tool`).
- **`requires_auth` field**: Per-source auth gating replaces the hardcoded `id === 'web_search'` check in the frontend. Sources using backend API keys (Tavily, Serper) default to `false`; enterprise sources needing user OAuth tokens set `true`. Auth-required sources appear greyed out with "Sign in required" until the user authenticates.
- **Fix: deep researcher missing tools in Dask worker**: The async job runner bypassed auto-inherit logic, so deep research sub-agents got zero search tools. Now mirrors the register function pattern.
- **Fix: silent auth transport failures** in WebSocket and SSE connections (#170).
- **Docs**: Full field reference tables in `tools-and-sources.md` and `adding-a-data-source.md`; expanded config comments for external ISVs; updated MCP tools guide.

## Test plan

- [ ] Backend: `pytest tests/aiq_agent/common/test_data_source_registry.py` — 27 tests covering registry population, `requires_auth`, tool/group maps, auto-inherit refs
- [ ] Backend: `pytest tests/aiq_agent/common/test_data_sources.py` — filtering tests
- [ ] Backend: `pytest tests/aiq_agent/jobs/test_runner.py` — 73 tests for async job runner
- [ ] Frontend: `npx vitest run` — 1179 tests pass (DataSourcesPanel auth gating, DataConnectionCard, chat store default-enable logic)
- [ ] Frontend: TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] Manual: enable paper_search in UI → shallow and deep researchers both use it
- [ ] Manual: source with `requires_auth: true` shows greyed out without sign-in, available after sign-in
- [ ] Manual: adding a new source to the registry makes it available to all agents without per-agent config changes