### PR TITLE
Fix backend silently dropping WebSocket messages after DB pool failure

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -174,7 +178,7 @@
         "filename": "deploy/helm/deployment-k8s/values.yaml",
         "hashed_secret": "4ec8fc01a883d5cfb76b31d75404d1f1da1c22b2",
         "is_verified": false,
-        "line_number": 126
+        "line_number": 142
       }
     ],
     "docs/source/deployment/kubernetes.md": [
@@ -286,5 +290,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-26T19:44:15Z"
+  "generated_at": "2026-02-27T06:15:27Z"
 }

--- a/deploy/helm/deployment-k8s/values.yaml
+++ b/deploy/helm/deployment-k8s/values.yaml
@@ -38,7 +38,23 @@ aiq:
         targetPort: 8000
       port: 8000
       healthCheck:
-        enabled: false
+        enabled: true
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 30
+          periodSeconds: 15
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
       resources:
         requests:
           cpu: 500m

--- a/frontends/aiq_api/src/aiq_api/jobs/event_store.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/event_store.py
@@ -139,6 +139,7 @@ class EventStore:
                 pool_pre_ping=True,
                 pool_size=5,
                 max_overflow=10,
+                pool_recycle=1800,
                 connect_args=connect_args,
             )
             cls._sync_engine_cache[db_url] = (engine, time.monotonic())
@@ -165,6 +166,7 @@ class EventStore:
                 pool_pre_ping=True,
                 pool_size=5,
                 max_overflow=10,
+                pool_recycle=1800,
             )
             cls._async_engine_cache[db_url] = (engine, time.monotonic())
             logger.debug("Created async engine for %s", db_url[:50])

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -257,8 +257,31 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
 
     @app.get("/health", tags=["health"], summary="Health check")
     async def health_check():
-        """Simple health check endpoint."""
-        return {"status": "ok", "dask_available": dask_available}
+        """Health check endpoint that validates DB connectivity."""
+        from sqlalchemy import text
+
+        from ..jobs import EventStore
+
+        result = {"status": "ok", "dask_available": dask_available, "db": "ok"}
+
+        # Check DB connectivity using any cached async engine
+        try:
+            cache = EventStore._async_engine_cache
+            if cache:
+                engine = next(iter(cache.values()))[0]
+                async with engine.connect() as conn:
+                    await asyncio.wait_for(conn.execute(text("SELECT 1")), timeout=3.0)
+            else:
+                result["db"] = "no_engine"
+        except Exception:
+            logger.warning("Health check DB ping failed", exc_info=True)
+            result["status"] = "degraded"
+            result["db"] = "unreachable"
+            from fastapi.responses import JSONResponse
+
+            return JSONResponse(status_code=503, content=result)
+
+        return result
 
     @app.post(
         "/v1/jobs/async/submit",


### PR DESCRIPTION
-   Add DB connectivity check to /health endpoint so Kubernetes liveness
-   probes restart the pod when the asyncpg connection pool gets stuck.
-   Add pool_recycle=1800 to SQLAlchemy engines to proactively replace
-   stale connections. Enable backend health probes in default helm values.