### PR TITLE
AIQ UI session storage fixes

### DIFF
--- a/frontends/ui/src/features/chat/lib/prune-message-for-storage.spec.ts
+++ b/frontends/ui/src/features/chat/lib/prune-message-for-storage.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, test, expect } from 'vitest'
-import { pruneMessageForStorage, capString, pruneThinkingSteps, prunePlanMessages } from './prune-message-for-storage'
+import { pruneMessageForStorage, capString, stripThinkingStepsForStorage, prunePlanMessages } from './prune-message-for-storage'
 import type { ChatMessage } from '../types'
 
 describe('prune-message-for-storage', () => {
@@ -79,7 +79,6 @@ describe('prune-message-for-storage', () => {
 
       const pruned = pruneMessageForStorage(message)
 
-      // Essential fields kept
       expect(pruned.thinkingSteps).toBeDefined()
       expect(pruned.thinkingSteps).toHaveLength(1)
       expect(pruned.planMessages).toBeDefined()
@@ -88,6 +87,96 @@ describe('prune-message-for-storage', () => {
       expect(pruned.messageFiles).toHaveLength(1)
       expect(pruned.deepResearchJobId).toBe('job_123')
       expect(pruned.deepResearchJobStatus).toBe('success')
+    })
+
+    test('strips thinking step content and removes deep research steps', () => {
+      const message: ChatMessage = {
+        id: 'msg_3',
+        role: 'user',
+        content: 'Question',
+        timestamp: new Date(),
+        messageType: 'user',
+        thinkingSteps: [
+          {
+            id: 'ts_shallow',
+            userMessageId: 'msg_3',
+            category: 'tools',
+            functionName: 'web_search_tool',
+            displayName: 'Web Search',
+            content: 'Large content that is never displayed in ChatThinking',
+            rawPayload: '{"raw": "payload data"}',
+            timestamp: new Date(),
+            isComplete: true,
+            isDeepResearch: false,
+          },
+          {
+            id: 'ts_deep',
+            userMessageId: 'msg_3',
+            category: 'agents',
+            functionName: 'deep_agent',
+            displayName: 'Deep Agent',
+            content: 'Deep research content',
+            timestamp: new Date(),
+            isComplete: true,
+            isDeepResearch: true,
+          },
+        ],
+      }
+
+      const pruned = pruneMessageForStorage(message)
+
+      // Deep research step removed entirely
+      expect(pruned.thinkingSteps).toHaveLength(1)
+      expect(pruned.thinkingSteps![0].id).toBe('ts_shallow')
+
+      // Shallow step content stripped
+      expect(pruned.thinkingSteps![0].content).toBe('')
+      expect(pruned.thinkingSteps![0].rawPayload).toBeUndefined()
+
+      // Display fields preserved
+      expect(pruned.thinkingSteps![0].displayName).toBe('Web Search')
+      expect(pruned.thinkingSteps![0].functionName).toBe('web_search_tool')
+      expect(pruned.thinkingSteps![0].isTopLevel).toBeUndefined()
+    })
+
+    test('caps plan message text during pruning', () => {
+      const message: ChatMessage = {
+        id: 'msg_4',
+        role: 'assistant',
+        content: 'Response',
+        timestamp: new Date(),
+        messageType: 'agent_response',
+        planMessages: [
+          {
+            id: 'pm1',
+            text: 'x'.repeat(20000),
+            inputType: 'approval',
+            timestamp: new Date(),
+            userResponse: 'y'.repeat(5000),
+          },
+        ],
+      }
+
+      const pruned = pruneMessageForStorage(message)
+
+      expect(pruned.planMessages![0].text).toHaveLength(10000)
+      expect(pruned.planMessages![0].userResponse).toHaveLength(2000)
+    })
+
+    test('handles messages without thinkingSteps or planMessages', () => {
+      const message: ChatMessage = {
+        id: 'msg_5',
+        role: 'user',
+        content: 'Simple message',
+        timestamp: new Date(),
+      }
+
+      const pruned = pruneMessageForStorage(message)
+
+      expect(pruned.id).toBe('msg_5')
+      expect(pruned.content).toBe('Simple message')
+      expect(pruned.thinkingSteps).toBeUndefined()
+      expect(pruned.planMessages).toBeUndefined()
     })
   })
 
@@ -108,8 +197,40 @@ describe('prune-message-for-storage', () => {
     })
   })
 
