### PR TITLE
Fix Knowledge Layer File Upload Bugs

### DIFF
--- a/frontends/aiq_api/src/aiq_api/websocket_reconnect.py
+++ b/frontends/aiq_api/src/aiq_api/websocket_reconnect.py
@@ -254,10 +254,16 @@ class ReconnectableWebSocketMessageHandler(WebSocketMessageHandler):
             if message is not None:
                 sent = await _registry.send(self._conversation_id, message)
                 if not sent:
-                    try:
-                        await self._socket.send_json(message.model_dump())
-                    except Exception as exc:  # pragma: no cover - socket may be closed
-                        logger.warning("Failed to send websocket message: %s", exc)
+                    if not self._conversation_id:
+                        try:
+                            await self._socket.send_json(message.model_dump())
+                        except Exception as exc:  # pragma: no cover - socket may be closed
+                            logger.warning("Failed to send websocket message: %s", exc)
+                    else:
+                        logger.debug(
+                            "Dropping message for disconnected conversation %s",
+                            self._conversation_id,
+                        )
 
     async def human_interaction_callback(self, prompt: InteractionPrompt) -> HumanResponse:
         """

--- a/frontends/ui/src/features/documents/hooks/use-file-upload.spec.ts
+++ b/frontends/ui/src/features/documents/hooks/use-file-upload.spec.ts
@@ -23,6 +23,7 @@ const { mockClient, mockDocumentsStoreState, mockOrchestratorFns } = vi.hoisted(
     addTrackedFile: vi.fn(),
     updateTrackedFile: vi.fn(),
     removeTrackedFile: vi.fn(),
+    unmarkRecentlyDeleted: vi.fn(),
     setUploading: vi.fn(),
     setError: vi.fn(),
     clearError: vi.fn(),

--- a/frontends/ui/src/features/documents/hooks/use-file-upload.spec.ts
+++ b/frontends/ui/src/features/documents/hooks/use-file-upload.spec.ts
@@ -31,6 +31,7 @@ const { mockClient, mockDocumentsStoreState, mockOrchestratorFns } = vi.hoisted(
     setAuthToken: vi.fn(),
     setCallbacks: vi.fn(),
     handleSessionChange: vi.fn(),
+    loadFilesForSession: vi.fn(),
     startPolling: vi.fn(),
     stopPolling: vi.fn(),
   },
@@ -73,6 +74,11 @@ vi.mock('@/features/chat', () => {
 
 vi.mock('../orchestrator', () => ({
   UploadOrchestrator: mockOrchestratorFns,
+}))
+
+vi.mock('@/features/layout/store', () => ({
+  useLayoutStore: (selector: (state: { knowledgeLayerAvailable: boolean }) => unknown) =>
+    selector({ knowledgeLayerAvailable: true }),
 }))
 
 const mockMarkSessionHasCollection = vi.fn()
@@ -136,13 +142,18 @@ describe('useFileUpload', () => {
       })
     })
 
-    test('handles session change when sessionId changes', async () => {
+    test('calls handleSessionChange on initial mount with sessionId', () => {
+      renderHook(() => useFileUpload({ sessionId: 'session-1' }))
+
+      expect(mockOrchestratorFns.handleSessionChange).toHaveBeenCalledWith('session-1')
+    })
+
+    test('calls handleSessionChange when sessionId changes', () => {
       const { rerender } = renderHook(({ sessionId }) => useFileUpload({ sessionId }), {
         initialProps: { sessionId: 'session-1' },
       })
 
-      // Initial render doesn't call handleSessionChange since previousSessionIdRef starts undefined
-      // and the effect checks for sessionId !== previousSessionId
+      mockOrchestratorFns.handleSessionChange.mockClear()
 
       rerender({ sessionId: 'session-2' })
 

--- a/frontends/ui/src/features/documents/hooks/use-file-upload.ts
+++ b/frontends/ui/src/features/documents/hooks/use-file-upload.ts
@@ -17,6 +17,7 @@ import { createDocumentsClient } from '@/adapters/api'
 import { useDocumentsStore } from '../store'
 import { useAuth } from '@/adapters/auth'
 import { useAppConfig } from '@/shared/context'
+import { useLayoutStore } from '@/features/layout/store'
 import type { TrackedFile } from '../types'
 import { validateFileUpload, type ValidationContext } from '../validation'
 import { UploadOrchestrator } from '../orchestrator'
@@ -97,6 +98,18 @@ export const useFileUpload = (options: UseFileUploadOptions = {}): UseFileUpload
       previousSessionIdRef.current = sessionId
     }
   }, [sessionId])
+
+  // Retry file loading when knowledgeLayerAvailable becomes true.
+  // On browser refresh, the initial loadFilesForSession call may fire before
+  // fetchDataSources completes, causing it to skip because
+  // knowledgeLayerAvailable is still false. This effect ensures we retry
+  // once the knowledge layer is confirmed available.
+  const knowledgeLayerAvailable = useLayoutStore((state) => state.knowledgeLayerAvailable)
+  useEffect(() => {
+    if (knowledgeLayerAvailable && sessionId) {
+      UploadOrchestrator.loadFilesForSession(sessionId)
+    }
+  }, [knowledgeLayerAvailable, sessionId])
 
   // Note: We intentionally don't cleanup the orchestrator on unmount.
   // The orchestrator is a singleton that manages polling across component lifecycles.

--- a/frontends/ui/src/features/documents/hooks/use-file-upload.ts
+++ b/frontends/ui/src/features/documents/hooks/use-file-upload.ts
@@ -175,32 +175,34 @@ export const useFileUpload = (options: UseFileUploadOptions = {}): UseFileUpload
 
       const trackedFileMap: Map<string, TrackedFile> = new Map()
 
+      // Add tracked files to the store immediately so uploading cards appear
+      // in the UI before any network calls (collection creation, upload POST)
+      for (const file of validFiles) {
+        const trackedFile: TrackedFile = {
+          id: uuidv4(),
+          file,
+          fileName: file.name,
+          fileSize: file.size,
+          status: 'uploading',
+          progress: 0,
+          collectionName,
+          uploadedAt: new Date().toISOString(),
+        }
+        addTrackedFile(trackedFile)
+        trackedFileMap.set(file.name, trackedFile)
+      }
+
+      // Show informational banner in chat as soon as upload starts
+      const chatStore = useChatStore.getState()
+      chatStore.addFileUploadStatusCard(
+        'uploaded',
+        validFiles.length,
+        `upload-${Date.now()}`,
+        collectionName
+      )
+
       try {
         await ensureCollectionExists(collectionName)
-
-        for (const file of validFiles) {
-          const trackedFile: TrackedFile = {
-            id: uuidv4(),
-            file,
-            fileName: file.name,
-            fileSize: file.size,
-            status: 'uploading',
-            progress: 0,
-            collectionName,
-            uploadedAt: new Date().toISOString(),
-          }
-          addTrackedFile(trackedFile)
-          trackedFileMap.set(file.name, trackedFile)
-        }
-
-        // Show informational banner in chat as soon as upload starts
-        const chatStore = useChatStore.getState()
-        chatStore.addFileUploadStatusCard(
-          'uploaded',
-          validFiles.length,
-          `upload-${Date.now()}`,
-          collectionName
-        )
 
         const { job_id, file_ids } = await clientRef.current.uploadFiles(collectionName, validFiles)
 

--- a/frontends/ui/src/features/documents/hooks/use-file-upload.ts
+++ b/frontends/ui/src/features/documents/hooks/use-file-upload.ts
@@ -268,8 +268,6 @@ export const useFileUpload = (options: UseFileUploadOptions = {}): UseFileUpload
     setUploading(false)
   }, [setUploading])
 
-  const addFileUploadStatusCard = useChatStore((state) => state.addFileUploadStatusCard)
-
   const deleteFile = useCallback(
     async (fileId: string) => {
       const file = trackedFiles.find((f) => f.id === fileId)

--- a/frontends/ui/src/features/documents/hooks/use-file-upload.ts
+++ b/frontends/ui/src/features/documents/hooks/use-file-upload.ts
@@ -50,7 +50,7 @@ export const useFileUpload = (options: UseFileUploadOptions = {}): UseFileUpload
   const { idToken } = useAuth()
   const { fileUpload: fileUploadConfig } = useAppConfig()
   const clientRef = useRef(createDocumentsClient({ authToken: idToken }))
-  const previousSessionIdRef = useRef<string | undefined>(sessionId)
+  const previousSessionIdRef = useRef<string | undefined>(undefined)
 
   const {
     trackedFiles,

--- a/frontends/ui/src/features/documents/hooks/use-file-upload.ts
+++ b/frontends/ui/src/features/documents/hooks/use-file-upload.ts
@@ -278,20 +278,23 @@ export const useFileUpload = (options: UseFileUploadOptions = {}): UseFileUpload
       }
 
       const collectionName = file.collectionName
+      const deleteId = file.serverFileId || file.fileName
+
+      // Optimistic delete: remove from UI immediately, call API in background.
+      // This prevents the file from reappearing if a concurrent server reload
+      // returns stale data before the backend processes the delete.
+      removeTrackedFile(fileId)
 
       try {
-        const deleteId = file.serverFileId || file.fileName
         await clientRef.current.deleteFiles(collectionName, [deleteId])
-        removeTrackedFile(fileId)
-
-        // File deletion is handled silently - no status message needed
-        // (removed 'deleted' status type from FileUploadStatusType)
       } catch (err) {
+        // Restore the file on failure so the user can retry
+        addTrackedFile(file)
         const message = err instanceof Error ? err.message : 'Delete failed'
         setError(message)
       }
     },
-    [trackedFiles, removeTrackedFile, setError, addFileUploadStatusCard]
+    [trackedFiles, addTrackedFile, removeTrackedFile, setError, addFileUploadStatusCard]
   )
 
   const retryFile = useCallback(

--- a/frontends/ui/src/features/documents/hooks/use-file-upload.ts
+++ b/frontends/ui/src/features/documents/hooks/use-file-upload.ts
@@ -265,7 +265,8 @@ export const useFileUpload = (options: UseFileUploadOptions = {}): UseFileUpload
       const collectionName = file.collectionName
 
       try {
-        await clientRef.current.deleteFiles(collectionName, [file.fileName])
+        const deleteId = file.serverFileId || file.fileName
+        await clientRef.current.deleteFiles(collectionName, [deleteId])
         removeTrackedFile(fileId)
 
         // File deletion is handled silently - no status message needed

--- a/frontends/ui/src/features/documents/hooks/use-file-upload.ts
+++ b/frontends/ui/src/features/documents/hooks/use-file-upload.ts
@@ -62,6 +62,7 @@ export const useFileUpload = (options: UseFileUploadOptions = {}): UseFileUpload
     addTrackedFile,
     updateTrackedFile,
     removeTrackedFile,
+    unmarkRecentlyDeleted,
     setUploading,
     setError,
     clearError,
@@ -288,13 +289,16 @@ export const useFileUpload = (options: UseFileUploadOptions = {}): UseFileUpload
       try {
         await clientRef.current.deleteFiles(collectionName, [deleteId])
       } catch (err) {
-        // Restore the file on failure so the user can retry
+        // Restore the file on failure so the user can retry.
+        // Also undo the recentlyDeletedIds entry so the file isn't
+        // filtered out on the next server sync.
         addTrackedFile(file)
+        unmarkRecentlyDeleted(file)
         const message = err instanceof Error ? err.message : 'Delete failed'
         setError(message)
       }
     },
-    [trackedFiles, addTrackedFile, removeTrackedFile, setError, addFileUploadStatusCard]
+    [trackedFiles, addTrackedFile, removeTrackedFile, unmarkRecentlyDeleted, setError]
   )
 
   const retryFile = useCallback(

--- a/frontends/ui/src/features/documents/orchestrator.spec.ts
+++ b/frontends/ui/src/features/documents/orchestrator.spec.ts
@@ -29,6 +29,7 @@ const mockDocumentsStore = {
   setError: vi.fn(),
   clearError: vi.fn(),
   updateFilesFromJobStatus: vi.fn(),
+  setLoadingFiles: vi.fn(),
   trackedFiles: [],
   isUploading: false,
   isPolling: false,
@@ -133,7 +134,7 @@ describe('UploadOrchestrator', () => {
       await UploadOrchestrator.handleSessionChange('session-2')
 
       expect(mockDocumentsStore.clearFilesForCollection).toHaveBeenCalledWith('session-1')
-      expect(mockDocumentsStore.clearFilesForCollection).toHaveBeenCalledWith('session-2')
+      expect(mockDocumentsStore.clearFilesForCollection).not.toHaveBeenCalledWith('session-2')
     })
 
     test('loads files for new session when session has known collection', async () => {

--- a/frontends/ui/src/features/documents/orchestrator.ts
+++ b/frontends/ui/src/features/documents/orchestrator.ts
@@ -93,9 +93,10 @@ class UploadOrchestratorImpl {
     this.currentSessionId = newSessionId ?? null
     this.lastLoadedSessionId = null
 
-    // Clear files for new session to ensure fresh state
-    if (newSessionId) {
-      this.getStore().clearFilesForCollection(newSessionId)
+    // Signal loading immediately so the UI shows a spinner before any async work.
+    // loadFilesForSession (or early returns below) will clear this.
+    if (newSessionId && sessionHasKnownCollection(newSessionId)) {
+      this.getStore().setLoadingFiles(true)
     }
 
     // Check for persisted job to resume
@@ -123,24 +124,29 @@ class UploadOrchestratorImpl {
    * This prevents unnecessary 404 errors for sessions that never had files uploaded.
    */
   async loadFilesForSession(sessionId: string): Promise<void> {
+    const store = this.getStore()
+
     // Skip if Knowledge Layer is not available (prevents 404 errors when backend
     // doesn't have knowledge_retrieval configured)
     const { knowledgeLayerAvailable } = useLayoutStore.getState()
     if (!knowledgeLayerAvailable) {
+      store.setLoadingFiles(false)
       return
     }
 
     if (sessionId === this.lastLoadedSessionId) {
+      store.setLoadingFiles(false)
       return
     }
 
-    const store = this.getStore()
     if (store.isUploading || store.isPolling) {
+      store.setLoadingFiles(false)
       return
     }
 
     // Check if session changed before making network request
     if (sessionId !== this.currentSessionId) {
+      store.setLoadingFiles(false)
       return
     }
 
@@ -151,11 +157,13 @@ class UploadOrchestratorImpl {
     const hasPersistedJob = getPersistedJobForCollection(sessionId) !== null
     if (!hasKnownCollection && !hasPersistedJob) {
       this.lastLoadedSessionId = sessionId
+      store.setLoadingFiles(false)
       return
     }
 
     const client = this.getClient()
 
+    store.setLoadingFiles(true)
     try {
       const collection = await client.getCollection(sessionId)
 
@@ -189,6 +197,8 @@ class UploadOrchestratorImpl {
       // Network/connection errors should still mark session as loaded to prevent retry loops.
       // Don't unmark the collection here - the backend may just be temporarily unavailable.
       this.lastLoadedSessionId = sessionId
+    } finally {
+      store.setLoadingFiles(false)
     }
   }
 

--- a/frontends/ui/src/features/documents/store.ts
+++ b/frontends/ui/src/features/documents/store.ts
@@ -91,6 +91,20 @@ export const useDocumentsStore = create<DocumentsStore>()(
         )
       },
 
+      unmarkRecentlyDeleted: (file) => {
+        set(
+          (state) => {
+            const nextDeleted = new Set(state.recentlyDeletedIds)
+            nextDeleted.delete(file.id)
+            if (file.serverFileId) nextDeleted.delete(file.serverFileId)
+            nextDeleted.delete(file.fileName)
+            return { recentlyDeletedIds: nextDeleted }
+          },
+          false,
+          'unmarkRecentlyDeleted'
+        )
+      },
+
       clearTrackedFiles: () => {
         set({ trackedFiles: [] }, false, 'clearTrackedFiles')
       },

--- a/frontends/ui/src/features/documents/store.ts
+++ b/frontends/ui/src/features/documents/store.ts
@@ -169,7 +169,19 @@ export const useDocumentsStore = create<DocumentsStore>()(
                 .map((f) => [f.serverFileId || f.id, f])
             )
 
-            // Remove any existing files for this collection
+            // Separate in-progress files (uploading/ingesting) that the server
+            // doesn't know about yet. These must survive the replace so the UI
+            // keeps showing upload progress cards.
+            const serverFileIds = new Set(files.map((f) => f.file_id))
+            const inProgressFiles = state.trackedFiles.filter(
+              (f) =>
+                f.collectionName === collectionName &&
+                (f.status === 'uploading' || f.status === 'ingesting') &&
+                !serverFileIds.has(f.serverFileId ?? '') &&
+                !serverFileIds.has(f.id)
+            )
+
+            // Remove existing files for this collection (except in-progress ones kept above)
             const otherFiles = state.trackedFiles.filter((f) => f.collectionName !== collectionName)
 
             // Convert FileInfo to TrackedFile, preserving jobId from existing files
@@ -194,7 +206,7 @@ export const useDocumentsStore = create<DocumentsStore>()(
             })
 
             return {
-              trackedFiles: [...otherFiles, ...serverFiles],
+              trackedFiles: [...otherFiles, ...serverFiles, ...inProgressFiles],
             }
           },
           false,

--- a/frontends/ui/src/features/documents/store.ts
+++ b/frontends/ui/src/features/documents/store.ts
@@ -21,6 +21,9 @@ const initialState: DocumentsState = {
   isCreatingCollection: false,
   isUploading: false,
   isPolling: false,
+  isLoadingFiles: false,
+  loadedSessionId: null,
+  recentlyDeletedIds: new Set<string>(),
   error: null,
   shownBannersForJobs: {},
 }
@@ -70,9 +73,19 @@ export const useDocumentsStore = create<DocumentsStore>()(
 
       removeTrackedFile: (id) => {
         set(
-          (state) => ({
-            trackedFiles: state.trackedFiles.filter((f) => f.id !== id),
-          }),
+          (state) => {
+            const file = state.trackedFiles.find((f) => f.id === id)
+            const nextDeleted = new Set(state.recentlyDeletedIds)
+            if (file) {
+              nextDeleted.add(file.id)
+              if (file.serverFileId) nextDeleted.add(file.serverFileId)
+              nextDeleted.add(file.fileName)
+            }
+            return {
+              trackedFiles: state.trackedFiles.filter((f) => f.id !== id),
+              recentlyDeletedIds: nextDeleted,
+            }
+          },
           false,
           'removeTrackedFile'
         )
@@ -86,6 +99,7 @@ export const useDocumentsStore = create<DocumentsStore>()(
         set(
           (state) => ({
             trackedFiles: state.trackedFiles.filter((f) => f.collectionName !== collectionName),
+            recentlyDeletedIds: new Set<string>(),
           }),
           false,
           'clearFilesForCollection'
@@ -116,6 +130,10 @@ export const useDocumentsStore = create<DocumentsStore>()(
         set({ isPolling: polling }, false, 'setPolling')
       },
 
+      setLoadingFiles: (loading) => {
+        set({ isLoadingFiles: loading }, false, 'setLoadingFiles')
+      },
+
       // --------------------------------------------------------------------------
       // Error Handling
       // --------------------------------------------------------------------------
@@ -136,6 +154,9 @@ export const useDocumentsStore = create<DocumentsStore>()(
         set(
           (state) => {
             const updatedFiles = state.trackedFiles.map((file) => {
+              // Never overwrite client-side transient states with backend data
+              if (file.status === 'deleting') return file
+
               // Find matching file in job details by server ID or filename
               const jobFile = jobStatus.file_details.find(
                 (jf) => jf.file_id === file.serverFileId || jf.file_name === file.fileName
@@ -169,24 +190,35 @@ export const useDocumentsStore = create<DocumentsStore>()(
                 .map((f) => [f.serverFileId || f.id, f])
             )
 
-            // Separate in-progress files (uploading/ingesting) that the server
-            // doesn't know about yet. These must survive the replace so the UI
-            // keeps showing upload progress cards.
+            // Separate client-side transient files that the server doesn't know
+            // about yet. These must survive the replace so the UI keeps showing
+            // upload progress cards and pending deletes.
             const serverFileIds = new Set(files.map((f) => f.file_id))
-            const inProgressFiles = state.trackedFiles.filter(
+            const transientStatuses = new Set(['uploading', 'ingesting', 'deleting'])
+            const preservedFiles = state.trackedFiles.filter(
               (f) =>
                 f.collectionName === collectionName &&
-                (f.status === 'uploading' || f.status === 'ingesting') &&
+                transientStatuses.has(f.status) &&
                 !serverFileIds.has(f.serverFileId ?? '') &&
                 !serverFileIds.has(f.id)
             )
 
-            // Remove existing files for this collection (except in-progress ones kept above)
+            // Remove existing files for this collection (except transient ones kept above)
             const otherFiles = state.trackedFiles.filter((f) => f.collectionName !== collectionName)
+
+            // Build set of file IDs to exclude from server data: transient files
+            // (e.g. actively deleting) and recently deleted files whose stale
+            // entries may still appear in the server response.
+            const excludedIds = new Set([
+              ...preservedFiles.flatMap((f) => [f.serverFileId ?? '', f.id, f.fileName]),
+              ...state.recentlyDeletedIds,
+            ])
 
             // Convert FileInfo to TrackedFile, preserving jobId from existing files
             // Use the collectionName parameter (sessionId) for consistency with sessionFiles filtering
-            const serverFiles: TrackedFile[] = files.map((file) => {
+            const serverFiles: TrackedFile[] = files.filter(
+              (f) => !excludedIds.has(f.file_id) && !excludedIds.has(f.file_name)
+            ).map((file) => {
               const existingFile = existingFilesMap.get(file.file_id)
               return {
                 id: file.file_id, // Use server ID as local ID
@@ -206,7 +238,8 @@ export const useDocumentsStore = create<DocumentsStore>()(
             })
 
             return {
-              trackedFiles: [...otherFiles, ...serverFiles, ...inProgressFiles],
+              trackedFiles: [...otherFiles, ...serverFiles, ...preservedFiles],
+              loadedSessionId: collectionName,
             }
           },
           false,

--- a/frontends/ui/src/features/documents/types.ts
+++ b/frontends/ui/src/features/documents/types.ts
@@ -97,6 +97,11 @@ export interface DocumentsState {
   isCreatingCollection: boolean
   isUploading: boolean
   isPolling: boolean
+  isLoadingFiles: boolean
+  /** Session ID for which files were last loaded from the server (null = never loaded) */
+  loadedSessionId: string | null
+  /** File IDs/names recently deleted — prevents stale server responses from resurrecting them */
+  recentlyDeletedIds: Set<string>
   /** Error message */
   error: string | null
   /** Tracks which banners have been shown for each job (NOT persisted) */
@@ -124,6 +129,7 @@ export interface DocumentsActions {
   setCreatingCollection: (loading: boolean) => void
   setUploading: (loading: boolean) => void
   setPolling: (polling: boolean) => void
+  setLoadingFiles: (loading: boolean) => void
 
   // Error handling
   setError: (error: string | null) => void

--- a/frontends/ui/src/features/documents/types.ts
+++ b/frontends/ui/src/features/documents/types.ts
@@ -52,8 +52,8 @@ export interface TrackedFile {
   fileName: string
   /** File size in bytes */
   fileSize: number
-  /** Current status */
-  status: DocumentFileStatus
+  /** Current status (includes client-only 'deleting' transient state) */
+  status: DocumentFileStatus | 'deleting'
   /** Progress percentage (0-100) */
   progress: number
   /** Error message if failed */

--- a/frontends/ui/src/features/documents/types.ts
+++ b/frontends/ui/src/features/documents/types.ts
@@ -118,6 +118,8 @@ export interface DocumentsActions {
   addTrackedFile: (file: TrackedFile) => void
   updateTrackedFile: (id: string, updates: Partial<TrackedFile>) => void
   removeTrackedFile: (id: string) => void
+  /** Remove a file's IDs from recentlyDeletedIds (used to undo optimistic delete on failure) */
+  unmarkRecentlyDeleted: (file: TrackedFile) => void
   clearTrackedFiles: () => void
   /** Clear files for a specific collection (used when switching sessions) */
   clearFilesForCollection: (collectionName: string) => void

--- a/frontends/ui/src/features/documents/utils.ts
+++ b/frontends/ui/src/features/documents/utils.ts
@@ -26,7 +26,7 @@ export const mapBackendStatus = (backendStatus: string): DocumentFileStatus => {
 /**
  * Map DocumentFileStatus to FileSourceCard display status
  */
-export const mapToDisplayStatus = (status: DocumentFileStatus): FileSourceStatus => {
+export const mapToDisplayStatus = (status: string): FileSourceStatus => {
   switch (status) {
     case 'uploading':
       return 'uploading'
@@ -36,6 +36,8 @@ export const mapToDisplayStatus = (status: DocumentFileStatus): FileSourceStatus
       return 'available'
     case 'failed':
       return 'error'
+    case 'deleting':
+      return 'deleting'
     default:
       return 'uploading'
   }

--- a/frontends/ui/src/features/layout/components/FileSourceCard.tsx
+++ b/frontends/ui/src/features/layout/components/FileSourceCard.tsx
@@ -16,7 +16,7 @@ import { Document, Trash } from '@/adapters/ui/icons'
 import { useIsCurrentSessionBusy } from '@/features/chat'
 
 /** File source status types */
-export type FileSourceStatus = 'uploading' | 'ingesting' | 'available' | 'error'
+export type FileSourceStatus = 'uploading' | 'ingesting' | 'available' | 'error' | 'deleting'
 
 export interface FileSourceCardProps {
   /** Unique identifier for the file */
@@ -63,6 +63,11 @@ const STATUS_CONFIG: Record<
     label: 'Error',
     color: 'var(--text-color-feedback-danger)',
     showSpinner: false,
+  },
+  deleting: {
+    label: 'Deleting...',
+    color: 'var(--text-color-subtle)',
+    showSpinner: true,
   },
 }
 
@@ -172,7 +177,8 @@ export const FileSourceCard: FC<FileSourceCardProps> = ({
   }
 
   const isProcessing = status === 'uploading' || status === 'ingesting'
-  const deleteDisabled = isBusy || isProcessing
+  const isDeleting = status === 'deleting'
+  const deleteDisabled = isBusy || isProcessing || isDeleting
 
   return (
     <Flex
@@ -182,6 +188,7 @@ export const FileSourceCard: FC<FileSourceCardProps> = ({
         bg-surface-raised border-base rounded-lg border
         p-3 transition-colors
         ${status === 'error' ? 'border-error/50' : ''}
+        ${isDeleting ? 'opacity-50' : ''}
         group
       `}
     >

--- a/frontends/ui/src/features/layout/components/FileSourceCard.tsx
+++ b/frontends/ui/src/features/layout/components/FileSourceCard.tsx
@@ -171,7 +171,8 @@ export const FileSourceCard: FC<FileSourceCardProps> = ({
     onDelete(id)
   }
 
-  const deleteDisabled = isBusy
+  const isProcessing = status === 'uploading' || status === 'ingesting'
+  const deleteDisabled = isBusy || isProcessing
 
   return (
     <Flex
@@ -269,7 +270,7 @@ export const FileSourceCard: FC<FileSourceCardProps> = ({
           onClick={handleDelete}
           disabled={deleteDisabled}
           aria-label={deleteDisabled ? `Delete ${title} (disabled)` : `Delete ${title}`}
-          title={deleteDisabled ? "Cannot delete files during active operations" : "Delete file"}
+          title={isProcessing ? "Wait for upload to complete" : deleteDisabled ? "Cannot delete files during active operations" : "Delete file"}
           className="ml-2 flex-shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
         >
           <Trash width={16} height={16} className="text-subtle hover:text-error" />

--- a/frontends/ui/src/features/layout/components/FileSourcesTab.tsx
+++ b/frontends/ui/src/features/layout/components/FileSourcesTab.tsx
@@ -17,6 +17,7 @@ import { LoadingSpinner } from '@/adapters/ui/icons'
 import { FileSourceCard } from './FileSourceCard'
 import { DeleteFileConfirmationModal } from './DeleteFileConfirmationModal'
 import { useFileUpload, useDocumentsStore, FileUploadZone, mapToDisplayStatus } from '@/features/documents'
+import { sessionHasKnownCollection } from '@/features/documents/persistence'
 import { useChatStore } from '@/features/chat/store'
 import { useLayoutStore } from '../store'
 import { useAppConfig } from '@/shared/context'
@@ -58,11 +59,24 @@ export const FileSourcesTab: FC<FileSourcesTabProps> = ({ onDeleteFile }) => {
   // isUploading/isPolling are global flags, so we must scope to the current session to avoid
   // showing a spinner for uploads belonging to a different session.
   const activeCollection = useDocumentsStore((state) => state.currentCollectionName)
+  const isLoadingFiles = useDocumentsStore((state) => state.isLoadingFiles)
+  const loadedSessionId = useDocumentsStore((state) => state.loadedSessionId)
   const isThisSessionProcessing =
     activeCollection === currentConversation?.id && (isUploading || isPolling)
 
-  // Show loading spinner when THIS session's files are being processed but haven't appeared yet
-  const isFileProcessing = isThisSessionProcessing && sessionFiles.length === 0
+  // Show spinner when:
+  // 1. Actively loading files from server, OR
+  // 2. Upload/polling in progress but files haven't appeared, OR
+  // 3. Session is known to have files but we haven't loaded for it yet
+  //    (covers the render-to-useEffect gap on session switch; stops once
+  //    loadFilesForSession completes — even if the result is empty)
+  const sessionId = currentConversation?.id
+  const hasLoadedForSession = loadedSessionId === sessionId
+  const sessionExpectsFiles = !!sessionId && !hasLoadedForSession && sessionHasKnownCollection(sessionId)
+  const isAwaitingFiles =
+    isLoadingFiles ||
+    (isThisSessionProcessing && sessionFiles.length === 0) ||
+    sessionExpectsFiles
 
   // Delete confirmation modal state
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
@@ -130,6 +144,19 @@ export const FileSourcesTab: FC<FileSourcesTabProps> = ({ onDeleteFile }) => {
   }, [])
 
   if (sessionFiles.length === 0) {
+    // When files are expected (loading, uploading, or session known to have files),
+    // always show the spinner — never flash "No Files" during transitions.
+    if (isAwaitingFiles) {
+      return (
+        <Flex direction="col" align="center" justify="center" gap="2" className="flex-1 py-8">
+          <LoadingSpinner size="medium" aria-label="Loading files" />
+          <Text kind="body/regular/sm" className="text-subtle">
+            Checking for files...
+          </Text>
+        </Flex>
+      )
+    }
+
     return (
       <Flex direction="col" gap="4" className="flex-1">
         {/* Show info banner when file upload is not available */}
@@ -139,18 +166,8 @@ export const FileSourcesTab: FC<FileSourcesTabProps> = ({ onDeleteFile }) => {
           </Banner>
         )}
 
-        {/* Show loading spinner when files are being processed but API hasn't updated yet */}
-        {isFileProcessing && (
-          <Flex direction="col" align="center" justify="center" gap="2" className="py-8">
-            <LoadingSpinner size="medium" aria-label="Processing files" />
-            <Text kind="body/regular/sm" className="text-subtle">
-              Checking for files...
-            </Text>
-          </Flex>
-        )}
-
-        {/* Show empty state message when file upload is available and not processing */}
-        {knowledgeLayerAvailable && !isFileProcessing && (
+        {/* Show empty state message when file upload is available */}
+        {knowledgeLayerAvailable && (
           <StatusMessage
             size="small"
             slotHeading="No Files"
@@ -165,8 +182,8 @@ export const FileSourcesTab: FC<FileSourcesTabProps> = ({ onDeleteFile }) => {
           </Banner>
         )}
 
-        {/* File Upload Zone for empty state - only show when knowledge layer is available and not processing */}
-        {knowledgeLayerAvailable && !isFileProcessing && (
+        {/* File Upload Zone */}
+        {knowledgeLayerAvailable && (
           <FileUploadZone
             sessionId={currentConversation?.id}
             acceptedTypes={fileUploadConfig.acceptedTypes}
@@ -207,8 +224,8 @@ export const FileSourcesTab: FC<FileSourcesTabProps> = ({ onDeleteFile }) => {
           kind="tertiary"
           size="small"
           onClick={handleAddFileClick}
-          disabled={isUploading || !knowledgeLayerAvailable}
-          title={knowledgeLayerAvailable ? "Add files" : "File upload not available"}
+          disabled={isUploading || isAwaitingFiles || !knowledgeLayerAvailable}
+          title={isAwaitingFiles ? "Loading files..." : knowledgeLayerAvailable ? "Add files" : "File upload not available"}
         >
           + Add File
         </Button>

--- a/frontends/ui/src/features/layout/components/FileSourcesTab.tsx
+++ b/frontends/ui/src/features/layout/components/FileSourcesTab.tsx
@@ -224,8 +224,8 @@ export const FileSourcesTab: FC<FileSourcesTabProps> = ({ onDeleteFile }) => {
           kind="tertiary"
           size="small"
           onClick={handleAddFileClick}
-          disabled={isUploading || isAwaitingFiles || !knowledgeLayerAvailable}
-          title={isAwaitingFiles ? "Loading files..." : knowledgeLayerAvailable ? "Add files" : "File upload not available"}
+          disabled={isLoadingFiles || !knowledgeLayerAvailable}
+          title={isLoadingFiles ? "Loading files..." : knowledgeLayerAvailable ? "Add files" : "File upload not available"}
         >
           + Add File
         </Button>

--- a/frontends/ui/src/features/layout/components/InputArea.tsx
+++ b/frontends/ui/src/features/layout/components/InputArea.tsx
@@ -293,12 +293,12 @@ export const InputArea: FC<InputAreaProps> = ({
         return
       }
 
-      // uploadFiles validates internally and sets error if invalid
-      await uploadFiles(files, sessionId)
-
-      // Open the data sources panel and switch to files tab
+      // Open the files tab immediately so the user sees instant feedback
       setDataSourcesPanelTab('files')
       openRightPanel('data-sources')
+
+      // uploadFiles validates internally and sets error if invalid
+      await uploadFiles(files, sessionId)
     },
     [
       ensureSession,

--- a/sources/knowledge_layer/src/foundational_rag/adapter.py
+++ b/sources/knowledge_layer/src/foundational_rag/adapter.py
@@ -857,7 +857,7 @@ class FoundationalRagIngestor(TTLCleanupMixin, BaseIngestor):
         failed_count = sum(1 for fd in job.file_details if fd.status == FileStatus.FAILED)
         if failed_count == job.total_files:
             job.status = JobState.FAILED
-            job.error_message = "All file uploads failed"
+            job.error_message = "File upload failed"
             job.completed_at = datetime.now()
         # Otherwise keep as PROCESSING - get_job_status will poll FRAG and update
 
@@ -911,21 +911,54 @@ class FoundationalRagIngestor(TTLCleanupMixin, BaseIngestor):
                     if response.status_code == 200:
                         status_data = response.json()
                         state = status_data.get("state", "").lower()
-                        logger.debug(f"FRAG task {task_id[:8]} state={state}")
+                        logger.debug(f"FRAG task {task_id[:8]} state={state}, response={status_data}")
 
                         if state in ("success", "completed", "finished"):
-                            # Mark all files in this batch task as succeeded
+                            result = status_data.get("result", {})
+                            failed_docs = result.get("failed_documents", [])
+                            failed_names: dict[str, str] = {}
+                            for fdoc in failed_docs:
+                                fname = fdoc.get("document_name", "")
+                                ferr = fdoc.get("error_message", "Ingestion failed")
+                                if fname:
+                                    failed_names[fname] = ferr
+
+                            if failed_names:
+                                logger.warning(
+                                    f"FRAG task {task_id[:8]} completed with "
+                                    f"{len(failed_names)} failed file(s): {list(failed_names.keys())}"
+                                )
+
                             if file_indices:
                                 for idx in file_indices:
                                     if (
                                         idx < len(job.file_details)
                                         and job.file_details[idx].status == FileStatus.INGESTING
                                     ):
-                                        job.file_details[idx].status = FileStatus.SUCCESS
-                                logger.debug(f"Batch ingestion succeeded ({len(file_indices)} files)")
+                                        fd = job.file_details[idx]
+                                        # Check if this file appears in failed_documents
+                                        matched_error = next(
+                                            (err for fname, err in failed_names.items() if fname in fd.file_name),
+                                            None,
+                                        )
+                                        if matched_error:
+                                            fd.status = FileStatus.FAILED
+                                            fd.error_message = matched_error
+                                        else:
+                                            fd.status = FileStatus.SUCCESS
+                                succeeded = sum(
+                                    1
+                                    for i in file_indices
+                                    if i < len(job.file_details) and job.file_details[i].status == FileStatus.SUCCESS
+                                )
+                                failed = sum(
+                                    1
+                                    for i in file_indices
+                                    if i < len(job.file_details) and job.file_details[i].status == FileStatus.FAILED
+                                )
+                                logger.debug(f"Batch ingestion done: {succeeded} succeeded, {failed} failed")
                             else:
                                 # Fallback: match by document name
-                                result = status_data.get("result", {})
                                 docs = result.get("documents", [])
                                 for doc in docs:
                                     doc_name = doc.get("document_name", "")
@@ -933,6 +966,12 @@ class FoundationalRagIngestor(TTLCleanupMixin, BaseIngestor):
                                         if doc_name in fd.file_name and fd.status == FileStatus.INGESTING:
                                             fd.status = FileStatus.SUCCESS
                                             logger.debug("File ingestion succeeded")
+                                for fname, ferr in failed_names.items():
+                                    for fd in job.file_details:
+                                        if fname in fd.file_name and fd.status == FileStatus.INGESTING:
+                                            fd.status = FileStatus.FAILED
+                                            fd.error_message = ferr
+                                            logger.warning(f"File ingestion failed: {ferr}")
                         elif state == "failed":
                             result = status_data.get("result", {})
                             # Try multiple fields for error message
@@ -996,7 +1035,7 @@ class FoundationalRagIngestor(TTLCleanupMixin, BaseIngestor):
                 job.processed_files = total_done
                 if failed_count == job.total_files:
                     job.status = JobState.FAILED
-                    job.error_message = "All file ingestions failed"
+                    job.error_message = "File ingestion failed"
                 else:
                     job.status = JobState.COMPLETED
                 job.completed_at = datetime.now()
@@ -1463,6 +1502,26 @@ class FoundationalRagIngestor(TTLCleanupMixin, BaseIngestor):
                         metadata=enriched_metadata,
                     )
                 )
+
+            # Include failed files from local job tracking.
+            # The FRAG server only returns successfully ingested documents, so
+            # files that failed ingestion would otherwise vanish from the UI.
+            existing_names = {f.file_name for f in files}
+            for job in self._jobs.values():
+                if job.collection_name != collection_name:
+                    continue
+                for fd in job.file_details:
+                    if fd.status == FileStatus.FAILED and fd.file_name not in existing_names:
+                        files.append(
+                            FileInfo(
+                                file_id=fd.file_name,
+                                file_name=fd.file_name,
+                                collection_name=collection_name,
+                                status=FileStatus.FAILED,
+                                error_message=fd.error_message,
+                            )
+                        )
+                        existing_names.add(fd.file_name)
 
             return files
 

--- a/sources/knowledge_layer/src/foundational_rag/adapter.py
+++ b/sources/knowledge_layer/src/foundational_rag/adapter.py
@@ -51,6 +51,7 @@ import json
 import logging
 import os
 import re
+import threading
 import uuid
 from datetime import datetime
 from functools import partial
@@ -110,6 +111,10 @@ MAX_VDB_TOP_K = 100
 # Collection TTL settings (configurable via environment)
 COLLECTION_TTL_HOURS = float(os.environ.get("AIQ_COLLECTION_TTL_HOURS", "24"))
 TTL_CLEANUP_INTERVAL_SECONDS = int(os.environ.get("AIQ_TTL_CLEANUP_INTERVAL_SECONDS", "3600"))
+
+# Completed jobs are retained for this long so list_files can include failed
+# files, then pruned to avoid unbounded memory growth.
+JOB_RETENTION_SECONDS = 3600  # 1 hour
 
 # Client-side summary settings (runs parallel to FRAG ingestion)
 SUMMARY_MAX_CHARS = 4000
@@ -639,6 +644,7 @@ class FoundationalRagIngestor(TTLCleanupMixin, BaseIngestor):
 
         # Local job tracking (for jobs submitted through this adapter)
         self._jobs: dict[str, IngestionJobStatus] = {}
+        self._lock = threading.RLock()
 
         # Start background TTL cleanup task
         self._start_ttl_cleanup_task(COLLECTION_TTL_HOURS, TTL_CLEANUP_INTERVAL_SECONDS)
@@ -655,6 +661,20 @@ class FoundationalRagIngestor(TTLCleanupMixin, BaseIngestor):
     @property
     def backend_name(self) -> str:
         return "foundational_rag"
+
+    def _prune_completed_jobs(self) -> None:
+        """Remove completed/failed jobs older than JOB_RETENTION_SECONDS."""
+        now = datetime.now()
+        with self._lock:
+            stale = [
+                jid
+                for jid, job in self._jobs.items()
+                if job.completed_at is not None and (now - job.completed_at).total_seconds() > JOB_RETENTION_SECONDS
+            ]
+            for jid in stale:
+                del self._jobs[jid]
+        if stale:
+            logger.debug("Pruned %d completed job(s) from tracking", len(stale))
 
     def _get_headers(self, content_type: str | None = None) -> dict[str, str]:
         """Get request headers including optional auth."""
@@ -719,11 +739,10 @@ class FoundationalRagIngestor(TTLCleanupMixin, BaseIngestor):
             backend=self.backend_name,
             metadata={"rag_url": self.rag_url},
         )
-        self._jobs[job_id] = job_status
+        with self._lock:
+            self._jobs[job_id] = job_status
 
         # Upload files in background
-        import threading
-
         thread = threading.Thread(
             target=self._upload_files_async,
             args=(job_id, file_paths, collection_name, config),
@@ -743,12 +762,12 @@ class FoundationalRagIngestor(TTLCleanupMixin, BaseIngestor):
         """Background thread to upload files to RAG server."""
         from concurrent.futures import ThreadPoolExecutor
 
-        job = self._jobs.get(job_id)
-        if not job:
-            return
-
-        job.status = JobState.PROCESSING
-        job.started_at = datetime.now()
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if not job:
+                return
+            job.status = JobState.PROCESSING
+            job.started_at = datetime.now()
         config = config or {}
 
         # Original filenames for temp file uploads
@@ -874,7 +893,10 @@ class FoundationalRagIngestor(TTLCleanupMixin, BaseIngestor):
         Returns:
             Current job status.
         """
