### PR TITLE
Fix: Stale workflow responses leaking to reconnected WebSocket clients

### DIFF
--- a/docs/notebooks/1_Deep_Researcher_Web_Search.ipynb
+++ b/docs/notebooks/1_Deep_Researcher_Web_Search.ipynb
@@ -60,7 +60,19 @@
    "cell_type": "markdown",
    "id": "4629edb9",
    "metadata": {},
-   "source": "<a id=\"prereqs\"></a>\n## Prerequisites\n\n- **Python 3.11–3.13**\n- **[uv](https://github.com/astral-sh/uv)** package manager\n- **LLM API key** – For your chosen provider (required for LLM inference):\n    - **NVIDIA API Key** from [NVIDIA AI](https://build.nvidia.com/) (for NIM models)\nOptional requirements:\n- **Web search API key**:\n  - **Tavily** – [tavily.com](https://tavily.com) (for general web search)\n- **Node.js 22+ and npm** (optional, for web UI mode)"
+   "source": [
+    "<a id=\"prereqs\"></a>\n",
+    "## Prerequisites\n",
+    "\n",
+    "- **Python 3.11–3.13**\n",
+    "- **[uv](https://github.com/astral-sh/uv)** package manager\n",
+    "- **LLM API key** – For your chosen provider (required for LLM inference):\n",
+    "    - **NVIDIA API Key** from [NVIDIA AI](https://build.nvidia.com/) (for NIM models)\n",
+    "Optional requirements:\n",
+    "- **Web search API key**:\n",
+    "  - **Tavily** – [tavily.com](https://tavily.com) (for general web search)\n",
+    "- **Node.js 22+ and npm** (optional, for web UI mode)"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/frontends/aiq_api/src/aiq_api/websocket_reconnect.py
+++ b/frontends/aiq_api/src/aiq_api/websocket_reconnect.py
@@ -51,11 +51,12 @@ logger = logging.getLogger(__name__)
 
 
 class WebSocketSessionRegistry:
-    """Keep track of active sockets and pending HITL responses."""
+    """Keep track of active sockets, pending HITL responses, and running workflow tasks."""
 
     def __init__(self) -> None:
         self._sockets: dict[str, WebSocket] = {}
         self._pending_interactions: dict[str, asyncio.Future[TextContent]] = {}
+        self._workflow_tasks: dict[str, asyncio.Task] = {}
         self._lock = asyncio.Lock()
 
     async def set_socket(self, conversation_id: str | None, socket: WebSocket) -> None:
@@ -123,6 +124,27 @@ class WebSocketSessionRegistry:
         async with self._lock:
             self._pending_interactions.pop(conversation_id, None)
 
+    async def set_workflow_task(self, conversation_id: str | None, task: asyncio.Task) -> None:
+        """Register the running workflow task, cancelling any stale one first."""
+        if not conversation_id:
+            return
+        async with self._lock:
+            old_task = self._workflow_tasks.get(conversation_id)
+            if old_task is not None and not old_task.done():
+                old_task.cancel()
+                logger.info("Cancelled stale workflow task for conversation %s", conversation_id)
+            self._workflow_tasks[conversation_id] = task
+
+    async def cancel_workflow_task(self, conversation_id: str | None) -> None:
+        """Cancel and remove the workflow task for a conversation."""
+        if not conversation_id:
+            return
+        async with self._lock:
+            task = self._workflow_tasks.pop(conversation_id, None)
+            if task is not None and not task.done():
+                task.cancel()
+                logger.info("Cancelled workflow task for conversation %s", conversation_id)
+
 
 _registry = WebSocketSessionRegistry()
 _installed = False
@@ -166,14 +188,32 @@ class ReconnectableWebSocketMessageHandler(WebSocketMessageHandler):
                             )
             except (asyncio.CancelledError, WebSocketDisconnect):
                 await _registry.clear_socket(self._conversation_id, self._socket)
+                await _registry.cancel_workflow_task(self._conversation_id)
+                self._cancel_running_workflow()
                 break
             except ValidationError as exc:
                 logger.warning("Invalid websocket message payload: %s", str(exc))
+
+    def _cancel_running_workflow(self) -> None:
+        """Cancel the background workflow task spawned by NAT's create_task."""
+        task = self._running_workflow_task
+        if task is not None and not task.done():
+            task.cancel()
+            logger.info(
+                "Cancelled in-flight workflow task for conversation %s",
+                self._conversation_id,
+            )
 
     async def process_workflow_request(self, user_message_as_validated_type: WebSocketUserMessage) -> None:
         """Process user messages and register sockets for reconnect."""
         await _registry.set_socket(user_message_as_validated_type.conversation_id, self._socket)
         await super().process_workflow_request(user_message_as_validated_type)