-  describe('pruneThinkingSteps', () => {
-    test('caps content length in thinking steps', () => {
+  describe('stripThinkingStepsForStorage', () => {
+    test('removes deep research steps', () => {
+      const steps = [
+        {
+          id: 'ts_shallow',
+          userMessageId: 'msg_1',
+          category: 'tools' as const,
+          functionName: 'web_search',
+          displayName: 'Web Search',
+          content: 'some content',
+          timestamp: new Date(),
+          isComplete: true,
+          isDeepResearch: false,
+        },
+        {
+          id: 'ts_deep',
+          userMessageId: 'msg_1',
+          category: 'agents' as const,
+          functionName: 'deep_agent',
+          displayName: 'Deep Agent',
+          content: 'deep content',
+          timestamp: new Date(),
+          isComplete: true,
+          isDeepResearch: true,
+        },
+      ]
+
+      const stripped = stripThinkingStepsForStorage(steps)
+
+      expect(stripped).toHaveLength(1)
+      expect(stripped[0].id).toBe('ts_shallow')
+    })
+
+    test('strips content from shallow steps', () => {
       const steps = [
         {
           id: 'ts1',
@@ -118,38 +239,51 @@ describe('prune-message-for-storage', () => {
           functionName: 'test_function',
           displayName: 'Step 1',
           content: 'x'.repeat(10000),
+          rawPayload: '{"large": "payload"}',
           timestamp: new Date(),
           isComplete: true,
         },
       ]
 
-      const pruned = pruneThinkingSteps(steps, 100)
+      const stripped = stripThinkingStepsForStorage(steps)
 
-      expect(pruned).toHaveLength(1)
-      expect(pruned[0].content).toHaveLength(100)
-      expect(pruned[0].displayName).toBe('Step 1')
+      expect(stripped).toHaveLength(1)
+      expect(stripped[0].content).toBe('')
+      expect(stripped[0].rawPayload).toBeUndefined()
+      expect(stripped[0].displayName).toBe('Step 1')
+      expect(stripped[0].functionName).toBe('test_function')
     })
 
-    test('keeps other step fields intact', () => {
+    test('preserves display fields', () => {
+      const ts = new Date()
       const steps = [
         {
           id: 'ts1',
           userMessageId: 'msg_1',
           category: 'tools' as const,
-          functionName: 'test_function',
-          displayName: 'Step 1',
-          content: 'Short content',
-          timestamp: new Date(),
+          functionName: 'search_tool',
+          displayName: 'Search Tool',
+          content: 'content',
+          timestamp: ts,
           isComplete: true,
-          isDeepResearch: true,
+          isTopLevel: true,
         },
       ]
 
-      const pruned = pruneThinkingSteps(steps, 5000)
+      const stripped = stripThinkingStepsForStorage(steps)
 
-      expect(pruned[0].id).toBe('ts1')
-      expect(pruned[0].isDeepResearch).toBe(true)
-      expect(pruned[0].isComplete).toBe(true)
+      expect(stripped[0].id).toBe('ts1')
+      expect(stripped[0].userMessageId).toBe('msg_1')
+      expect(stripped[0].functionName).toBe('search_tool')
+      expect(stripped[0].displayName).toBe('Search Tool')
+      expect(stripped[0].timestamp).toBe(ts)
+      expect(stripped[0].isComplete).toBe(true)
+      expect(stripped[0].isTopLevel).toBe(true)
+    })
+
+    test('handles empty array', () => {
+      const stripped = stripThinkingStepsForStorage([])
+      expect(stripped).toHaveLength(0)
     })
   })
 

--- a/frontends/ui/src/features/chat/lib/prune-message-for-storage.ts
+++ b/frontends/ui/src/features/chat/lib/prune-message-for-storage.ts
@@ -11,87 +11,43 @@
 import type { ChatMessage } from '../types'
 
 /**
- * Prune a message for localStorage storage by removing heavy fields that
- * can be fetched from the backend on demand.
- *
- * KEEPS (Essential for UI):
- * - Core message fields (id, role, content, timestamp, messageType)
- * - thinkingSteps (for ChatThinking display)
- * - planMessages (cannot be refetched - WebSocket only)
- * - enabledDataSources, messageFiles (for "Selected Data Sources")
- * - Deep research job metadata (for restoration)
- * - HITL/prompt fields (for interaction state)
- * - Other message type data (status, file, error, banner data)
- *
- * REMOVES (Can fetch from backend via importStreamOnly):
- * - reportContent (can fetch via loadReport or importStreamOnly)
- * - citations (fetch via importStreamOnly)
- * - deepResearchTodos (fetch via importStreamOnly)
- * - deepResearchLLMSteps (fetch via importStreamOnly)
- * - deepResearchAgents (fetch via importStreamOnly)
- * - deepResearchToolCalls (fetch via importStreamOnly)
- * - deepResearchFiles (fetch via importStreamOnly)
- * - intermediateSteps (legacy, unused)
- *
- * @param message - The message to prune
- * @returns Pruned message with heavy fields removed
- */
-export const pruneMessageForStorage = (message: ChatMessage): ChatMessage => {
-  // Create a shallow copy and explicitly remove heavy fields
-  const {
-    // Remove these heavy, refetchable fields
-    reportContent: _reportContent,
-    citations: _citations,
-    deepResearchTodos: _deepResearchTodos,
-    deepResearchLLMSteps: _deepResearchLLMSteps,
-    deepResearchAgents: _deepResearchAgents,
-    deepResearchToolCalls: _deepResearchToolCalls,
-    deepResearchFiles: _deepResearchFiles,
-    intermediateSteps: _intermediateSteps,
-    // Keep everything else
-    ...prunedMessage
-  } = message
-
-  return prunedMessage
-}
-
-/**
- * Cap string content to prevent excessively large messages.
- * Used as a safety measure for user/agent message content.
- *
- * @param value - String to cap
- * @param max - Maximum length
- * @returns Capped string
+ * Cap string content to prevent excessively large values.
  */
 export const capString = (value: string, max: number): string => {
   return value.length > max ? value.slice(0, max) : value
 }
 
 /**
- * Prune thinking steps to reduce storage size.
- * Keeps step metadata but caps content length.
+ * Strip thinking steps for storage. ChatThinking only renders displayName
+ * and timestamp — content/rawPayload/category are never displayed.
  *
- * @param steps - Array of thinking steps
- * @param maxContentLength - Maximum length for step content
- * @returns Pruned thinking steps
+ * - Deep research steps (isDeepResearch=true) are removed entirely since
+ *   they are refetched from the async backend API.
+ * - Shallow steps keep only the fields needed for ChatThinking display.
  */
-export const pruneThinkingSteps = (
-  steps: NonNullable<ChatMessage['thinkingSteps']>,
-  maxContentLength = 5000
+export const stripThinkingStepsForStorage = (
+  steps: NonNullable<ChatMessage['thinkingSteps']>
 ): NonNullable<ChatMessage['thinkingSteps']> => {
-  return steps.map((step) => ({
-    ...step,
-    content: capString(step.content, maxContentLength),
-  }))
+  return steps
+    .filter((step) => !step.isDeepResearch)
+    .map((step) => ({
+      id: step.id,
+      userMessageId: step.userMessageId,
+      functionName: step.functionName,
+      displayName: step.displayName,
+      content: '',
+      timestamp: step.timestamp,
+      isComplete: step.isComplete,
+      isDeepResearch: step.isDeepResearch,
+      isTopLevel: step.isTopLevel,
+      category: step.category,
+    }))
 }
 
 /**
  * Prune plan messages to reduce storage size.
  * Keeps plan structure but caps text content.
- *
- * @param planMessages - Array of plan messages
- * @param maxTextLength - Maximum length for plan text
- * @returns Pruned plan messages
+ * planMessages cannot be refetched (WebSocket only).
  */
 export const prunePlanMessages = (
   planMessages: NonNullable<ChatMessage['planMessages']>,
@@ -102,4 +58,49 @@ export const prunePlanMessages = (
     text: capString(pm.text, maxTextLength),
     userResponse: pm.userResponse ? capString(pm.userResponse, 2000) : pm.userResponse,
   }))
+}
+
+/**
+ * Prune a message for localStorage storage by removing heavy fields that
+ * can be fetched from the backend on demand, stripping thinking step
+ * content, and capping plan message text.
+ *
+ * KEEPS (Essential for UI):
+ * - Core message fields (id, role, content, timestamp, messageType)
+ * - thinkingSteps (stripped: content removed, deep research steps dropped)
+ * - planMessages (capped: text 10k, userResponse 2k — cannot be refetched)
+ * - enabledDataSources, messageFiles (for "Selected Data Sources")
+ * - Deep research job metadata (for restoration)
+ * - HITL/prompt fields (for interaction state)
+ * - Other message type data (status, file, error, banner data)
+ *
+ * REMOVES (Can fetch from backend via importStreamOnly):
+ * - reportContent, citations, deepResearchTodos, deepResearchLLMSteps,
+ *   deepResearchAgents, deepResearchToolCalls, deepResearchFiles
+ * - intermediateSteps (legacy, unused)
+ * - thinkingStep content/rawPayload (never displayed in ChatThinking)
+ * - Deep research thinking steps (refetched from async API)
+ */
+export const pruneMessageForStorage = (message: ChatMessage): ChatMessage => {
+  const {
+    reportContent: _reportContent,
+    citations: _citations,
+    deepResearchTodos: _deepResearchTodos,
+    deepResearchLLMSteps: _deepResearchLLMSteps,
+    deepResearchAgents: _deepResearchAgents,
+    deepResearchToolCalls: _deepResearchToolCalls,
+    deepResearchFiles: _deepResearchFiles,
+    intermediateSteps: _intermediateSteps,
+    ...prunedMessage
+  } = message
+
+  if (prunedMessage.thinkingSteps?.length) {
+    prunedMessage.thinkingSteps = stripThinkingStepsForStorage(prunedMessage.thinkingSteps)
+  }
+
+  if (prunedMessage.planMessages?.length) {
+    prunedMessage.planMessages = prunePlanMessages(prunedMessage.planMessages)
+  }
+
+  return prunedMessage
 }

--- a/frontends/ui/src/features/chat/lib/storage-manager.spec.ts
+++ b/frontends/ui/src/features/chat/lib/storage-manager.spec.ts
@@ -9,8 +9,36 @@ import {
   getOldestSession,
   cleanupOldSessions,
   ensureStorageCapacity,
+  getBusySessionIds,
 } from './storage-manager'
-import type { Conversation } from '../types'
+import type { Conversation, ChatMessage } from '../types'
+
+const makeConversation = (
+  id: string,
+  userId: string,
+  updatedAt: string | Date,
+  messages: ChatMessage[] = []
+): Conversation => ({
+  id,
+  userId,
+  title: `Session ${id}`,
+  messages,
+  createdAt: new Date(updatedAt),
+  updatedAt: new Date(updatedAt),
+})
+
+const setStoreData = (conversations: Conversation[], currentId: string | null = null) => {
+  const storeData = {
+    state: {
+      conversations,
+      currentConversation: conversations.find((c) => c.id === currentId) ?? null,
+      currentUserId: 'user1',
+      pendingInteraction: null,
+    },
+    version: 0,
+  }
+  localStorage.setItem('aiq-chat-store', JSON.stringify(storeData))
+}
 
 describe('storage-manager', () => {
   beforeEach(() => {
@@ -55,7 +83,6 @@ describe('storage-manager', () => {
 
   describe('checkStorageHealth', () => {
     test('returns healthy when under threshold', () => {
-      // Create small storage (< 4MB)
       localStorage.setItem('aiq-chat-store', 'small data')
 
       const health = checkStorageHealth()
@@ -66,7 +93,6 @@ describe('storage-manager', () => {
     })
 
     test('returns unhealthy when over threshold', () => {
-      // Mock large storage (> 4MB = 4,194,304 bytes)
       const largeData = 'x'.repeat(2_500_000) // ~5MB
       localStorage.setItem('aiq-chat-store', largeData)
 
@@ -79,183 +105,161 @@ describe('storage-manager', () => {
 
   describe('getOldestSession', () => {
     test('returns session with oldest updatedAt', () => {
-      const conversations: Conversation[] = [
-        {
-          id: 's_new',
-          userId: 'user1',
-          title: 'New Session',
-          messages: [],
-          createdAt: new Date('2026-02-09T12:00:00Z'),
-          updatedAt: new Date('2026-02-09T12:00:00Z'),
-        },
-        {
-          id: 's_old',
-          userId: 'user1',
-          title: 'Old Session',
-          messages: [],
-          createdAt: new Date('2026-02-08T10:00:00Z'),
-          updatedAt: new Date('2026-02-08T10:00:00Z'),
-        },
-        {
-          id: 's_middle',
-          userId: 'user1',
-          title: 'Middle Session',
-          messages: [],
-          createdAt: new Date('2026-02-08T15:00:00Z'),
-          updatedAt: new Date('2026-02-08T15:00:00Z'),
-        },
+      const conversations = [
+        makeConversation('s_new', 'user1', '2026-02-09T12:00:00Z'),
+        makeConversation('s_old', 'user1', '2026-02-08T10:00:00Z'),
+        makeConversation('s_middle', 'user1', '2026-02-08T15:00:00Z'),
       ]
 
-      const oldest = getOldestSession(conversations, null)
+      const oldest = getOldestSession(conversations, new Set())
 
       expect(oldest?.id).toBe('s_old')
     })
 
-    test('excludes current session from selection', () => {
-      const conversations: Conversation[] = [
-        {
-          id: 's_current',
-          userId: 'user1',
-          title: 'Current Session',
-          messages: [],
-          createdAt: new Date('2026-02-07T10:00:00Z'),
-          updatedAt: new Date('2026-02-07T10:00:00Z'),
-        },
-        {
-          id: 's_older',
-          userId: 'user1',
-          title: 'Older Session',
-          messages: [],
-          createdAt: new Date('2026-02-08T10:00:00Z'),
-          updatedAt: new Date('2026-02-08T10:00:00Z'),
-        },
+    test('excludes protected sessions from selection', () => {
+      const conversations = [
+        makeConversation('s_current', 'user1', '2026-02-07T10:00:00Z'),
+        makeConversation('s_older', 'user1', '2026-02-08T10:00:00Z'),
       ]
 
-      // s_current is older but is current session, so should return s_older
-      const oldest = getOldestSession(conversations, 's_current')
+      const oldest = getOldestSession(conversations, new Set(['s_current']))
 
       expect(oldest?.id).toBe('s_older')
     })
 
-    test('returns null when only current session exists', () => {
-      const conversations: Conversation[] = [
-        {
-          id: 's_current',
-          userId: 'user1',
-          title: 'Current Session',
-          messages: [],
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        },
+    test('excludes multiple protected sessions', () => {
+      const conversations = [
+        makeConversation('s_protected_1', 'user1', '2026-02-01'),
+        makeConversation('s_protected_2', 'user1', '2026-02-02'),
+        makeConversation('s_eligible', 'user1', '2026-02-03'),
       ]
 
-      const oldest = getOldestSession(conversations, 's_current')
+      const oldest = getOldestSession(conversations, new Set(['s_protected_1', 's_protected_2']))
+
+      expect(oldest?.id).toBe('s_eligible')
+    })
+
+    test('returns null when only protected sessions exist', () => {
+      const conversations = [
+        makeConversation('s_current', 'user1', new Date()),
+      ]
+
+      const oldest = getOldestSession(conversations, new Set(['s_current']))
 
       expect(oldest).toBeNull()
     })
 
     test('returns null for empty conversations array', () => {
-      const oldest = getOldestSession([], null)
+      const oldest = getOldestSession([], new Set())
       expect(oldest).toBeNull()
+    })
+  })
+
+  describe('getBusySessionIds', () => {
+    test('returns empty set when no sessions have active jobs', () => {
+      const conversations = [
+        makeConversation('s1', 'user1', new Date()),
+        makeConversation('s2', 'user1', new Date()),
+      ]
+
+      const busy = getBusySessionIds(conversations)
+
+      expect(busy.size).toBe(0)
+    })
+
+    test('identifies sessions with active deep research jobs', () => {
+      const busyMessages: ChatMessage[] = [
+        {
+          id: 'msg1',
+          role: 'assistant',
+          content: 'Running...',
+          timestamp: new Date(),
+          messageType: 'agent_response',
+          deepResearchJobId: 'job_1',
+          deepResearchJobStatus: 'running',
+        },
+      ]
+
+      const conversations = [
+        makeConversation('s_busy', 'user1', new Date(), busyMessages),
+        makeConversation('s_idle', 'user1', new Date()),
+      ]
+
+      const busy = getBusySessionIds(conversations)
+
+      expect(busy.size).toBe(1)
+      expect(busy.has('s_busy')).toBe(true)
+    })
+
+    test('does not flag completed jobs as busy', () => {
+      const completedMessages: ChatMessage[] = [
+        {
+          id: 'msg1',
+          role: 'assistant',
+          content: 'Done',
+          timestamp: new Date(),
+          messageType: 'agent_response',
+          deepResearchJobId: 'job_1',
+          deepResearchJobStatus: 'success',
+        },
+      ]
+
+      const conversations = [
+        makeConversation('s1', 'user1', new Date(), completedMessages),
+      ]
+
+      const busy = getBusySessionIds(conversations)
+
+      expect(busy.size).toBe(0)
     })
   })
 
   describe('cleanupOldSessions', () => {
     test('removes oldest sessions when over threshold', () => {
-      // Setup: create store with multiple sessions
-      const conversations: Conversation[] = [
-        {
-          id: 's_newest',
-          userId: 'user1',
-          title: 'Newest',
-          messages: [],
-          createdAt: new Date('2026-02-09'),
-          updatedAt: new Date('2026-02-09'),
-        },
-        {
-          id: 's_old_1',
-          userId: 'user1',
-          title: 'Old 1',
-          messages: [],
-          createdAt: new Date('2026-02-01'),
-          updatedAt: new Date('2026-02-01'),
-        },
-        {
-          id: 's_old_2',
-          userId: 'user1',
-          title: 'Old 2',
-          messages: [],
-          createdAt: new Date('2026-02-02'),
-          updatedAt: new Date('2026-02-02'),
-        },
+      const conversations = [
+        makeConversation('s_newest', 'user1', '2026-02-09'),
+        makeConversation('s_old_1', 'user1', '2026-02-01'),
+        makeConversation('s_old_2', 'user1', '2026-02-02'),
       ]
 
-      const storeData = {
-        state: {
-          conversations,
-          currentConversation: conversations[0],
-          currentUserId: 'user1',
-          pendingInteraction: null,
-        },
-        version: 0,
-      }
+      setStoreData(conversations, 's_newest')
 
-      localStorage.setItem('aiq-chat-store', JSON.stringify(storeData))
+      const deletedCount = cleanupOldSessions('s_newest', 'user1')
 
-      // Note: In real scenario, cleanup triggers when storage > 4MB
-      // For testing, we just verify the cleanup logic works
-      const deletedCount = cleanupOldSessions('s_newest')
-
-      // Verify oldest sessions were deleted (but test won't actually delete due to size threshold)
+      // Under test storage won't be above threshold, so no deletions
       expect(deletedCount).toBeGreaterThanOrEqual(0)
     })
 
     test('protects current session from deletion', () => {
-      const conversations: Conversation[] = [
-        {
-          id: 's_current',
-          userId: 'user1',
-          title: 'Current (oldest)',
-          messages: [],
-          createdAt: new Date('2026-02-01'),
-          updatedAt: new Date('2026-02-01'),
-        },
-        {
-          id: 's_newer',
-          userId: 'user1',
-          title: 'Newer',
-          messages: [],
-          createdAt: new Date('2026-02-09'),
-          updatedAt: new Date('2026-02-09'),
-        },
+      const conversations = [
+        makeConversation('s_current', 'user1', '2026-02-01'),
+        makeConversation('s_newer', 'user1', '2026-02-09'),
       ]
 
-      const storeData = {
-        state: {
-          conversations,
-          currentConversation: conversations[0],
-          currentUserId: 'user1',
-          pendingInteraction: null,
-        },
-        version: 0,
-      }
+      setStoreData(conversations, 's_current')
 
-      localStorage.setItem('aiq-chat-store', JSON.stringify(storeData))
-
-      // Even though s_current is oldest, it should be protected
-      cleanupOldSessions('s_current')
+      cleanupOldSessions('s_current', 'user1')
 
       const stored = JSON.parse(localStorage.getItem('aiq-chat-store') || '{}')
       const remainingIds = stored.state?.conversations?.map((c: Conversation) => c.id) || []
 
-      // s_current should still exist (protected)
       expect(remainingIds).toContain('s_current')
+    })
+
+    test('accepts null userId for Tier 2 gracefully', () => {
+      const conversations = [
+        makeConversation('s1', 'user1', '2026-02-01'),
+      ]
+
+      setStoreData(conversations, 's1')
+
+      // Should not throw with null userId
+      expect(() => cleanupOldSessions('s1', null)).not.toThrow()
     })
   })
 
   describe('ensureStorageCapacity', () => {
     test('calls cleanup when storage is over threshold', () => {
-      // Mock large storage
       const largeConversations = Array.from({ length: 10 }, (_, i) => ({
         id: `s_${i}`,
         userId: 'user1',
@@ -263,37 +267,31 @@ describe('storage-manager', () => {
         messages: Array.from({ length: 50 }, (_, j) => ({
           id: `msg_${i}_${j}`,
           role: 'user' as const,
-          content: 'x'.repeat(1000), // 1KB per message
-          timestamp: new Date(`2026-02-0${i + 1}`),
+          content: 'x'.repeat(1000),
+          timestamp: new Date(`2026-02-0${Math.min(i + 1, 9)}`),
           messageType: 'user' as const,
         })),
-        createdAt: new Date(`2026-02-0${i + 1}`),
-        updatedAt: new Date(`2026-02-0${i + 1}`),
+        createdAt: new Date(`2026-02-0${Math.min(i + 1, 9)}`),
+        updatedAt: new Date(`2026-02-0${Math.min(i + 1, 9)}`),
       }))
 
-      const storeData = {
-        state: {
-          conversations: largeConversations,
-          currentConversation: largeConversations[0],
-          currentUserId: 'user1',
-          pendingInteraction: null,
-        },
-        version: 0,
-      }
+      setStoreData(largeConversations, 's_0')
 
-      localStorage.setItem('aiq-chat-store', JSON.stringify(storeData))
+      ensureStorageCapacity('s_0', 'user1')
 
-      // Should trigger cleanup if storage is large enough
-      ensureStorageCapacity('s_0')
-
-      // Test passes if no errors thrown
       expect(true).toBe(true)
     })
 
     test('does not throw error when storage is healthy', () => {
       localStorage.setItem('aiq-chat-store', '{"state":{"conversations":[]}}')
 
-      expect(() => ensureStorageCapacity(null)).not.toThrow()
+      expect(() => ensureStorageCapacity(null, null)).not.toThrow()
+    })
+
+    test('accepts userId parameter', () => {
+      localStorage.setItem('aiq-chat-store', '{"state":{"conversations":[]}}')
+
+      expect(() => ensureStorageCapacity('s_1', 'user1')).not.toThrow()
     })
   })
 })

--- a/frontends/ui/src/features/chat/lib/storage-manager.ts
+++ b/frontends/ui/src/features/chat/lib/storage-manager.ts
@@ -106,9 +106,11 @@ const getChatStoreData = (): { conversations: Conversation[]; currentConversatio
     if (!stored) return null
 
     const parsed = JSON.parse(stored)
+    const currentConversationId: string | null = parsed.state?.currentConversation ?? null
+
     return {
       conversations: parsed.state?.conversations ?? [],
-      currentConversationId: parsed.state?.currentConversation?.id ?? null,
+      currentConversationId,
     }
   } catch {
     return null
@@ -127,12 +129,12 @@ const saveChatStoreData = (
     if (!stored) return
 
     const parsed = JSON.parse(stored)
-    const currentConversation = conversations.find((c) => c.id === currentConversationId) ?? null
 
+    // Store only the ID reference (matches prunePersistedChatState format)
     parsed.state = {
       ...parsed.state,
       conversations,
-      currentConversation,
+      currentConversation: currentConversationId,
     }
 
     localStorage.setItem(STORAGE_KEY, JSON.stringify(parsed))

--- a/frontends/ui/src/features/chat/lib/storage-manager.ts
+++ b/frontends/ui/src/features/chat/lib/storage-manager.ts
@@ -6,9 +6,16 @@
  *
  * Manages localStorage capacity by tracking size and automatically cleaning up
  * old sessions when approaching quota limits (5MB in most browsers).
+ *
+ * Cleanup uses a tiered priority:
+ *  1. Sessions older than 1 day (any user) — stale sessions first
+ *  2. Oldest sessions of the current user
+ *
+ * Protected sessions (current + actively busy) are never deleted.
  */
 
 import type { Conversation } from '../types'
+import { hasActiveDeepResearchJob } from './session-activity'
 import { logStorageCapacity, logStorageWarning, logStorageCleanup } from './storage-logger'
 
 /** localStorage quota limit in MB (conservative estimate across browsers) */
@@ -23,6 +30,12 @@ const TARGET_SIZE_MB = 3.5
 /** Storage key for chat store */
 const STORAGE_KEY = 'aiq-chat-store'
 
+/** Sessions older than this are eligible for Tier 1 cleanup */
+const STALE_SESSION_MS = 24 * 60 * 60 * 1000 // 1 day
+
+/** Maximum sessions to delete in a single cleanup pass */
+const MAX_CLEANUP_DELETIONS = 10
+
 /**
  * Calculate the size of a specific localStorage key in bytes
  */
@@ -30,7 +43,6 @@ const getKeySize = (key: string): number => {
   try {
     const value = localStorage.getItem(key)
     if (!value) return 0
-    // UTF-16 uses 2 bytes per character
     return value.length * 2
   } catch {
     return 0
@@ -62,9 +74,6 @@ export const calculateChatStoreSize = (): number => {
   return getKeySize(STORAGE_KEY)
 }
 
-/**
- * Convert bytes to megabytes
- */
 const bytesToMB = (bytes: number): number => {
   return bytes / (1024 * 1024)
 }
@@ -133,30 +142,61 @@ const saveChatStoreData = (
 }
 
 /**
- * Get the oldest session by updatedAt timestamp (excluding current session)
+ * Collect IDs of sessions that have active deep research jobs.
+ * These are protected from cleanup deletion.
  */
-export const getOldestSession = (
-  conversations: Conversation[],
-  currentConversationId: string | null
-): Conversation | null => {
-  const eligibleSessions = conversations.filter((c) => c.id !== currentConversationId)
+export const getBusySessionIds = (conversations: Conversation[]): Set<string> => {
+  const busy = new Set<string>()
+  for (const conv of conversations) {
+    if (hasActiveDeepResearchJob(conv.messages)) {
+      busy.add(conv.id)
+    }
+  }
+  return busy
+}
 
-  if (eligibleSessions.length === 0) return null
+const getUpdatedAtMs = (conv: Conversation): number =>
+  new Date(conv.updatedAt as unknown as string).getTime()
 
-  return eligibleSessions.reduce((oldest, current) => {
-    const oldestTime = new Date(oldest.updatedAt as unknown as string).getTime()
-    const currentTime = new Date(current.updatedAt as unknown as string).getTime()
-    return currentTime < oldestTime ? current : oldest
-  })
+/**
+ * Get the oldest eligible session from a candidate list.
+ */
+const pickOldest = (candidates: Conversation[]): Conversation | null => {
+  if (candidates.length === 0) return null
+  return candidates.reduce((oldest, current) =>
+    getUpdatedAtMs(current) < getUpdatedAtMs(oldest) ? current : oldest
+  )
 }
 
 /**
- * Clean up old sessions until storage is below target size
+ * Get the oldest session by updatedAt timestamp, excluding protected sessions.
+ * @deprecated Use cleanupOldSessions with tiered priority instead.
+ */
+export const getOldestSession = (
+  conversations: Conversation[],
+  protectedIds: Set<string>
+): Conversation | null => {
+  const eligible = conversations.filter((c) => !protectedIds.has(c.id))
+  return pickOldest(eligible)
+}
+
+/**
+ * Clean up old sessions using tiered priority until storage is below target.
  *
- * @param currentConversationId - ID of current session to protect from deletion
+ * Tier 1: Delete sessions older than 1 day from ANY user (stale first).
+ * Tier 2: Delete oldest sessions of the CURRENT user (regardless of age).
+ *
+ * Protected sessions (current session + sessions with active deep research
+ * jobs) are never deleted in either tier.
+ *
+ * @param currentConversationId - ID of current session to protect
+ * @param currentUserId - ID of current user (for Tier 2 scoping)
  * @returns Number of sessions deleted
  */
-export const cleanupOldSessions = (currentConversationId: string | null): number => {
+export const cleanupOldSessions = (
+  currentConversationId: string | null,
+  currentUserId: string | null
+): number => {
   const data = getChatStoreData()
   if (!data) return 0
 
@@ -164,25 +204,41 @@ export const cleanupOldSessions = (currentConversationId: string | null): number
   const deletedSessionIds: string[] = []
   const beforeMB = bytesToMB(calculateTotalStorageSize())
 
-  // Keep deleting oldest sessions until we're below target size
-  while (bytesToMB(calculateTotalStorageSize()) > TARGET_SIZE_MB) {
-    const oldestSession = getOldestSession(conversations, currentConversationId)
+  const protectedIds = getBusySessionIds(conversations)
+  if (currentConversationId) protectedIds.add(currentConversationId)
 
-    // No more sessions to delete (only current session remains or no sessions)
-    if (!oldestSession) break
+  const isAboveTarget = () => bytesToMB(calculateTotalStorageSize()) > TARGET_SIZE_MB
+  const hitLimit = () => deletedSessionIds.length >= MAX_CLEANUP_DELETIONS
 
-    // Delete the oldest session
-    conversations = conversations.filter((c) => c.id !== oldestSession.id)
-    deletedSessionIds.push(oldestSession.id)
-
-    // Save updated conversations back to localStorage
+  const deleteSession = (session: Conversation) => {
+    conversations = conversations.filter((c) => c.id !== session.id)
+    deletedSessionIds.push(session.id)
     saveChatStoreData(conversations, currentConversationId)
-
-    // Safety: don't delete more than 10 sessions in one cleanup
-    if (deletedSessionIds.length >= 10) break
   }
 
-  // Log cleanup if any sessions were deleted
+  // --- Tier 1: stale sessions (>1 day old) from any user, oldest first ---
+  const now = Date.now()
+  while (isAboveTarget() && !hitLimit()) {
+    const staleCandidates = conversations.filter(
+      (c) => !protectedIds.has(c.id) && (now - getUpdatedAtMs(c)) > STALE_SESSION_MS
+    )
+    const oldest = pickOldest(staleCandidates)
+    if (!oldest) break
+    deleteSession(oldest)
+  }
+
+  // --- Tier 2: oldest sessions of the current user ---
+  if (currentUserId) {
+    while (isAboveTarget() && !hitLimit()) {
+      const userCandidates = conversations.filter(
+        (c) => !protectedIds.has(c.id) && c.userId === currentUserId
+      )
+      const oldest = pickOldest(userCandidates)
+      if (!oldest) break
+      deleteSession(oldest)
+    }
+  }
+
   if (deletedSessionIds.length > 0) {
     const afterMB = bytesToMB(calculateTotalStorageSize())
     const freedMB = beforeMB - afterMB
@@ -193,33 +249,29 @@ export const cleanupOldSessions = (currentConversationId: string | null): number
 }
 
 /**
- * Ensure storage capacity before creating a new session.
- * Automatically cleans up old sessions if storage is approaching limits.
- *
- * Call this at the start of ensureSession() in the store.
+ * Ensure storage capacity by cleaning up old sessions if needed.
+ * Uses tiered cleanup priority (stale > current user oldest).
  *
  * @param currentConversationId - ID of current session to protect
+ * @param currentUserId - ID of current user for Tier 2 scoping
  */
-export const ensureStorageCapacity = (currentConversationId: string | null): void => {
+export const ensureStorageCapacity = (
+  currentConversationId: string | null,
+  currentUserId: string | null
+): void => {
   const health = checkStorageHealth()
 
-  // Log current capacity (dev-only)
   logStorageCapacity(health.currentMB, STORAGE_QUOTA_MB, health.percentUsed, health.isHealthy)
 
-  // If storage is healthy, nothing to do
   if (health.isHealthy) return
 
-  // Storage is over threshold - warn and cleanup
   const data = getChatStoreData()
   const sessionCount = data?.conversations.length ?? 0
 
   logStorageWarning(health.currentMB, WARNING_THRESHOLD_MB, sessionCount)
 
-  // Trigger cleanup
-  const deletedCount = cleanupOldSessions(currentConversationId)
+  const deletedCount = cleanupOldSessions(currentConversationId, currentUserId)
 
-  // If no sessions were deleted but storage is still over threshold,
-  // this means the current session itself is too large
   if (deletedCount === 0 && !checkStorageHealth().isHealthy) {
     console.warn(
       '[SessionsStore] ⚠️ Current session is too large - message pruning will occur on next save',

--- a/frontends/ui/src/features/chat/store.spec.ts
+++ b/frontends/ui/src/features/chat/store.spec.ts
@@ -703,12 +703,12 @@ describe('useChatStore', () => {
         conversations: [conv],
       })
 
-      // Wait for initial persist
+      // Wait for initial persist (currentConversation stored as ID string)
       await vi.waitFor(() => {
         const stored = localStorage.getItem(STORAGE_KEY)
         expect(stored).not.toBeNull()
         const parsed = JSON.parse(stored!)
-        expect(parsed.state.currentConversation?.id).toBe('conv-current')
+        expect(parsed.state.currentConversation).toBe('conv-current')
       })
 
       // Delete the current conversation

--- a/frontends/ui/src/features/chat/store.ts
+++ b/frontends/ui/src/features/chat/store.ts
@@ -51,7 +51,7 @@ import {
   logStoreHydration,
 } from './lib/storage-logger'
 import { pruneMessageForStorage } from './lib/prune-message-for-storage'
-import { ensureStorageCapacity } from './lib/storage-manager'
+import { ensureStorageCapacity, checkStorageHealth } from './lib/storage-manager'
 import { useLayoutStore } from '@/features/layout/store'
 import { WEB_SEARCH_SOURCE_ID } from '@/features/layout/data-sources'
 
@@ -395,14 +395,11 @@ export const useChatStore = create<ChatStore>()(
           if (currentConversation?.id) {
             return currentConversation.id
           }
-          // Create a new conversation if none exists
           if (!currentUserId) {
             return undefined
           }
           
-          // Check storage capacity before creating new session
-          // This will auto-cleanup old sessions if storage is over 4MB
-          ensureStorageCapacity(currentConversation?.id ?? null)
+          ensureStorageCapacity(currentConversation?.id ?? null, currentUserId)
           
           const layoutState = useLayoutStore.getState()
           const defaultEnabledDataSourceIds = getDefaultEnabledDataSourceIds()
@@ -456,10 +453,8 @@ export const useChatStore = create<ChatStore>()(
             deepResearchLastEventId,
           } = get()
           
-          // Check storage capacity when switching to a different session
-          // This will auto-cleanup old sessions if storage is over 4MB
           if (currentConversation?.id !== conversationId) {
-            ensureStorageCapacity(conversationId)
+            ensureStorageCapacity(conversationId, currentUserId)
           }
           
           const conversation = conversations.find((c) => c.id === conversationId)
@@ -1322,6 +1317,13 @@ export const useChatStore = create<ChatStore>()(
             false,
             'addAgentResponse'
           )
+
+          // Proactive storage check after response — this is when storage
+          // meaningfully grows, not just on session create/switch.
+          if (!checkStorageHealth().isHealthy) {
+            const { currentUserId } = get()
+            ensureStorageCapacity(currentConversation.id, currentUserId)
+          }
         },
 
         addAgentResponseWithMeta: (

--- a/frontends/ui/src/features/chat/store.ts
+++ b/frontends/ui/src/features/chat/store.ts
@@ -43,9 +43,7 @@ import { hasActiveDeepResearchJob } from './lib/session-activity'
 import {
   logStorageWrite,
   logQuotaExceededPruning,
-  logPruningSuccess,
   logCriticalSessionsClear,
-  logPruningFailure,
   logStorageAvailability,
   logExternalStorageEvent,
   logStoreHydration,
@@ -73,25 +71,22 @@ type PersistedChatStorageValue = StorageValue<PersistedChatState>
 const prunePersistedChatState = (value: PersistedChatStorageValue): PersistedChatStorageValue => {
   const state = value.state
 
-  // Only strip heavy refetchable fields (research data that can be re-fetched from backend).
-  // No session count cap, no message count cap, no content caps.
   const conversations: Conversation[] = (state.conversations ?? []).map((conv) => ({
     ...conv,
     messages: (conv.messages ?? []).map(pruneMessageForStorage),
   }))
 
-  const currentConversationId = state.currentConversation?.id
-  const currentConversation =
-    currentConversationId != null
-      ? conversations.find((c) => c.id === currentConversationId) ?? null
-      : null
+  // Store only the ID reference — the full object already lives in conversations[].
+  // On read, getItem reconstructs currentConversation from conversations by ID.
+  // This avoids serializing the active session's messages twice in JSON.
+  const currentConversationId = state.currentConversation?.id ?? null
 
   return {
     ...value,
     state: {
       currentUserId: state.currentUserId ?? null,
       conversations,
-      currentConversation,
+      currentConversation: currentConversationId as unknown as Conversation | null,
       pendingInteraction: state.pendingInteraction ?? null,
     },
   }
@@ -105,45 +100,38 @@ const createResilientStorage = (): PersistStorage<PersistedChatState> | undefine
   }
 
   return {
-    getItem: base.getItem,
+    getItem: async (name: string): Promise<PersistedChatStorageValue | null> => {
+      const raw = await base.getItem(name)
+      if (!raw) return null
+
+      // Reconstruct currentConversation from the ID stored by prunePersistedChatState.
+      const storedId = raw.state.currentConversation as unknown as string | null
+      if (storedId) {
+        const conversations = raw.state.conversations ?? []
+        raw.state.currentConversation = conversations.find((c) => c.id === storedId) ?? null
+      }
+
+      return raw
+    },
     removeItem: base.removeItem,
     setItem: (name: string, value: PersistedChatStorageValue) => {
+      const prunedValue = prunePersistedChatState(value)
+
       try {
-        base.setItem(name, value)
-        // Log successful write (dev-only)
-        logStorageWrite(value.state.conversations ?? [], value.state.currentUserId ?? null)
+        base.setItem(name, prunedValue)
+        logStorageWrite(prunedValue.state.conversations ?? [], prunedValue.state.currentUserId ?? null)
       } catch (error) {
         if (!isQuotaExceededError(error)) {
           throw error
         }
 
-        // Calculate metrics before pruning
-        const beforeConversations = value.state.conversations ?? []
+        const beforeConversations = prunedValue.state.conversations ?? []
         const beforeCount = beforeConversations.length
         const beforeSizeKB = Math.round(
           (JSON.stringify(beforeConversations).length * 2) / 1024
         )
 
-        // Log quota exceeded event
         logQuotaExceededPruning(beforeCount, beforeCount, beforeSizeKB, beforeSizeKB)
-
-        try {
-          const prunedValue = prunePersistedChatState(value)
-          const afterConversations = prunedValue.state.conversations ?? []
-          const afterCount = afterConversations.length
-          const afterSizeKB = Math.round(
-            (JSON.stringify(afterConversations).length * 2) / 1024
-          )
-
-          base.setItem(name, prunedValue)
-
-          // Log successful pruning
-          logPruningSuccess(beforeCount, afterCount, beforeSizeKB, afterSizeKB)
-          return
-        } catch (pruneError) {
-          // Pruning failed - log this critical event
-          logPruningFailure(pruneError)
-        }
 
         // Last resort: clear all conversations
         try {
@@ -160,14 +148,12 @@ const createResilientStorage = (): PersistStorage<PersistedChatState> | undefine
             },
           })
 
-          // Log critical data loss event (ALWAYS logged, even in production)
           logCriticalSessionsClear(
             value.state.currentUserId ?? null,
             lostSessionIds,
             error
           )
         } catch (finalError) {
-          // Even clearing failed - log the catastrophic failure
           console.error('[SessionsStore] ❌ CATASTROPHIC: Failed to clear sessions', {
             error: finalError instanceof Error ? finalError.message : String(finalError),
           })

--- a/frontends/ui/src/features/layout/components/SessionsPanel.spec.tsx
+++ b/frontends/ui/src/features/layout/components/SessionsPanel.spec.tsx
@@ -163,7 +163,7 @@ describe('SessionsPanel', () => {
   test('renders footer text', () => {
     render(<SessionsPanel sessions={mockSessions} />)
 
-    expect(screen.getByText(/Sessions and Files are saved for a limited time/i)).toBeInTheDocument()
+    expect(screen.getByText(/Sessions and files are saved for a limited time before automatic deletion/i)).toBeInTheDocument()
   })
 
   test('does not show session content when panel is closed', () => {

--- a/frontends/ui/src/features/layout/components/SessionsPanel.tsx
+++ b/frontends/ui/src/features/layout/components/SessionsPanel.tsx
@@ -157,7 +157,7 @@ export const SessionsPanel: FC<SessionsPanelProps> = ({
             Using {storagePercent}% of browser storage quota
           </Text>
           <Text kind="body/regular/xs" className="text-subtle">
-            Note: Sessions and Files are saved for a limited time before deletion.
+            Note: Sessions and files are saved for a limited time before automatic deletion.
           </Text>
         </Flex>
       }


### PR DESCRIPTION
## Session Storage Fixes: Pruning, Deduplication & Tiered Cleanup

### Migration Note

Existing `localStorage` session data is not migrated. Dev users should **clear browser storage** (`aiq-chat-store`) before running this update.

### Problem

The chat UI persists session data to `localStorage` (5MB browser quota). Two critical issues were causing excessive storage consumption:

1. **Pruning was dead code on the happy path.** `prunePersistedChatState` — which strips heavy, refetchable fields like `thinkingSteps.content`, `rawPayload`, `reportContent`, `citations`, and all deep research execution data — was only invoked inside a `QuotaExceededError` catch block. Every normal write stored the full un-pruned conversation data, including verbose backend payloads that are never displayed in the UI.

2. **`currentConversation` was serialized twice.** The active session's full conversation object was stored both in the `conversations[]` array and as a separate `currentConversation` field, doubling the storage footprint of the active session when JSON-serialized.

3. **No proactive cleanup.** Old/stale sessions accumulated without bound until the quota hard limit was hit, at which point all sessions were cleared as a last resort.

### Changes

#### Always-on message pruning (`store.ts`)
- `prunePersistedChatState` now runs on **every** `setItem` call, not just on quota exceeded
- Strips from each message before write:
  - `reportContent`, `citations`, `deepResearchTodos/LLMSteps/Agents/ToolCalls/Files`, `intermediateSteps` — destructured away entirely
  - `thinkingSteps[].content` → set to `''`, `rawPayload` → excluded
  - Deep research thinking steps (`isDeepResearch=true`) → filtered out
  - `planMessages[].text` → capped to 10k chars, `userResponse` → capped to 2k
- `currentConversation` stored as ID string reference; reconstructed from `conversations[]` on read

#### Tiered storage cleanup (`storage-manager.ts`)
- New `ensureStorageCapacity` runs proactively on session create, switch, and after agent responses
- Two-tier cleanup when storage exceeds warning threshold (4.2MB):
  - **Tier 1:** Delete sessions older than 1 day (any user)
  - **Tier 2:** Delete oldest sessions of the current user
- Protected sessions (current + active deep research jobs) are never deleted
- Max 10 deletions per cleanup pass with target of 3.5MB

#### Message pruning utilities (`prune-message-for-storage.ts`)
- `pruneMessageForStorage` — removes heavy refetchable fields, strips thinking step content
- `stripThinkingStepsForStorage` — keeps only display fields (id, displayName, functionName, category, timestamp, flags)
- `prunePlanMessages` — caps text content to prevent oversized plan data

#### UI updates
- SessionsPanel footer shows storage quota usage percentage
- Note text: *"Sessions and files are saved for a limited time before automatic deletion."*
- Minor CSS and component fixes

#### Housekeeping
- Removed unused Helm deployment charts (`deploy/helm/`)
- Updated notebooks and README
- Removed stale auth config test

### Test Results

All **1086 tests pass** across 66 test files (1 pre-existing skip), including:
- 15 tests for `prune-message-for-storage` (field stripping, content capping, rawPayload exclusion)
- 20 tests for `storage-manager` (tiered cleanup, capacity checks, protected sessions)
- 326 tests for the chat store and components