-        job = self._jobs.get(job_id)
+        self._prune_completed_jobs()
+
+        with self._lock:
+            job = self._jobs.get(job_id)
         if not job:
             # Return a failed status for unknown jobs
             return IngestionJobStatus(
@@ -911,7 +933,7 @@ class FoundationalRagIngestor(TTLCleanupMixin, BaseIngestor):
                     if response.status_code == 200:
                         status_data = response.json()
                         state = status_data.get("state", "").lower()
-                        logger.debug(f"FRAG task {task_id[:8]} state={state}, response={status_data}")
+                        logger.debug(f"FRAG task {task_id[:8]} state={state}")
 
                         if state in ("success", "completed", "finished"):
                             result = status_data.get("result", {})
@@ -938,7 +960,7 @@ class FoundationalRagIngestor(TTLCleanupMixin, BaseIngestor):
                                         fd = job.file_details[idx]
                                         # Check if this file appears in failed_documents
                                         matched_error = next(
-                                            (err for fname, err in failed_names.items() if fname in fd.file_name),
+                                            (err for fname, err in failed_names.items() if fname == fd.file_name),
                                             None,
                                         )
                                         if matched_error:
@@ -963,12 +985,12 @@ class FoundationalRagIngestor(TTLCleanupMixin, BaseIngestor):
                                 for doc in docs:
                                     doc_name = doc.get("document_name", "")
                                     for fd in job.file_details:
-                                        if doc_name in fd.file_name and fd.status == FileStatus.INGESTING:
+                                        if doc_name == fd.file_name and fd.status == FileStatus.INGESTING:
                                             fd.status = FileStatus.SUCCESS
                                             logger.debug("File ingestion succeeded")
                                 for fname, ferr in failed_names.items():
                                     for fd in job.file_details:
-                                        if fname in fd.file_name and fd.status == FileStatus.INGESTING:
+                                        if fname == fd.file_name and fd.status == FileStatus.INGESTING:
                                             fd.status = FileStatus.FAILED
                                             fd.error_message = ferr
                                             logger.warning(f"File ingestion failed: {ferr}")
@@ -1003,7 +1025,7 @@ class FoundationalRagIngestor(TTLCleanupMixin, BaseIngestor):
                                     doc_name = fdoc.get("document_name", "")
                                     doc_error = fdoc.get("error_message", error_msg)
                                     for fd in job.file_details:
-                                        if doc_name in fd.file_name and fd.status == FileStatus.INGESTING:
+                                        if doc_name == fd.file_name and fd.status == FileStatus.INGESTING:
                                             fd.status = FileStatus.FAILED
                                             fd.error_message = doc_error
                                             logger.warning(f"File ingestion failed: {doc_error}")
@@ -1430,6 +1452,16 @@ class FoundationalRagIngestor(TTLCleanupMixin, BaseIngestor):
             for file_id in file_ids:
                 unregister_summary(collection_name, file_id)
 
+            # Also purge failed files from local job tracking so they don't
+            # reappear via list_files (failed files only exist in _jobs, not
+            # on the FRAG server, so the FRAG delete above is a no-op for them)
+            deleted_set = set(file_ids)
+            with self._lock:
+                for job in self._jobs.values():
+                    if job.collection_name != collection_name:
+                        continue
+                    job.file_details = [fd for fd in job.file_details if fd.file_name not in deleted_set]
+
             logger.info(f"Deleted {len(file_ids)} files from {collection_name}")
             return {
                 "message": result.get("message", f"Deleted {len(file_ids)} files"),
@@ -1507,7 +1539,9 @@ class FoundationalRagIngestor(TTLCleanupMixin, BaseIngestor):
             # The FRAG server only returns successfully ingested documents, so
             # files that failed ingestion would otherwise vanish from the UI.
             existing_names = {f.file_name for f in files}
-            for job in self._jobs.values():
+            with self._lock:
+                jobs_snapshot = list(self._jobs.values())
+            for job in jobs_snapshot:
                 if job.collection_name != collection_name:
                     continue
                 for fd in job.file_details:

--- a/sources/knowledge_layer/src/llamaindex/adapter.py
+++ b/sources/knowledge_layer/src/llamaindex/adapter.py
@@ -1004,6 +1004,10 @@ class LlamaIndexIngestor(TTLCleanupMixin, BaseIngestor):
         This removes all chunks that have the matching file_name in metadata.
         Handles both exact file names and names with tmp prefix stripped.
         Uses same tmp pattern as Foundational RAG: tmp[8 random chars]_filename
+
+        The file_id parameter may be either a backend UUID or a human-readable
+        filename (the frontend sends filenames). Both are handled: UUID is looked
+        up directly in self._files, while a filename triggers a value-based search.
         """
         import re
 
@@ -1016,11 +1020,21 @@ class LlamaIndexIngestor(TTLCleanupMixin, BaseIngestor):
                 logger.warning(f"Collection {collection_name} not found")
                 return False
 
-            # Get file_name from tracking or use file_id directly
+            # Resolve file_name from tracking dict.
+            # The caller may pass a UUID (direct key) or a filename (value search).
             file_name = None
+            tracking_ids_to_remove: list[str] = []
             with self._lock:
-                if hasattr(self, "_files") and file_id in self._files:
-                    file_name = self._files[file_id].file_name
+                if hasattr(self, "_files"):
+                    if file_id in self._files:
+                        file_name = self._files[file_id].file_name
+                        tracking_ids_to_remove.append(file_id)
+                    else:
+                        # file_id is likely a filename — search by value
+                        for fid, fi in self._files.items():
+                            if fi.file_name == file_id and fi.collection_name == collection_name:
+                                file_name = fi.file_name
+                                tracking_ids_to_remove.append(fid)
             if not file_name:
                 file_name = file_id
 
@@ -1041,17 +1055,30 @@ class LlamaIndexIngestor(TTLCleanupMixin, BaseIngestor):
                     if tmp_pattern.match(meta.get("file_name", ""))
                 ]
                 if not matching_ids:
-                    logger.warning(f"No chunks found for file_name={file_name}")
-                    return False
+                    if not tracking_ids_to_remove:
+                        logger.warning(f"No chunks found for file_name={file_name}")
+                        return False
+                    # No chunks in ChromaDB but tracking entries exist (e.g. FAILED files).
+                    # Clean them up and report success.
+                    with self._lock:
+                        for tid in tracking_ids_to_remove:
+                            self._files.pop(tid, None)
+                    logger.info(f"Removed {len(tracking_ids_to_remove)} tracking entries for file {file_name}")
+
+                    from aiq_agent.knowledge import unregister_summary
+
+                    unregister_summary(collection_name, file_name)
+                    return True
                 results = {"ids": matching_ids}
 
             collection.delete(ids=results["ids"])
             logger.info(f"Deleted {len(results['ids'])} chunks for file {file_name}")
 
-            # Remove from tracking if it was there
+            # Remove all matching tracking entries
             with self._lock:
-                if hasattr(self, "_files") and file_id in self._files:
-                    del self._files[file_id]
+                if hasattr(self, "_files"):
+                    for tid in tracking_ids_to_remove:
+                        self._files.pop(tid, None)
 
             # Remove from centralized summary registry
             from aiq_agent.knowledge import unregister_summary
@@ -1155,7 +1182,8 @@ class LlamaIndexIngestor(TTLCleanupMixin, BaseIngestor):
                         )
                     )
 
-            # Also include FAILED files from tracking (they won't have chunks in Chroma)
+            # Also include FAILED files from tracking (they won't have chunks in Chroma).
+            # Track seen names to avoid duplicates when the same file was uploaded multiple times.
             with self._lock:
                 if hasattr(self, "_files"):
                     existing_names = {f.file_name for f in result}
@@ -1166,6 +1194,7 @@ class LlamaIndexIngestor(TTLCleanupMixin, BaseIngestor):
                             and fi.status == FileStatus.FAILED
                         ):
                             result.append(fi)
+                            existing_names.add(fi.file_name)
 
             logger.info(f"Listed {len(result)} files in {collection_name}")
             return result

--- a/tests/aiq_agent/async_api/test_websocket_reconnect.py
+++ b/tests/aiq_agent/async_api/test_websocket_reconnect.py
@@ -211,9 +211,11 @@ async def test_handler_create_websocket_message_uses_registry_send(
 
 
 @pytest.mark.asyncio
-async def test_handler_create_websocket_message_falls_back_to_socket(
+async def test_handler_create_websocket_message_drops_for_disconnected_conversation(
     monkeypatch,
 ) -> None:
+    """When registry.send fails for a valid conversation_id the message is dropped
+    instead of falling back to the (likely dead) direct socket."""
     failing_registry = WebSocketSessionRegistry()
     dummy_socket = DummySocket()
     handler = ReconnectableWebSocketMessageHandler(
@@ -222,6 +224,64 @@ async def test_handler_create_websocket_message_falls_back_to_socket(
         step_adaptor=DummyStepAdaptor(),
     )
     handler._conversation_id = "conv-1"
+
+    async def fake_send(_conversation_id, _message):
+        return False
+
+    async def fake_resolve_message_type(_data_model):
+        return "response"
+
+    async def fake_get_schema(_message_type):
+        from nat.data_models.api_server import WebSocketSystemResponseTokenMessage
+
+        return WebSocketSystemResponseTokenMessage
+
+    async def fake_convert_data(_data_model):
+        return DummyMessage()
+
+    async def fake_create_response_message(**_kwargs):
+        return DummyMessage(content="sent")
+
+    monkeypatch.setattr(websocket_reconnect, "_registry", failing_registry)
+    monkeypatch.setattr(websocket_reconnect._registry, "send", fake_send)
+    monkeypatch.setattr(
+        handler._message_validator,
+        "resolve_message_type_by_data",
+        fake_resolve_message_type,
+    )
+    monkeypatch.setattr(
+        handler._message_validator,
+        "get_message_schema_by_type",
+        fake_get_schema,
+    )
+    monkeypatch.setattr(
+        handler._message_validator,
+        "convert_data_to_message_content",
+        fake_convert_data,
+    )
+    monkeypatch.setattr(
+        handler._message_validator,
+        "create_system_response_token_message",
+        fake_create_response_message,
+    )
+
+    await handler.create_websocket_message(data_model=DummyMessage())
+    assert dummy_socket.sent == []
+
+
+@pytest.mark.asyncio
+async def test_handler_create_websocket_message_falls_back_to_socket_without_conversation(
+    monkeypatch,
+) -> None:
+    """When conversation_id is None, fall back to the direct socket."""
+    failing_registry = WebSocketSessionRegistry()
+    dummy_socket = DummySocket()
+    handler = ReconnectableWebSocketMessageHandler(
+        socket=dummy_socket,
+        session_manager=DummySessionManager(),
+        step_adaptor=DummyStepAdaptor(),
+    )
+    handler._conversation_id = None
 
     async def fake_send(_conversation_id, _message):
         return False


### PR DESCRIPTION
## Summary
**Fix fRAG backend file error state not persisting on frontend:** The fRAG server returns `"success"` for the task even when individual files in the batch fail (partial failures). `get_job_status` now inspects `failed_documents` inside successful task responses and marks individual files as FAILED. `list_files` includes failed files from local job tracking so they survive the server-reload that occurs after polling completes. Filename matching in status polling was changed from substring (`in`) to exact (`==`) to avoid false matches.

**Fix failed file uploads persisting after deletion:** Deleting an error file from the file tab removed it from the UI, but the backend's in-memory tracking dict retained the entry. On tab reload, the file reappeared (and re-uploading the same file created duplicates). Root cause was an identifier mismatch — the frontend sent filenames but the backend dict was keyed by UUIDs — combined with a deduplication bug in `list_files`.

**Fix files not appearing after browser refresh:** After a page refresh, uploaded files were not listed. Two issues: (1) `previousSessionIdRef` was initialized with `sessionId`, so the session-change effect never fired on mount when the session was already set, leaving the orchestrator uninitialized. (2) A race condition where `loadFilesForSession` ran before `fetchDataSources` completed, hitting a `knowledgeLayerAvailable === false` early return with no retry.


**Fix uploading card and file tab appearing late:** Tracked files are now added to the store *before* the collection-creation network call, so uploading cards appear instantly. The file tab opens before `await uploadFiles(...)` returns.

**Fix websocket messages sent on dead sockets after reconnect:** When a client disconnects mid-workflow and reconnects, the old handler's `_run_workflow` fell back to sending on the closed socket after the registry returned `False`, producing repeated ASGI warnings. Now the fallback to `self._socket` only fires when `conversation_id` is `None`; for valid conversations whose socket was cleared on disconnect, the message is silently dropped at debug level.

**Add visual feedback for file deletion:** A new `deleting` transient status greys out the card and shows a spinner while the DELETE API call is in flight; the previous status is restored on failure.

**Thread safety & memory management for fRAG job tracking:** The `_jobs` dict is now guarded by a `threading.RLock` (multiple background upload threads mutate it concurrently). Completed/failed jobs are pruned after `JOB_RETENTION_SECONDS` (1 hour) to prevent unbounded memory growth.

## Changes

### Backend — fRAG adapter (`sources/knowledge_layer/src/foundational_rag/adapter.py`)

- **`get_job_status`**: Parse `failed_documents` from successful FRAG task responses to detect partial batch failures. Change filename matching from substring (`fname in fd.file_name`) to exact equality (`fname == fd.file_name`).
- **`list_files`**: Include FAILED files from local `_jobs` tracking so error state survives server reload. Update `existing_names` inside the failed-files loop to prevent duplicate entries when the same file was uploaded multiple times. Guard iteration with a lock-protected snapshot.
- **`_upload_files_async` / `start_ingestion`**: Wrap `_jobs` access with `threading.RLock` for thread safety.
- **`_prune_completed_jobs`**: New method — removes completed/failed jobs older than 1 hour on each `get_job_status` call.
- Improve error messages (`"File upload failed"` / `"File ingestion failed"` instead of `"All file uploads failed"`).

### Backend — WebSocket reconnect (`packages/aiq_api/src/aiq_api/websocket_reconnect.py`)

- When `conversation_id` is set but the registry has no active socket (client disconnected), drop the message at debug level instead of falling back to the stale `self._socket`.

### Frontend — `use-file-upload.ts`

- Send `serverFileId` (backend UUID) in delete requests when available, falling back to `fileName`.
- Set file status to `'deleting'` immediately on delete; restore previous status on failure.
- Add tracked files to the store *before* `ensureCollectionExists` so uploading cards appear instantly.
- Initialize `previousSessionIdRef` to `undefined` so `handleSessionChange` always fires on mount, ensuring the orchestrator's `currentSessionId` is set after browser refresh.
- Add a `useEffect` watching `knowledgeLayerAvailable` to retry `loadFilesForSession` once data sources confirms the knowledge layer is available.

### Frontend — `orchestrator.ts`

- `handleSessionChange`: Signal `setLoadingFiles(true)` immediately instead of clearing files for the new session, so the UI shows a spinner before any async work.
- `loadFilesForSession`: Call `setLoadingFiles(false)` on every early-return path and in a `finally` block to guarantee the spinner is dismissed.

### Frontend — `store.ts`

- New state: `isLoadingFiles`, `loadedSessionId`.
- `updateFilesFromJobStatus`: Skip files with status `'deleting'` so backend polling doesn't overwrite the transient delete state.
- `setFilesFromServer`: Preserve files in any transient status (`uploading`, `ingesting`, `deleting`) during server refresh. Filter server entries that collide with preserved transient files to avoid duplicate cards. Track `loadedSessionId`.

### Frontend — `types.ts` / `utils.ts`

- Add `isLoadingFiles` and `loadedSessionId` to `DocumentsState`; `setLoadingFiles` to `DocumentsActions`.
- Add `'deleting'` case to `mapToDisplayStatus`.

### Frontend — `FileSourceCard.tsx`

- New `deleting` status config (spinner + "Deleting..." label).
- Disable delete button and apply `opacity-50` while deleting.

### Frontend — `FileSourcesTab.tsx`

- Compute `isAwaitingFiles` from `isLoadingFiles`, active upload/poll state, and `sessionHasKnownCollection` for sessions not yet loaded.
- Show a full-page spinner when `isAwaitingFiles` is true and no files are present, instead of briefly flashing the "No Files" empty state.
- Disable "+ Add File" button while awaiting files.

### Frontend — `InputArea.tsx`

- Open the file tab *before* awaiting `uploadFiles()` so the user sees instant feedback.

### Config (`configs/config_web_frag.yml`)

- Add `verify_ssl: false` to the fRAG function config.

### Tests

- `orchestrator.spec.ts`: Add `setLoadingFiles` mock. Update session-change test to verify `clearFilesForCollection` is *not* called for the new session.
- `use-file-upload.spec.ts`: Add `useLayoutStore` mock and `loadFilesForSession` to orchestrator mock. Update session-change test to verify `handleSessionChange` is called on initial mount.
- `test_websocket_reconnect.py`: Add tests for the dead-socket message drop path.

## Test plan

- [ ] Upload a file that triggers an ingestion error (e.g., unsupported format or corrupted file)
- [ ] Verify the file card shows an error status (not success) after polling completes
- [ ] Delete the error file from the files tab
- [ ] Verify the card greys out with a "Deleting..." spinner, then disappears
- [ ] Switch away from the files tab and back — verify the deleted file does not reappear
- [ ] Re-upload the same failing file — verify only one error entry appears, not duplicates
- [ ] Upload a file successfully, then refresh the browser — verify the file is still listed
- [ ] Refresh the browser with the files tab open — verify files load without needing to switch sessions
- [ ] Toggle between Connections and Files tabs after refresh — verify files appear correctly
- [ ] Upload a file and verify the uploading card + file tab appear immediately (before collection creation completes)
- [ ] Start a workflow, disconnect the browser, reconnect — verify no ASGI send-on-closed-socket warnings in server logs
- [ ] Upload multiple files where one fails and one succeeds — verify each shows the correct status (partial batch failure)