+        # NAT's parent creates the task via asyncio.create_task and stores it
+        # in self._running_workflow_task. Track it in the registry so a
+        # reconnected handler can cancel a stale workflow for this conversation.
+        task = self._running_workflow_task
+        if task is not None and not task.done():
+            await _registry.set_workflow_task(user_message_as_validated_type.conversation_id, task)
 
     async def create_websocket_message(
         self,

--- a/frontends/aiq_api/src/aiq_api/websocket_reconnect.py
+++ b/frontends/aiq_api/src/aiq_api/websocket_reconnect.py
@@ -208,9 +208,10 @@ class ReconnectableWebSocketMessageHandler(WebSocketMessageHandler):
         """Process user messages and register sockets for reconnect."""
         await _registry.set_socket(user_message_as_validated_type.conversation_id, self._socket)
         await super().process_workflow_request(user_message_as_validated_type)
-        # NAT's parent creates the task via asyncio.create_task and stores it
-        # in self._running_workflow_task. Track it in the registry so a
-        # reconnected handler can cancel a stale workflow for this conversation.
+        # TODO(NAT-upstream): _running_workflow_task is currently always None
+        # because NAT's message_handler.py assigns via method chaining:
+        #   self._running_workflow_task = asyncio.create_task(...).add_done_callback(cb)
+        # add_done_callback() returns None. Blocked on NeMo-Agent-Toolkit#1744.
         task = self._running_workflow_task
         if task is not None and not task.done():
             await _registry.set_workflow_task(user_message_as_validated_type.conversation_id, task)

--- a/frontends/ui/src/adapters/api/websocket-client.ts
+++ b/frontends/ui/src/adapters/api/websocket-client.ts
@@ -35,9 +35,9 @@ export interface ConnectionChangeContext {
 /** Callbacks for NAT WebSocket client */
 export interface NATWebSocketClientCallbacks {
   /** Called when a system response message arrives (final or streaming content) */
-  onResponse?: (content: string, status: string, isFinal: boolean) => void
+  onResponse?: (content: string, status: string, isFinal: boolean, parentId?: string) => void
   /** Called when intermediate steps arrive (thinking, tool calls) */
-  onIntermediateStep?: (content: NATIntermediateStepContent | string, status: string) => void
+  onIntermediateStep?: (content: NATIntermediateStepContent | string, status: string, parentId?: string) => void
   /** Called when a human prompt arrives (clarification, approval, etc.) */
   onHumanPrompt?: (promptId: string, parentId: string, prompt: NATHumanPrompt) => void
   /** Called when an error occurs */
@@ -74,6 +74,8 @@ export class NATWebSocketClient {
   private isIntentionallyClosed = false
   private errorBeforeClose = false
   private messageIdCounter = 0
+  /** ID of the last user message sent -- used by callbacks to detect stale responses */
+  activeParentId: string | null = null
 
   constructor(options: NATWebSocketClientOptions) {
     this.options = {
@@ -145,10 +147,13 @@ export class NATWebSocketClient {
       data_sources: enabledDataSources ?? [],
     })
 
+    const messageId = this.generateMessageId()
+    this.activeParentId = messageId
+
     const message: NATUserMessage = {
       type: NATMessageType.USER_MESSAGE,
       schema_type: NATSchemaType.CHAT_STREAM,
-      id: this.generateMessageId(),
+      id: messageId,
       conversation_id: this.options.conversationId,
       content: {
         messages: [
@@ -282,14 +287,13 @@ export class NATWebSocketClient {
             content = message.content.text
           }
 
-
           const isFinal = message.status === 'complete'
-          this.options.callbacks.onResponse?.(content, message.status, isFinal)
+          this.options.callbacks.onResponse?.(content, message.status, isFinal, message.parent_id)
           break
         }
 
         case NATMessageType.SYSTEM_INTERMEDIATE: {
-          this.options.callbacks.onIntermediateStep?.(message.content, message.status)
+          this.options.callbacks.onIntermediateStep?.(message.content, message.status, message.parent_id)
           break
         }
 

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
@@ -415,14 +415,15 @@ describe('useWebSocketChat', () => {
     // autoConnect: true creates the WebSocket client and captures callbacks
     renderWebSocketHook()
 
+    // Both intermediate steps and the isFinal guard require isStreaming=true.
+    mockStoreState.isStreaming = true
+
     // Simulate an intermediate step first to create a thinking step
     act(() => {
       capturedCallbacks.onIntermediateStep?.('Working...', 'in_progress')
     })
 
     vi.clearAllMocks()
-    // The hook now ignores stale final completions when the store is not streaming.
-    mockStoreState.isStreaming = true
 
     // Simulate final response
     act(() => {
@@ -453,6 +454,9 @@ describe('useWebSocketChat', () => {
   test('onIntermediateStep callback creates thinking step if none exists', () => {
     renderWebSocketHook()
 
+    // Intermediate steps are dropped when not streaming (stale-guard).
+    mockStoreState.isStreaming = true
+
     // Simulate intermediate step with string content - no thinking step exists yet
     act(() => {
       capturedCallbacks.onIntermediateStep?.('Thinking...', 'in_progress')
@@ -470,6 +474,9 @@ describe('useWebSocketChat', () => {
 
   test('onIntermediateStep callback appends to existing thinking step', () => {
     renderWebSocketHook()
+
+    // Intermediate steps are dropped when not streaming (stale-guard).
+    mockStoreState.isStreaming = true
 
     // First call creates a step
     act(() => {
@@ -495,6 +502,9 @@ describe('useWebSocketChat', () => {
 
   test('onIntermediateStep callback handles object content with payload', () => {
     renderWebSocketHook()
+
+    // Intermediate steps are dropped when not streaming (stale-guard).
+    mockStoreState.isStreaming = true
 
     // Simulate intermediate step with object content - creates new step
     act(() => {

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
@@ -421,6 +421,8 @@ describe('useWebSocketChat', () => {
     })
 
     vi.clearAllMocks()
+    // The hook now ignores stale final completions when the store is not streaming.
+    mockStoreState.isStreaming = true
 
     // Simulate final response
     act(() => {

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -355,9 +355,14 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         }
       },
 
-      onIntermediateStep: (content: NATIntermediateStepContent | string, status: string, parentId?: string) => {
-        if (isStaleMessage(parentId)) {
-          console.warn('Dropping stale intermediate step (parent_id mismatch)', { parentId, active: wsClientRef.current?.activeParentId })
+      onIntermediateStep: (content: NATIntermediateStepContent | string, status: string, _parentId?: string) => {
+        // NAT uses an internal step ID (not the user message ID) for intermediate step parent_id,
+        // so we cannot use parent_id for stale detection here. Guard instead on isStreaming:
+        // if we are not currently streaming, the workflow that sent this step was already
+        // cancelled/disconnected, so discard it.
+        const { isStreaming: currentlyStreaming } = useChatStore.getState()
+        if (!currentlyStreaming) {
+          console.warn('Ignoring stale intermediate step -- not currently streaming')
           return
         }
         // Handle string content (legacy format)

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -209,8 +209,23 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
    * Create WebSocket callbacks that route messages to the store
    */
   const createCallbacks = useCallback((): NATWebSocketClientCallbacks => {
+    /**
+     * Guard against stale messages from a previous (cancelled) workflow.
+     * Returns true when the message should be dropped.
+     */
+    const isStaleMessage = (parentId?: string): boolean => {
+      const activeId = wsClientRef.current?.activeParentId
+      if (!parentId || !activeId) return false
+      return parentId !== activeId
+    }
+
     return {
-      onResponse: (content: string, status: string, isFinal: boolean) => {
+      onResponse: (content: string, status: string, isFinal: boolean, parentId?: string) => {
+        if (isStaleMessage(parentId)) {
+          console.warn('Dropping stale system_response (parent_id mismatch)', { parentId, active: wsClientRef.current?.activeParentId })
+          return
+        }
+
         // Check for deep research escalation signal
         // Backend sends: "Deep research job submitted. Job ID: {uuid}"
         const deepResearchMatch = content?.match(
@@ -316,6 +331,14 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
 
         // status: "complete" with null text signals task completion
         if (isFinal) {
+          // Guard: if we're not streaming, this is a stale COMPLETE from a
+          // previous workflow that outlived its socket (e.g. after disconnect).
+          const { isStreaming: currentlyStreaming } = useChatStore.getState()
+          if (!currentlyStreaming) {
+            console.warn('Ignoring stale isFinal -- not currently streaming')
+            return
+          }
+
           // Complete any pending thinking step
           if (currentThinkingStepIdRef.current) {
             completeThinkingStep(currentThinkingStepIdRef.current)
@@ -332,7 +355,11 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         }
       },
 
-      onIntermediateStep: (content: NATIntermediateStepContent | string, status: string) => {
+      onIntermediateStep: (content: NATIntermediateStepContent | string, status: string, parentId?: string) => {
+        if (isStaleMessage(parentId)) {
+          console.warn('Dropping stale intermediate step (parent_id mismatch)', { parentId, active: wsClientRef.current?.activeParentId })
+          return
+        }
         // Handle string content (legacy format)
         if (typeof content === 'string') {
           // For plain string content, create a generic thinking step

--- a/tests/aiq_agent/async_api/test_websocket_reconnect.py
+++ b/tests/aiq_agent/async_api/test_websocket_reconnect.py
@@ -539,6 +539,78 @@ async def test_handler_run_processes_user_message(monkeypatch) -> None:
     assert sockets == ["conv-1"]
 
 
+@pytest.mark.asyncio
+async def test_handler_run_cancels_workflow_on_disconnect(monkeypatch) -> None:
+    """When the socket disconnects, in-flight workflow tasks are cancelled."""
+    dummy_socket = DummySocket()  # no messages → immediate WebSocketDisconnect
+    handler = ReconnectableWebSocketMessageHandler(
+        socket=dummy_socket,
+        session_manager=DummySessionManager(),
+        step_adaptor=DummyStepAdaptor(),
+    )
+    handler._conversation_id = "conv-1"
+
+    # Simulate a long-running workflow task (sleeps forever)
+    workflow_task = asyncio.create_task(asyncio.sleep(999))
+    handler._running_workflow_task = workflow_task
+
+    # Also register the task in the global registry
+    await websocket_reconnect._registry.set_workflow_task("conv-1", workflow_task)
+
+    await handler.run()
+
+    # Let the event loop process the cancellation
+    await asyncio.sleep(0)
+    assert workflow_task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_registry_set_workflow_task_cancels_stale() -> None:
+    """Registering a new workflow task cancels any previous stale one."""
+    registry = WebSocketSessionRegistry()
+
+    stale_task = asyncio.create_task(asyncio.sleep(999))
+    await registry.set_workflow_task("conv-1", stale_task)
+    await asyncio.sleep(0)
+    assert not stale_task.cancelled()
+
+    new_task = asyncio.create_task(asyncio.sleep(999))
+    await registry.set_workflow_task("conv-1", new_task)
+    await asyncio.sleep(0)  # let cancellation propagate to stale_task
+
+    assert stale_task.cancelled()
+    assert not new_task.cancelled()
+
+    new_task.cancel()
+    await asyncio.sleep(0)  # let cancellation propagate
+
+
+@pytest.mark.asyncio
+async def test_registry_cancel_workflow_task() -> None:
+    """cancel_workflow_task removes and cancels the tracked task."""
+    registry = WebSocketSessionRegistry()
+
+    task = asyncio.create_task(asyncio.sleep(999))
+    await registry.set_workflow_task("conv-1", task)
+    await asyncio.sleep(0)
+    assert not task.cancelled()
+
+    await registry.cancel_workflow_task("conv-1")
+    await asyncio.sleep(0)  # let cancellation propagate
+    assert task.cancelled()
+
+    # Idempotent: calling again is a no-op
+    await registry.cancel_workflow_task("conv-1")
+
+
+@pytest.mark.asyncio
+async def test_registry_cancel_workflow_task_noop_for_missing() -> None:
+    """cancel_workflow_task is safe for missing conversation IDs."""
+    registry = WebSocketSessionRegistry()
+    await registry.cancel_workflow_task(None)
+    await registry.cancel_workflow_task("nonexistent")
+
+
 def test_install_reconnectable_handler(monkeypatch) -> None:
     from nat.front_ends.fastapi import fastapi_front_end_plugin_worker as worker_module
 


### PR DESCRIPTION
### Problem

When a WebSocket connection is broken mid-request (network drop, browser
refresh, tab close), the frontend correctly marks the in-progress
`chatThinking` as **Interrupted**. However, responses from the original
request could still arrive — sometimes after a second `chatThinking`
cycle had already started — causing three distinct bugs:

1. **Ghost responses** — the stale workflow's final `SYSTEM_RESPONSE`
   arriving on the new socket, injecting a response belonging to the
   previous (cancelled) request.
2. **Interleaved thinking steps** — intermediate steps from the old
   workflow appearing inside a new request's `chatThinking` block.
3. **Premature stream termination** — the stale `COMPLETE` signal
   resetting `isStreaming = false`, cutting off the new request's
   in-progress thinking display.

---

### Root Cause

NAT's `WebSocketMessageHandler.process_workflow_request()` launches the
LLM workflow as a background `asyncio.create_task` and returns
immediately. When the socket disconnects, the `run()` loop exits — but
**the background task is never cancelled**. It keeps running and emitting
messages.

The `WebSocketSessionRegistry` (a module-level singleton) maps
`conversation_id → current WebSocket`. When the client reconnects with
the same `conversation_id`, the new socket replaces the old one in the
registry. The stale task's next `registry.send()` call finds the **new**
socket and delivers to it.

```
Client disconnects  →  run() loop exits  →  registry cleared
                                            ↕  task still running!
Client reconnects   →  new socket registered
Stale task resumes  →  registry.send() finds new socket  →  DELIVERED ❌
```

> **Note on intermediate steps:** NAT sets `parent_id` on
> `SYSTEM_INTERMEDIATE` messages using an **internal step ID**
> (`get_intermediate_step_parent_id()`), not the user message ID. This
> makes `parent_id`-based correlation impossible for thinking steps and
> is why the `isStreaming` guard is used instead.

---

### Changes

#### Backend — `frontends/aiq_api/src/aiq_api/websocket_reconnect.py`

**1. Cancel workflow task on disconnect**

`run()` now calls `_cancel_running_workflow()` and
`registry.cancel_workflow_task()` on every disconnect:

```python
except (asyncio.CancelledError, WebSocketDisconnect):
    await _registry.clear_socket(self._conversation_id, self._socket)
    await _registry.cancel_workflow_task(self._conversation_id)
    self._cancel_running_workflow()
    break
```

**2. Registry-level task tracking**

`WebSocketSessionRegistry` gains `_workflow_tasks: dict[str, asyncio.Task]`
and two new methods:

- `set_workflow_task(conversation_id, task)` — registers the task;
  auto-cancels any previously registered task for the same conversation
  (handles the race where a reconnected client sends a new request before
  the old task is cancelled).
- `cancel_workflow_task(conversation_id)` — cancels and removes the task.

**3. Register task after launch**

After `super().process_workflow_request()` fires the NAT background task,
the new task is registered in the registry:

```python
task = self._running_workflow_task
if task is not None and not task.done():
    await _registry.set_workflow_task(conversation_id, task)
```

---

#### Frontend — `frontends/ui/src/adapters/api/websocket-client.ts`

- Added `activeParentId: string | null` — tracks the `id` of the last
  user message sent; updated on every `sendMessage()` call.
- `onResponse` and `onIntermediateStep` callbacks now receive an optional
  `parentId` argument populated from `message.parent_id`.

---

#### Frontend — `frontends/ui/src/features/chat/hooks/use-websocket-chat.ts`

Two independent stale-message guards:

| Guard | Applies to | Mechanism |
|---|---|---|
| `parent_id` correlation | `onResponse` | `SYSTEM_RESPONSE.parent_id` reliably equals the client's user message ID. Drops responses where `parent_id !== activeParentId`. |
| `isStreaming` guard | `onResponse` (`isFinal`) and `onIntermediateStep` | If `isStreaming` is `false` when a completion or step arrives, the request was already interrupted — discard it. |

---

### Tests

**`tests/aiq_agent/async_api/test_websocket_reconnect.py`** — 4 new tests:

| Test | Verifies |
|---|---|
| `test_handler_run_cancels_workflow_on_disconnect` | Disconnect cancels the in-flight workflow task |
| `test_registry_set_workflow_task_cancels_stale` | Registering a new task cancels the previous one for the same conversation |
| `test_registry_cancel_workflow_task` | `cancel_workflow_task()` cancels and removes the tracked task |
| `test_registry_cancel_workflow_task_noop_for_missing` | No-op for missing/`None` conversation IDs |

**`frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts`** —
Updated 4 existing tests to set `mockStoreState.isStreaming = true` before
firing intermediate step callbacks, reflecting the real-app invariant that
`isStreaming` is always `true` while thinking steps are in flight.

---

### Test Results

| Suite | Result |
|---|---|
| `pytest` (Python, 703 collected) | ✅ 701 passed, 2 skipped |
| `npm test` (UI Vitest, 1126 collected) | ✅ 1125 passed, 1 skipped |
| `npm run lint` | ✅ 0 errors |
| `npm run type-check` | ✅ Pass |
| `pre-commit run --all-files` | ✅ All hooks passed |

---

### Defence-in-Depth Summary

The fix operates at two independent layers. Either one prevents the bug;
together they provide belt-and-suspenders coverage against the race window
between disconnect detection and task cancellation.

```
Layer 1 (Backend)
  Cancel asyncio.Task on disconnect
  → stale workflow stops producing messages immediately

Layer 2 (Frontend)
  isStreaming guard + parent_id guard
  → even if a stale message slips through the race window,
    it is silently discarded before touching UI state
```
