### PR TITLE
Structured metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,6 @@ jobs:
             ./frontends/benchmarks/intent_classifier \
             ./sources/tavily_web_search \
             ./sources/google_scholar_paper_search \
-            ./sources/eci
           do
             if [ -d "$pkg" ]; then
               uv pip install -e "$pkg"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
             ./frontends/benchmarks/freshqa \
             ./frontends/benchmarks/intent_classifier \
             ./sources/tavily_web_search \
-            ./sources/google_scholar_paper_search \
+            ./sources/google_scholar_paper_search
           do
             if [ -d "$pkg" ]; then
               uv pip install -e "$pkg"

--- a/frontends/aiq_api/src/aiq_api/jobs/callbacks.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/callbacks.py
@@ -148,8 +148,8 @@ class ToolArtifactMapping:
             "write_file",
             artifact_type=ArtifactType.FILE,
             content_key="content",
-            name_key="path",
-            extra_keys=["path", "filename"],
+            name_key="file_path",
+            extra_keys=["file_path", "path", "filename"],
         )
 
     def register(
@@ -230,6 +230,7 @@ class AgentEventCallback(BaseCallbackHandler):
         self._job_id = event_store.job_id if event_store else None
         self._instance_discovered_urls: set[str] = set()
         self._instance_cited_urls: set[str] = set()
+        self._source_registry = None  # Set via set_source_registry() for verified citation tracking
         self._init_job_url_sets()
 
     def _init_job_url_sets(self) -> None:
@@ -345,6 +346,18 @@ class AgentEventCallback(BaseCallbackHandler):
                 return name
         return kwargs.get("name", "unknown")
 
+    def set_source_registry(self, registry) -> None:
+        """Attach a SourceRegistry for verified citation tracking.
+
+        When set, citation_source events use the registry (which captures
+        URLs from ALL tool calls via middleware) instead of the callback's
+        own pattern-based _is_search_tool check. This means:
+        - All tools are covered, not just ones matching SEARCH_TOOL_PATTERNS
+        - URL normalization is consistent with verify_citations()
+        - citation_use validation uses the same registry as post-processing
+        """
+        self._source_registry = registry
+
     def _is_search_tool(self, tool_name: str) -> bool:
         """Check if tool is a search-related tool that returns URLs."""
         tool_lower = tool_name.lower()
@@ -427,16 +440,29 @@ class AgentEventCallback(BaseCallbackHandler):
         return "intermediate"
 
     def _emit_cited_urls(self, content: str) -> None:
-        """Extract URLs from output content and emit citation_use events."""
+        """Extract URLs from output content and emit citation_use events.
+
+        When a SourceRegistry is attached, validates against it (consistent
+        with verify_citations). Otherwise falls back to the callback's own
+        _discovered_urls set.
+        """
         urls = self._extract_urls(content)
         for url in urls:
             normalized = self._normalize_url(url)
-            # Check if normalized URL was discovered (handles trailing slash differences, etc.)
-            if normalized in self._discovered_urls and normalized not in self._cited_urls:
+            if normalized in self._cited_urls:
+                continue
+
+            is_valid = False
+            if self._source_registry is not None:
+                is_valid = self._source_registry.has_url(url)
+            else:
+                is_valid = normalized in self._discovered_urls
+
+            if is_valid:
                 self._cited_urls.add(normalized)
                 self._emit_artifact(
                     ArtifactType.CITATION_USE,
-                    url,  # Emit original URL for display
+                    url,
                     name=url,
                     url=url,
                 )
@@ -470,7 +496,7 @@ class AgentEventCallback(BaseCallbackHandler):
             for key in extra_keys:
                 if key in tool_input:
                     extra_data[key] = tool_input[key]
-                    if not name and key in ("path", "filename", "name"):
+                    if not name and key in ("file_path", "path", "filename", "name"):
                         name = tool_input[key]
         elif isinstance(tool_input, list) and content_key == "todos":
             content = tool_input

--- a/frontends/ui/src/adapters/api/deep-research-client.ts
+++ b/frontends/ui/src/adapters/api/deep-research-client.ts
@@ -508,10 +508,14 @@ export const createDeepResearchClient = (options: DeepResearchStreamOptions): De
             // citation_use = "Cited" sources (actually used in the report)
             callbacks.onCitationUpdate?.(artifactData.url || '', artifactData.content as string, true)
             break
-          case 'file':
-            // file artifacts are draft files written during research
-            callbacks.onFileUpdate?.(artifactData.url || 'draft', artifactData.content as string)
+          case 'file': {
+            // file artifacts are written during research — extract filename from path
+            const raw = artifactData as Record<string, unknown>
+            const filePath = (raw.file_path || raw.path || artifactData.url || 'unknown') as string
+            const fileName = filePath.split('/').pop() || filePath
+            callbacks.onFileUpdate?.(fileName, artifactData.content as string)
             break
+          }
           case 'output':
             callbacks.onOutputUpdate?.(artifactData.content as string, artifactData.output_category, artifactWorkflow)
             break

--- a/frontends/ui/src/features/chat/hooks/use-deep-research.ts
+++ b/frontends/ui/src/features/chat/hooks/use-deep-research.ts
@@ -177,7 +177,7 @@ export const useDeepResearch = (): UseDeepResearchReturn => {
         toolCalls: new Map<string, { name: string; input?: Record<string, unknown>; output?: string; workflow?: string; agentId?: string }>(),
         todos: null as TodoItem[] | null,
         citations: [] as Array<{ url: string; content: string; isCited: boolean }>,
-        files: [] as Array<{ filename: string; content: string }>,
+        files: new Map<string, string>(),
         reportContent: null as string | null,
       }
 
@@ -192,7 +192,7 @@ export const useDeepResearch = (): UseDeepResearchReturn => {
         const llmSteps = Array.from(buf.llmSteps.entries()).map(([id, s]) => ({ id, name: s.name, workflow: s.workflow, content: s.content, thinking: s.thinking, usage: s.usage, isComplete: true, timestamp: now }))
         const toolCalls = Array.from(buf.toolCalls.entries()).map(([id, t]) => ({ id, name: t.name, input: t.input, output: t.output, workflow: t.workflow, agentId: t.agentId, status: 'complete' as const, timestamp: now }))
         const citations = buf.citations.map((c, i) => ({ id: `citation-${i}`, url: c.url, content: c.content, isCited: c.isCited, timestamp: now }))
-        const files = buf.files.map((f, i) => ({ id: `file-${i}`, filename: f.filename, content: f.content, timestamp: now }))
+        const files = Array.from(buf.files.entries()).map(([filename, content], i) => ({ id: `file-${i}`, filename, content, timestamp: now }))
         const todos = buf.todos?.map((t, i) => ({ id: `todo-${i}-${t.content.substring(0, 20).replace(/\s+/g, '-').toLowerCase()}`, content: t.content, status: t.status as 'pending' | 'in_progress' | 'completed' | 'stopped' }))
 
         useChatStore.setState((state) => ({
@@ -429,7 +429,7 @@ export const useDeepResearch = (): UseDeepResearchReturn => {
           },
 
           onFileUpdate: (filename, content) => {
-            if (buf.active) { buf.files.push({ filename, content }); return }
+            if (buf.active) { buf.files.set(filename, content); return }
             if (!isOwnerActive()) return
             resetTimeout(); addDeepResearchFile({ filename, content })
           },
@@ -438,16 +438,13 @@ export const useDeepResearch = (): UseDeepResearchReturn => {
             if (outputCategory === 'intermediate') return
             if (buf.active) {
               if (outputCategory === 'final_report' || !outputCategory) { buf.reportContent = content }
-              if (outputCategory === 'research_notes') {
-                const filename = workflow ? `${workflow} - ${outputCategory}` : 'Sub-Agent Notes'
-                buf.files.push({ filename, content })
-              }
+              // research_notes are already captured via write_file artifacts — skip to avoid duplicates
               return
             }
             if (!isOwnerActive()) return
             if (outputCategory === 'research_notes') {
-              const filename = workflow ? `${workflow} - ${outputCategory}` : 'Sub-Agent Notes'
-              addDeepResearchFile({ filename, content })
+              // Skip — research notes are already tracked via write_file tool artifacts
+              void 0
             } else if (outputCategory === 'final_report' || !outputCategory) {
               setReportContent(content)
               setCurrentStatus('writing')

--- a/frontends/ui/src/features/chat/hooks/use-deep-research.ts
+++ b/frontends/ui/src/features/chat/hooks/use-deep-research.ts
@@ -434,7 +434,7 @@ export const useDeepResearch = (): UseDeepResearchReturn => {
             resetTimeout(); addDeepResearchFile({ filename, content })
           },
 
-          onOutputUpdate: (content, outputCategory, workflow) => {
+          onOutputUpdate: (content, outputCategory, _workflow) => {
             if (outputCategory === 'intermediate') return
             if (buf.active) {
               if (outputCategory === 'final_report' || !outputCategory) { buf.reportContent = content }

--- a/frontends/ui/src/features/chat/hooks/use-load-job-data.ts
+++ b/frontends/ui/src/features/chat/hooks/use-load-job-data.ts
@@ -210,7 +210,7 @@ export const useLoadJobData = (): UseLoadJobDataReturn => {
           toolCalls: new Map<string, { name: string; input?: Record<string, unknown>; output?: string; workflow?: string; agentId?: string }>(),
           todos: null as TodoItem[] | null,
           citations: [] as Array<{ url: string; content: string; isCited: boolean }>,
-          files: [] as Array<{ filename: string; content: string }>,
+          files: new Map<string, string>(),  // filename -> latest content (deduped)
           reportContent: null as string | null,
         }
 
@@ -261,10 +261,10 @@ export const useLoadJobData = (): UseLoadJobDataReturn => {
             timestamp: now,
           }))
 
-          const files = buffer.files.map((f, idx) => ({
+          const files = Array.from(buffer.files.entries()).map(([filename, content], idx) => ({
             id: `file-${idx}`,
-            filename: f.filename,
-            content: f.content,
+            filename,
+            content,
             timestamp: now,
           }))
 
@@ -393,15 +393,13 @@ export const useLoadJobData = (): UseLoadJobDataReturn => {
             },
 
             onFileUpdate: (filename, content) => {
-              buffer.files.push({ filename, content })
+              buffer.files.set(filename, content)
             },
 
-            onOutputUpdate: (content, outputCategory, workflow) => {
+            onOutputUpdate: (content, outputCategory) => {
               if (outputCategory === 'intermediate') return
-              if (outputCategory === 'research_notes') {
-                const filename = workflow ? `${workflow} - ${outputCategory}` : 'Sub-Agent Notes'
-                buffer.files.push({ filename, content })
-              } else if (outputCategory === 'final_report' || !outputCategory) {
+              // research_notes are already captured via write_file artifacts — skip to avoid duplicates
+              if (outputCategory === 'final_report' || !outputCategory) {
                 buffer.reportContent = content
               }
             },

--- a/frontends/ui/src/features/chat/store.ts
+++ b/frontends/ui/src/features/chat/store.ts
@@ -2300,6 +2300,20 @@ export const useChatStore = create<ChatStore>()(
         },
 
         addDeepResearchFile: (file: Omit<DeepResearchFile, 'id' | 'timestamp'>) => {
+          const { deepResearchFiles } = get()
+          const existingIndex = deepResearchFiles.findIndex((f) => f.filename === file.filename)
+
+          if (existingIndex >= 0) {
+            // Update existing file with latest content
+            const updatedFiles = deepResearchFiles.map((f, i) =>
+              i === existingIndex
+                ? { ...f, content: file.content, timestamp: new Date() }
+                : f
+            )
+            set({ deepResearchFiles: updatedFiles }, false, 'addDeepResearchFile:update')
+            return deepResearchFiles[existingIndex].id
+          }
+
           const fileId = uuidv4()
           const newFile: DeepResearchFile = {
             ...file,

--- a/sources/google_scholar_paper_search/src/paper_search.py
+++ b/sources/google_scholar_paper_search/src/paper_search.py
@@ -175,7 +175,13 @@ class PaperSearchTool:
             )
             formatted_papers.append(paper_str)
 
-        return "\n\n".join(formatted_papers)
+        content = "\n\n".join(formatted_papers)
+
+        from aiq_agent.common.source_metadata import SourceRef
+        from aiq_agent.common.source_metadata import encode_source_metadata
+
+        refs = [SourceRef(url=p.get("link", ""), title=p.get("title", "")) for p in results if p.get("link")]
+        return encode_source_metadata(content, refs)
 
     async def search(
         self,

--- a/sources/knowledge_layer/KNOWLEDGE-LAYER-SETUP.md
+++ b/sources/knowledge_layer/KNOWLEDGE-LAYER-SETUP.md
@@ -598,7 +598,6 @@ my_backend = [
 [tool.setuptools]
 packages = [
     "aiq_sources",
-    "knowledge_layer.eci",
     "knowledge_layer.knowledge",
     "knowledge_layer.llamaindex",
     "knowledge_layer.foundational_rag",

--- a/sources/knowledge_layer/src/register.py
+++ b/sources/knowledge_layer/src/register.py
@@ -203,12 +203,18 @@ def _format_results(retrieval_result, query: str) -> str:
 
     lines = [f"Found {len(retrieval_result.chunks)} relevant document(s):\n"]
 
+    from aiq_agent.common.source_metadata import SourceRef
+
+    refs: list[SourceRef] = []
+
     for i, chunk in enumerate(retrieval_result.chunks, 1):
         # Build citation string: "filename, p.X" or just "filename"
         if chunk.page_number and chunk.page_number > 0:
             citation = f"{chunk.file_name}, p.{chunk.page_number}"
         else:
             citation = chunk.file_name
+
+        refs.append(SourceRef(citation_key=citation, title=chunk.file_name))
 
         # Header with source info
         lines.append(f"--- Result {i} ---")
@@ -227,7 +233,9 @@ def _format_results(retrieval_result, query: str) -> str:
         lines.append(content)
         lines.append("")
 
-    return "\n".join(lines)
+    from aiq_agent.common.source_metadata import encode_source_metadata
+
+    return encode_source_metadata("\n".join(lines), refs)
 
 
 @register_function(config_type=KnowledgeRetrievalConfig)

--- a/sources/tavily_web_search/src/register.py
+++ b/sources/tavily_web_search/src/register.py
@@ -143,7 +143,16 @@ async def tavily_web_search(tool_config: TavilyWebSearchToolConfig, builder: Bui
                     ]
                 )
                 combined = answer_text + web_search_results
-                return combined if combined else "Search returned no results"
+                if not combined:
+                    return "Search returned no results"
+
+                from aiq_agent.common.source_metadata import SourceRef
+                from aiq_agent.common.source_metadata import encode_source_metadata
+
+                refs = [
+                    SourceRef(url=doc.get("url", ""), title=doc.get("title", "")) for doc in results if doc.get("url")
+                ]
+                return encode_source_metadata(combined, refs)
 
             except Exception as e:
                 if attempt == tool_config.max_retries - 1:

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Deep research agent using deepagents library for multi-phase workflow."""
 
@@ -23,9 +23,14 @@ from aiq_agent.common import LLMProvider
 from aiq_agent.common import LLMRole
 from aiq_agent.common import load_prompt
 from aiq_agent.common import render_prompt_template
+from aiq_agent.common.citation_verification import sanitize_report
+from aiq_agent.common.citation_verification import verify_citations
 
 from .custom_middleware import EmptyContentFixMiddleware
+from .custom_middleware import SourceRegistryMiddleware
 from .custom_middleware import ToolNameSanitizationMiddleware
+from .custom_middleware import ToolResultPruningMiddleware
+from .custom_middleware import ToolRetryMiddleware
 from .models import DeepResearchAgentState
 
 logger = logging.getLogger(__name__)
@@ -119,13 +124,44 @@ class DeepResearcherAgent:
         self.tools_info = []
         for t in self.tools:
             self.tools_info.append({"name": t.name, "description": t.description})
-        self.all_tools = [think, *self.tools]
+
+        self.source_registry_middleware = SourceRegistryMiddleware()
+
+        # Create a tool that gives the orchestrator access to verified sources
+        registry_middleware = self.source_registry_middleware
+
+        @tool
+        def get_verified_sources() -> str:
+            """Returns the list of all verified source URLs captured from search tool calls.
+
+            Call this tool during the Synthesize step (Step 5) BEFORE writing the
+            final report. It returns every URL and citation key that was returned
+            by search tools during research. Use ONLY these sources in your report
+            — any other URL will be automatically removed.
+
+            Returns:
+                A numbered list of verified sources with titles and URLs.
+            """
+            source_list = registry_middleware.get_source_list_text()
+            if source_list:
+                return source_list
+            return "No sources captured yet. Run research queries first."
+
+        self.all_tools = [think, get_verified_sources, *self.tools]
 
         self.middleware = [
             EmptyContentFixMiddleware(),
             ToolNameSanitizationMiddleware(valid_tool_names=[t.name for t in self.all_tools]),
+            ToolRetryMiddleware(max_retries=3, backoff_factor=2.0, initial_delay=1.0),
+            self.source_registry_middleware,
+            ToolResultPruningMiddleware(keep_last_n=3, max_chars=500),
             ModelRetryMiddleware(max_retries=10, backoff_factor=2.0, initial_delay=1.0),
         ]
+
+        # Share source registry with SSE callbacks for consistent citation tracking
+        for cb in self.callbacks:
+            if hasattr(cb, "set_source_registry"):
+                cb.set_source_registry(self.source_registry_middleware.registry)
 
     def _load_prompts(self) -> dict[str, str]:
         """Load all prompts for subagents."""
@@ -246,6 +282,27 @@ class DeepResearcherAgent:
         if not has_sources:
             return False, "missing_sources_section"
 
+        # Quick citation quality check — only reject if ALL citations are invalid
+        # (full verification with repair/renumbering happens in run() post-processing)
+        if self.source_registry_middleware.registry.all_sources():
+            from aiq_agent.common.citation_verification import _CITATION_LINE_RE
+            from aiq_agent.common.citation_verification import _REFERENCE_SECTION_RE
+            from aiq_agent.common.citation_verification import _URL_IN_LINE_RE
+
+            ref_match = _REFERENCE_SECTION_RE.search(content)
+            if ref_match:
+                ref_section = content[ref_match.start() :]
+                has_any_valid = False
+                for line_match in _CITATION_LINE_RE.finditer(ref_section):
+                    url_match = _URL_IN_LINE_RE.search(line_match.group(2))
+                    if url_match:
+                        url = url_match.group(0).rstrip(".,;)")
+                        if self.source_registry_middleware.registry.has_url(url):
+                            has_any_valid = True
+                            break
+                if not has_any_valid:
+                    return False, "no_valid_citations"
+
         giving_up_patterns = [
             "please confirm",
             "do you want me to",
@@ -315,6 +372,16 @@ class DeepResearcherAgent:
                     feedback_msg += "The report is too short. Expand your analysis and add more detail."
                 elif "missing_section_headers" in reason:
                     feedback_msg += "Use markdown headers (##) to structure the report."
+                elif "no_valid_citations" in reason:
+                    feedback_msg += (
+                        "None of your cited sources match actual tool results. "
+                        "Re-check your findings and cite only URLs returned by your search tools."
+                    )
+                    # Include the consolidated source list so the orchestrator
+                    # has an authoritative reference for the retry
+                    source_list = self.source_registry_middleware.get_source_list_text()
+                    if source_list:
+                        feedback_msg += "\n\n" + source_list
 
                 feedback_msg += " Please fix this immediately and call 'submit_final_report' when done."
 
@@ -337,6 +404,28 @@ class DeepResearcherAgent:
             if result and result.get("messages"):
                 final_content = result["messages"][-1].content
                 final_message = final_content if isinstance(final_content, str) else str(final_content)
+
+            # Post-process: verify citations against source registry
+            if self.source_registry_middleware.registry.all_sources():
+                verification = verify_citations(final_message, self.source_registry_middleware.registry)
+                if verification.removed_citations:
+                    logger.info(
+                        "Citation verification removed %d invalid citations: %s",
+                        len(verification.removed_citations),
+                        [c["reason"] for c in verification.removed_citations],
+                    )
+                final_message = verification.verified_report
+
+            # Post-process: sanitize report (strip body URLs, shortened URLs, unsafe URLs)
+            sanitization = sanitize_report(final_message)
+            final_message = sanitization.sanitized_report
+
+            if result and result.get("messages"):
+                last_msg = result["messages"][-1]
+                if hasattr(last_msg, "model_copy"):
+                    result["messages"][-1] = last_msg.model_copy(update={"content": final_message})
+                else:
+                    result["messages"][-1] = type(last_msg)(content=final_message)
 
             logger.info("=" * 80)
             logger.info("Deep Research Subagent: Workflow complete")

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -125,7 +125,9 @@ class DeepResearcherAgent:
         for t in self.tools:
             self.tools_info.append({"name": t.name, "description": t.description})
 
-        self.source_registry_middleware = SourceRegistryMiddleware()
+        self.source_registry_middleware = SourceRegistryMiddleware(
+            source_tool_names={t.name for t in self.tools},
+        )
 
         # Create a tool that gives the orchestrator access to verified sources
         registry_middleware = self.source_registry_middleware

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -305,9 +305,9 @@ class DeepResearcherAgent:
                             has_any_valid = True
                             break
                         continue
-                    # Check knowledge-layer citation keys
-                    is_kl, citation_key = _is_knowledge_citation(ref_text)
-                    if is_kl and citation_key and registry.has_citation_key(citation_key):
+                    # Check knowledge-layer citation keys (lenient — passes registry for fuzzy match)
+                    is_kl, citation_key = _is_knowledge_citation(ref_text, registry)
+                    if is_kl and citation_key:
                         has_any_valid = True
                         break
                 if not has_any_valid:

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -288,18 +288,28 @@ class DeepResearcherAgent:
             from aiq_agent.common.citation_verification import _CITATION_LINE_RE
             from aiq_agent.common.citation_verification import _REFERENCE_SECTION_RE
             from aiq_agent.common.citation_verification import _URL_IN_LINE_RE
+            from aiq_agent.common.citation_verification import _is_knowledge_citation
 
             ref_match = _REFERENCE_SECTION_RE.search(content)
             if ref_match:
                 ref_section = content[ref_match.start() :]
                 has_any_valid = False
+                registry = self.source_registry_middleware.registry
                 for line_match in _CITATION_LINE_RE.finditer(ref_section):
-                    url_match = _URL_IN_LINE_RE.search(line_match.group(2))
+                    ref_text = line_match.group(2).strip()
+                    # Check URL citations
+                    url_match = _URL_IN_LINE_RE.search(ref_text)
                     if url_match:
                         url = url_match.group(0).rstrip(".,;)")
-                        if self.source_registry_middleware.registry.has_url(url):
+                        if registry.has_url(url):
                             has_any_valid = True
                             break
+                        continue
+                    # Check knowledge-layer citation keys
+                    is_kl, citation_key = _is_knowledge_citation(ref_text)
+                    if is_kl and citation_key and registry.has_citation_key(citation_key):
+                        has_any_valid = True
+                        break
                 if not has_any_valid:
                     return False, "no_valid_citations"
 

--- a/src/aiq_agent/agents/deep_researcher/custom_middleware.py
+++ b/src/aiq_agent/agents/deep_researcher/custom_middleware.py
@@ -200,19 +200,6 @@ class ToolRetryMiddleware(AgentMiddleware):
         raise last_exception
 
 
-_INTERNAL_TOOLS = {
-    "think",
-    "get_verified_sources",
-    "write_todos",
-    "write_file",
-    "read_file",
-    "grep",
-    "ls",
-    "task",
-    "submit_final_report",
-}
-
-
 class SourceRegistryMiddleware(AgentMiddleware):
     """Intercepts tool call results to build a registry of actual sources.
 
@@ -222,16 +209,18 @@ class SourceRegistryMiddleware(AgentMiddleware):
        so the orchestrator has a single, authoritative reference list when
        writing the final report (no manual reconciliation across subagent files)
 
-    Internal tools (think, write_file, etc.) are skipped to prevent
-    LLM-hallucinated URLs in reasoning from polluting the registry.
-    Any user-added search tools are captured automatically.
+    Only tools whose names appear in ``source_tool_names`` contribute to the
+    registry.  This set is derived from the YAML config at construction time,
+    so user-added search tools are captured automatically and no internal-tool
+    blocklist needs to be maintained.
 
     The registry is also used by verify_citations() to strip fabricated,
     stale, or intermediate-artifact citations from the final report.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, source_tool_names: set[str] | None = None) -> None:
         self.registry = SourceRegistry()
+        self._source_tool_names = source_tool_names or set()
 
     async def awrap_tool_call(self, request, handler):
         """Capture sources from tool results after execution."""
@@ -240,7 +229,7 @@ class SourceRegistryMiddleware(AgentMiddleware):
             tool_name = ""
             if hasattr(request, "tool_call") and isinstance(request.tool_call, dict):
                 tool_name = request.tool_call.get("name", "")
-            if tool_name in _INTERNAL_TOOLS:
+            if tool_name not in self._source_tool_names:
                 return result
             sources = extract_sources_from_tool_result(tool_name, str(result.content))
             for source in sources:

--- a/src/aiq_agent/agents/deep_researcher/custom_middleware.py
+++ b/src/aiq_agent/agents/deep_researcher/custom_middleware.py
@@ -200,14 +200,31 @@ class ToolRetryMiddleware(AgentMiddleware):
         raise last_exception
 
 
+_INTERNAL_TOOLS = {
+    "think",
+    "get_verified_sources",
+    "write_todos",
+    "write_file",
+    "read_file",
+    "grep",
+    "ls",
+    "task",
+    "submit_final_report",
+}
+
+
 class SourceRegistryMiddleware(AgentMiddleware):
     """Intercepts tool call results to build a registry of actual sources.
 
     Two responsibilities:
-    1. awrap_tool_call: Capture URLs/citation keys from every tool result
+    1. awrap_tool_call: Capture URLs/citation keys from tool results
     2. awrap_model_call: Inject a consolidated source list into the LLM context
        so the orchestrator has a single, authoritative reference list when
        writing the final report (no manual reconciliation across subagent files)
+
+    Internal tools (think, write_file, etc.) are skipped to prevent
+    LLM-hallucinated URLs in reasoning from polluting the registry.
+    Any user-added search tools are captured automatically.
 
     The registry is also used by verify_citations() to strip fabricated,
     stale, or intermediate-artifact citations from the final report.
@@ -223,6 +240,8 @@ class SourceRegistryMiddleware(AgentMiddleware):
             tool_name = ""
             if hasattr(request, "tool_call") and isinstance(request.tool_call, dict):
                 tool_name = request.tool_call.get("name", "")
+            if tool_name in _INTERNAL_TOOLS:
+                return result
             sources = extract_sources_from_tool_result(tool_name, str(result.content))
             for source in sources:
                 self.registry.add(source)

--- a/src/aiq_agent/agents/deep_researcher/custom_middleware.py
+++ b/src/aiq_agent/agents/deep_researcher/custom_middleware.py
@@ -15,14 +15,24 @@
 
 """Custom middleware for the deep research agent."""
 
+import asyncio
 import logging
+from pathlib import Path
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelResponse
 from langchain_core.messages import AIMessage
 from langchain_core.messages import ToolMessage
 
+from aiq_agent.common import load_prompt
+from aiq_agent.common import render_prompt_template
+from aiq_agent.common.citation_verification import SourceRegistry
+from aiq_agent.common.citation_verification import extract_sources_from_tool_result
+
 logger = logging.getLogger(__name__)
+
+# Path to this agent's prompts directory
+_PROMPTS_DIR = Path(__file__).parent / "prompts"
 
 
 class EmptyContentFixMiddleware(AgentMiddleware):
@@ -147,3 +157,173 @@ class ToolNameSanitizationMiddleware(AgentMiddleware):
                 new_result.append(msg)
 
         return ModelResponse(result=new_result, structured_response=response.structured_response)
+
+
+class ToolRetryMiddleware(AgentMiddleware):
+    """Retries failed tool calls with exponential backoff.
+
+    Provides uniform retry coverage for all tools. Some tools (e.g., Tavily)
+    have their own internal retry; this middleware wraps the outer call so
+    tools without retry (knowledge layer, paper search) are also covered.
+    """
+
+    def __init__(
+        self,
+        max_retries: int = 3,
+        backoff_factor: float = 2.0,
+        initial_delay: float = 1.0,
+    ):
+        self.max_retries = max_retries
+        self.backoff_factor = backoff_factor
+        self.initial_delay = initial_delay
+
+    async def awrap_tool_call(self, request, handler):
+        """Retry tool calls on failure with exponential backoff."""
+        delay = self.initial_delay
+        last_exception = None
+        for attempt in range(self.max_retries + 1):
+            try:
+                return await handler(request)
+            except Exception as e:
+                last_exception = e
+                if attempt < self.max_retries:
+                    tool_name = request.tool_call.get("name", "?") if hasattr(request, "tool_call") else "?"
+                    logger.warning(
+                        "Tool %s failed (attempt %d/%d): %s",
+                        tool_name,
+                        attempt + 1,
+                        self.max_retries + 1,
+                        e,
+                    )
+                    await asyncio.sleep(delay)
+                    delay *= self.backoff_factor
+        raise last_exception
+
+
+class SourceRegistryMiddleware(AgentMiddleware):
+    """Intercepts tool call results to build a registry of actual sources.
+
+    Two responsibilities:
+    1. awrap_tool_call: Capture URLs/citation keys from every tool result
+    2. awrap_model_call: Inject a consolidated source list into the LLM context
+       so the orchestrator has a single, authoritative reference list when
+       writing the final report (no manual reconciliation across subagent files)
+
+    The registry is also used by verify_citations() to strip fabricated,
+    stale, or intermediate-artifact citations from the final report.
+    """
+
+    def __init__(self) -> None:
+        self.registry = SourceRegistry()
+
+    async def awrap_tool_call(self, request, handler):
+        """Capture sources from tool results after execution."""
+        result = await handler(request)
+        if isinstance(result, ToolMessage) and result.content:
+            tool_name = ""
+            if hasattr(request, "tool_call") and isinstance(request.tool_call, dict):
+                tool_name = request.tool_call.get("name", "")
+            sources = extract_sources_from_tool_result(tool_name, str(result.content))
+            for source in sources:
+                self.registry.add(source)
+            if sources:
+                logger.info(
+                    "[CitationRegistry] Captured %d source(s) from %s: %s",
+                    len(sources),
+                    tool_name,
+                    [s.url or s.citation_key for s in sources],
+                )
+        return result
+
+    def get_source_list_text(self) -> str | None:
+        """Build a consolidated source list for injection into retry feedback.
+
+        Returns rendered template text, or None if no sources captured.
+        Used by agent.run() to include the source list in retry messages
+        when citation quality is poor.
+        """
+        from urllib.parse import urlparse
+
+        from aiq_agent.common.citation_verification import _normalize_url
+
+        sources = self.registry.all_sources()
+        if not sources:
+            return None
+
+        seen: set[str] = set()
+        template_sources = []
+        for entry in sources:
+            if entry.url:
+                normalized = _normalize_url(entry.url)
+                if normalized in seen:
+                    continue
+                seen.add(normalized)
+                if entry.title:
+                    title = entry.title
+                else:
+                    try:
+                        title = urlparse(entry.url).netloc.replace("www.", "")
+                    except Exception:
+                        title = entry.url
+                template_sources.append({"title": title, "url": entry.url})
+            elif entry.citation_key:
+                key = entry.citation_key
+                if key in seen:
+                    continue
+                seen.add(key)
+                template_sources.append({"title": key, "url": key})
+
+        if not template_sources:
+            return None
+
+        try:
+            template = load_prompt(_PROMPTS_DIR, "source_registry")
+            return render_prompt_template(template, sources=template_sources)
+        except Exception:
+            logger.warning("Failed to load source_registry prompt template", exc_info=True)
+            return None
+
+
+class ToolResultPruningMiddleware(AgentMiddleware):
+    """Truncates older tool results to keep context manageable.
+
+    Keeps the last N tool results intact and truncates older ones to
+    reduce "lost in the middle" degradation. Operates on awrap_model_call
+    so the full results are still available for SourceRegistryMiddleware.
+    """
+
+    def __init__(self, keep_last_n: int = 3, max_chars: int = 500):
+        self.keep_last_n = keep_last_n
+        self.max_chars = max_chars
+
+    async def awrap_model_call(self, request, handler):
+        """Truncate older ToolMessage content before sending to the model."""
+        # Find all ToolMessage indices
+        tool_indices = [i for i, msg in enumerate(request.messages) if isinstance(msg, ToolMessage)]
+
+        if len(tool_indices) <= self.keep_last_n:
+            return await handler(request)
+
+        # Indices to truncate: all but the last keep_last_n
+        truncate_indices = set(tool_indices[: -self.keep_last_n])
+
+        pruned_messages = []
+        for i, msg in enumerate(request.messages):
+            if i in truncate_indices and isinstance(msg, ToolMessage) and msg.content:
+                content = str(msg.content)
+                if len(content) > self.max_chars:
+                    truncated_content = content[: self.max_chars] + "\n\n[... truncated ...]"
+                    pruned_messages.append(
+                        ToolMessage(
+                            content=truncated_content,
+                            tool_call_id=msg.tool_call_id,
+                            name=getattr(msg, "name", None),
+                            id=msg.id,
+                        )
+                    )
+                else:
+                    pruned_messages.append(msg)
+            else:
+                pruned_messages.append(msg)
+
+        return await handler(request.override(messages=pruned_messages))

--- a/src/aiq_agent/agents/deep_researcher/custom_middleware.py
+++ b/src/aiq_agent/agents/deep_researcher/custom_middleware.py
@@ -26,6 +26,7 @@ from langchain_core.messages import ToolMessage
 
 from aiq_agent.common import load_prompt
 from aiq_agent.common import render_prompt_template
+from aiq_agent.common.citation_verification import SourceEntry
 from aiq_agent.common.citation_verification import SourceRegistry
 from aiq_agent.common.citation_verification import extract_sources_from_tool_result
 
@@ -223,7 +224,14 @@ class SourceRegistryMiddleware(AgentMiddleware):
         self._source_tool_names = source_tool_names or set()
 
     async def awrap_tool_call(self, request, handler):
-        """Capture sources from tool results after execution."""
+        """Capture sources from tool results after execution.
+
+        Prefers structured metadata (encoded by tools via encode_source_metadata)
+        over regex extraction.  Strips the metadata block from the content so
+        the LLM never sees it.
+        """
+        from aiq_agent.common.source_metadata import extract_source_metadata
+
         result = await handler(request)
         if isinstance(result, ToolMessage) and result.content:
             tool_name = ""
@@ -231,16 +239,43 @@ class SourceRegistryMiddleware(AgentMiddleware):
                 tool_name = request.tool_call.get("name", "")
             if tool_name not in self._source_tool_names:
                 return result
-            sources = extract_sources_from_tool_result(tool_name, str(result.content))
-            for source in sources:
-                self.registry.add(source)
-            if sources:
+
+            content = str(result.content)
+            clean_content, refs = extract_source_metadata(content)
+
+            if refs:
+                for ref in refs:
+                    entry = SourceEntry(
+                        url=ref.url,
+                        title=ref.title,
+                        citation_key=ref.citation_key,
+                        source_type="structured",
+                        tool_name=tool_name,
+                    )
+                    self.registry.add(entry)
                 logger.info(
-                    "[CitationRegistry] Captured %d source(s) from %s: %s",
-                    len(sources),
+                    "[CitationRegistry] Captured %d structured source(s) from %s: %s",
+                    len(refs),
                     tool_name,
-                    [s.url or s.citation_key for s in sources],
+                    [r.url or r.citation_key for r in refs],
                 )
+                result = ToolMessage(
+                    content=clean_content,
+                    tool_call_id=result.tool_call_id,
+                    name=getattr(result, "name", None),
+                    id=result.id,
+                )
+            elif refs is None:
+                sources = extract_sources_from_tool_result(tool_name, content)
+                for source in sources:
+                    self.registry.add(source)
+                if sources:
+                    logger.info(
+                        "[CitationRegistry] Captured %d source(s) from %s via regex: %s",
+                        len(sources),
+                        tool_name,
+                        [s.url or s.citation_key for s in sources],
+                    )
         return result
 
     def get_source_list_text(self) -> str | None:

--- a/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
@@ -130,6 +130,7 @@ The report must read as if written by a professional human researcher.
 ## Citation Guidelines
 - Number sources sequentially [1][2], etc. for in-text citations
 - Place citations immediately following the relevant information
+- Never place bare URLs or hyperlinks in the report body — use only [N] citations inline. URLs belong exclusively in the References section.
 - For information supported by multiple sources, use [1][4][7]
 - Include the full reference list at the end of the document
 - Assign each unique URL a single citation number across ALL sub-agent findings

--- a/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
@@ -124,6 +124,8 @@ Use `think` tool to verify constraints after each researcher call and before fin
 - Methodology sections or meta-commentary about the report
 - Statements like "the user requested" or "this report satisfies"
 - Word counts or length statements
+- Internal tool names (e.g., get_verified_sources, advanced_web_search_tool, write_file, think, task) — these are implementation details invisible to the reader
+- Descriptions of how sources were gathered, verified, or validated — the reader sees only the final citations, not the process
 
 The report must read as if written by a professional human researcher.
 

--- a/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
@@ -128,19 +128,25 @@ Use `think` tool to verify constraints after each researcher call and before fin
 The report must read as if written by a professional human researcher.
 
 ## Citation Guidelines
+- Number sources sequentially [1][2], etc. for in-text citations
+- Place citations immediately following the relevant information
+- For information supported by multiple sources, use [1][4][7]
+- Include the full reference list at the end of the document
+- Assign each unique URL a single citation number across ALL sub-agent findings
+- Number sources sequentially without gaps (1,2,3,4...)
+- For internal documents(from knowledge_search): `- [N] filename.pdf, p.X` - use the Citation field verbatim, include page numbers
+- Do NOT invent or recall URLs from memory — use only URLs from `get_verified_sources` or researcher findings
+- Citations are automatically verified and renumbered by the system
 
-**CRITICAL: Do NOT invent or recall URLs from memory.** Call `get_verified_sources` during Step 5 to get the authoritative source list. Use ONLY those URLs in your report — any other URL will be automatically removed.
+### Format of References section: [1] Source Title: URL (each on separate line for proper list rendering)
+- Example:
 
-### How to cite
-- Cite sources inline with [1][2], etc. immediately after the relevant information
-- For multiple sources supporting one claim, use [1][4][7]
-- For internal documents (from knowledge_search): `[N] filename.pdf, p.X` — use the Citation field verbatim
+  Some important finding [1]. Another key insight [2]. A final comprehensive discussion [3]
 
-### Sources section
-Include `### Sources` at the end listing all referenced sources, one per line:
-  [1] Source Title: URL
-
-Citations are automatically verified and renumbered — focus on content quality, not citation perfection.
+  ### Sources
+  [1] internal-report.pdf, p.15
+  [2] AI Research Paper: https://example.com/paper
+  [3] Industry Analysis: https://example.com/analysis
 
 
 **Important**:

--- a/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
@@ -30,7 +30,7 @@ Step 1. **Task Decomposition and Progress Tracking**: Use `write_todos` to track
 Step 2. **Planning**: Delegate research planning to the planner-agent using the task() tool to generate task analysis, TOC, constraints, and queries.
 Step 3. **Research**: Read the generated plan using read_file /shared/plan.json, then delegate up to 6 researcher-agent calls for the queries from the plan using the task() tool. ALWAYS use the researcher-agent for research; never conduct search yourself and never re-delegate to the planner-agent.
 Step 4. **Verify after each researcher**: Use `think` tool to check and note down if findings satisfy constraints.
-Step 5. **Synthesize**: Use ls /shared/, read_file and grep to discover all research notes and sub-agent findings and consolidate citations. Use the `think` tool to record your observations / synthesis.
+Step 5. **Synthesize**: Use ls /shared/, read_file and grep to discover all research notes and sub-agent findings. Then call `get_verified_sources` to get the authoritative list of all URLs captured from search tools — use ONLY these URLs in your report. Use the `think` tool to record your synthesis observations.
 Step 6. **Write report**: Write a comprehensive, in-depth, long-form report following the TOC and satisfying constraints. 
 Step 7. **Final verification**: Use `think` tool to review constraints, note any gaps, proceed with best-effort report. Make sure that:
    - All TOC sections from planner are covered
@@ -128,23 +128,19 @@ Use `think` tool to verify constraints after each researcher call and before fin
 The report must read as if written by a professional human researcher.
 
 ## Citation Guidelines
-- Number sources sequentially [1][2], etc. for in-text citations
-- Place citations immediately following the relevant information
-- For information supported by multiple sources, use [1][4][7]
-- Include the full reference list at the end of the document
-- Assign each unique URL a single citation number across ALL sub-agent findings
-- Number sources sequentially without gaps (1,2,3,4...)
-- For internal documents(from knowledge_search): `- [N] filename.pdf, p.X` - use the Citation field verbatim, include page numbers
 
-### Format of References section: [1] Source Title: URL (each on separate line for proper list rendering)
-- Example:
+**CRITICAL: Do NOT invent or recall URLs from memory.** Call `get_verified_sources` during Step 5 to get the authoritative source list. Use ONLY those URLs in your report — any other URL will be automatically removed.
 
-  Some important finding [1]. Another key insight [2]. A final comprehensive discussion [3]
+### How to cite
+- Cite sources inline with [1][2], etc. immediately after the relevant information
+- For multiple sources supporting one claim, use [1][4][7]
+- For internal documents (from knowledge_search): `[N] filename.pdf, p.X` — use the Citation field verbatim
 
-  ### Sources
-  [1] internal-report.pdf, p.15
-  [2] AI Research Paper: https://example.com/paper
-  [3] Industry Analysis: https://example.com/analysis
+### Sources section
+Include `### Sources` at the end listing all referenced sources, one per line:
+  [1] Source Title: URL
+
+Citations are automatically verified and renumbered — focus on content quality, not citation perfection.
 
 
 **Important**:
@@ -156,7 +152,6 @@ Before outputting the final report to the user:
 1. Invoke write_todos to mark ALL todo items as "completed" but do not include this in your final message.
 2. Verify report meets length requirement (4000+ words)
 3. Verify all sections from the planner's TOC are covered
-4. Verify all citations are properly numbered with no placeholders
-5. Verify sources section lists all referenced URLs
+4. Verify sources section is present (citations are auto-verified by the system)
 
 Write final report using write_file to /report.md. Return ONLY the final report without anything else now.

--- a/src/aiq_agent/agents/deep_researcher/prompts/researcher.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/researcher.j2
@@ -79,7 +79,10 @@ Your output will be used to write a long-form report. Produce **in-depth, detail
 <be comprehensive - include all relevant details>
 
 **Sources**
-<list the sources you used here>
+List every source used, one per line, using ONLY URLs from search tool results:
+[1] Source Title: URL
+[2] Source Title: URL
+Do NOT add URLs from memory — only use URLs that appeared in tool call responses.
 
 Write this output using write_file to /shared/[query_topic_x].txt and return.
 Paths are VIRTUAL.

--- a/src/aiq_agent/agents/deep_researcher/prompts/source_registry.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/source_registry.j2
@@ -1,0 +1,6 @@
+## Consolidated Source Registry (auto-generated from tool calls)
+Use ONLY these sources when writing the final report. Each has been verified as a real tool result. You may use these [N] numbers directly or assign your own — citations will be auto-verified and renumbered.
+
+{% for source in sources %}
+[{{ loop.index }}] {{ source.title }}: {{ source.url }}
+{% endfor %}

--- a/src/aiq_agent/agents/shallow_researcher/agent.py
+++ b/src/aiq_agent/agents/shallow_researcher/agent.py
@@ -229,12 +229,30 @@ class ShallowResearcherAgent:
 
         tool_node = ToolNode(self.tools)
 
+        _internal_tools = {
+            "think",
+            "get_verified_sources",
+            "write_todos",
+            "write_file",
+            "read_file",
+            "grep",
+            "ls",
+            "task",
+            "submit_final_report",
+        }
+
         async def tool_node_with_source_capture(state: ShallowResearchAgentState) -> dict[str, Any]:
-            """Execute tools and capture source URLs/citations for verification."""
+            """Execute tools and capture source URLs/citations for verification.
+
+            Internal tools (think, write_file, etc.) are skipped to prevent
+            LLM-hallucinated URLs from polluting the registry.
+            """
             result = await tool_node.ainvoke(state)
             for msg in result.get("messages", []):
                 if isinstance(msg, ToolMessage) and msg.content:
                     tool_name = getattr(msg, "name", "") or ""
+                    if tool_name in _internal_tools:
+                        continue
                     sources = extract_sources_from_tool_result(tool_name, str(msg.content))
                     for source in sources:
                         self.source_registry.add(source)

--- a/src/aiq_agent/agents/shallow_researcher/agent.py
+++ b/src/aiq_agent/agents/shallow_researcher/agent.py
@@ -234,25 +234,60 @@ class ShallowResearcherAgent:
         async def tool_node_with_source_capture(state: ShallowResearchAgentState) -> dict[str, Any]:
             """Execute tools and capture source URLs/citations for verification.
 
-            Only config-defined source tools contribute to the registry;
-            internal tools are ignored automatically.
+            Prefers structured metadata over regex extraction.  Strips the
+            metadata block from the content so the LLM never sees it.
             """
+            from aiq_agent.common.citation_verification import SourceEntry
+            from aiq_agent.common.source_metadata import extract_source_metadata
+
             result = await tool_node.ainvoke(state)
+            new_messages = []
             for msg in result.get("messages", []):
                 if isinstance(msg, ToolMessage) and msg.content:
                     tool_name = getattr(msg, "name", "") or ""
                     if tool_name not in _source_tool_names:
+                        new_messages.append(msg)
                         continue
-                    sources = extract_sources_from_tool_result(tool_name, str(msg.content))
-                    for source in sources:
-                        self.source_registry.add(source)
-                    if sources:
+
+                    content = str(msg.content)
+                    clean_content, refs = extract_source_metadata(content)
+
+                    if refs:
+                        for ref in refs:
+                            self.source_registry.add(
+                                SourceEntry(
+                                    url=ref.url,
+                                    title=ref.title,
+                                    citation_key=ref.citation_key,
+                                    source_type="structured",
+                                    tool_name=tool_name,
+                                )
+                            )
                         logger.info(
-                            "[CitationRegistry] Captured %d source(s) from %s: %s",
-                            len(sources),
+                            "[CitationRegistry] Captured %d structured source(s) from %s: %s",
+                            len(refs),
                             tool_name,
-                            [s.url or s.citation_key for s in sources],
+                            [r.url or r.citation_key for r in refs],
                         )
+                        msg = ToolMessage(
+                            content=clean_content,
+                            tool_call_id=msg.tool_call_id,
+                            name=getattr(msg, "name", None),
+                            id=msg.id,
+                        )
+                    elif refs is None:
+                        sources = extract_sources_from_tool_result(tool_name, content)
+                        for source in sources:
+                            self.source_registry.add(source)
+                        if sources:
+                            logger.info(
+                                "[CitationRegistry] Captured %d source(s) from %s via regex: %s",
+                                len(sources),
+                                tool_name,
+                                [s.url or s.citation_key for s in sources],
+                            )
+                new_messages.append(msg)
+            result["messages"] = new_messages
             return result
 
         builder.add_node("agent", agent_node)

--- a/src/aiq_agent/agents/shallow_researcher/agent.py
+++ b/src/aiq_agent/agents/shallow_researcher/agent.py
@@ -27,6 +27,7 @@ from typing import Any
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage
 from langchain_core.messages import SystemMessage
+from langchain_core.messages import ToolMessage
 from langchain_core.tools import BaseTool
 from langgraph.graph import StateGraph
 from langgraph.graph.state import CompiledStateGraph
@@ -35,6 +36,10 @@ from langgraph.prebuilt import tools_condition
 
 from aiq_agent.common import load_prompt
 from aiq_agent.common import render_prompt_template
+from aiq_agent.common.citation_verification import SourceRegistry
+from aiq_agent.common.citation_verification import extract_sources_from_tool_result
+from aiq_agent.common.citation_verification import sanitize_report
+from aiq_agent.common.citation_verification import verify_citations
 
 from ...common import LLMProvider
 from ...common import LLMRole
@@ -106,6 +111,14 @@ class ShallowResearcherAgent:
 
         # Build tools info for prompt rendering
         self.tools_info = self._build_tools_info()
+
+        # Source registry for citation verification
+        self.source_registry = SourceRegistry()
+
+        # Share source registry with SSE callbacks for consistent citation tracking
+        for cb in self.callbacks:
+            if hasattr(cb, "set_source_registry"):
+                cb.set_source_registry(self.source_registry)
 
         # Build the LangGraph
         self._graph = self._build_graph()
@@ -214,8 +227,28 @@ class ShallowResearcherAgent:
 
         builder.set_entry_point("agent")
 
+        tool_node = ToolNode(self.tools)
+
+        async def tool_node_with_source_capture(state: ShallowResearchAgentState) -> dict[str, Any]:
+            """Execute tools and capture source URLs/citations for verification."""
+            result = await tool_node.ainvoke(state)
+            for msg in result.get("messages", []):
+                if isinstance(msg, ToolMessage) and msg.content:
+                    tool_name = getattr(msg, "name", "") or ""
+                    sources = extract_sources_from_tool_result(tool_name, str(msg.content))
+                    for source in sources:
+                        self.source_registry.add(source)
+                    if sources:
+                        logger.info(
+                            "[CitationRegistry] Captured %d source(s) from %s: %s",
+                            len(sources),
+                            tool_name,
+                            [s.url or s.citation_key for s in sources],
+                        )
+            return result
+
         builder.add_node("agent", agent_node)
-        builder.add_node("tools", ToolNode(self.tools))
+        builder.add_node("tools", tool_node_with_source_capture)
 
         builder.add_conditional_edges(
             "agent",
@@ -236,12 +269,41 @@ class ShallowResearcherAgent:
         Returns:
             Updated state with response in messages.
         """
+        self.source_registry.clear()
+
         recursion_limit = (self.max_llm_turns * 2) + 10
         config = {"recursion_limit": recursion_limit}
         if self.callbacks:
             config["callbacks"] = self.callbacks
         result = await self._graph.ainvoke(state, config=config)
-        return ShallowResearchAgentState.model_validate(result)
+
+        # Post-process: verify citations against source registry
+        validated_result = dict(result)
+        if validated_result.get("messages"):
+            last_msg = validated_result["messages"][-1]
+            if hasattr(last_msg, "content") and last_msg.content:
+                content = str(last_msg.content)
+
+                # Step 1: verify citations against registry
+                if self.source_registry.all_sources():
+                    verification = verify_citations(content, self.source_registry)
+                    if verification.removed_citations:
+                        logger.info(
+                            "Shallow researcher: removed %d invalid citations",
+                            len(verification.removed_citations),
+                        )
+                    content = verification.verified_report
+
+                # Step 2: sanitize report (strip body URLs, shortened URLs, unsafe URLs)
+                sanitization = sanitize_report(content)
+                content = sanitization.sanitized_report
+
+                if hasattr(last_msg, "model_copy"):
+                    validated_result["messages"][-1] = last_msg.model_copy(update={"content": content})
+                else:
+                    validated_result["messages"][-1] = type(last_msg)(content=content)
+
+        return ShallowResearchAgentState.model_validate(validated_result)
 
     @property
     def graph(self) -> CompiledStateGraph:

--- a/src/aiq_agent/agents/shallow_researcher/agent.py
+++ b/src/aiq_agent/agents/shallow_researcher/agent.py
@@ -229,29 +229,19 @@ class ShallowResearcherAgent:
 
         tool_node = ToolNode(self.tools)
 
-        _internal_tools = {
-            "think",
-            "get_verified_sources",
-            "write_todos",
-            "write_file",
-            "read_file",
-            "grep",
-            "ls",
-            "task",
-            "submit_final_report",
-        }
+        _source_tool_names = {t.name for t in self.tools}
 
         async def tool_node_with_source_capture(state: ShallowResearchAgentState) -> dict[str, Any]:
             """Execute tools and capture source URLs/citations for verification.
 
-            Internal tools (think, write_file, etc.) are skipped to prevent
-            LLM-hallucinated URLs from polluting the registry.
+            Only config-defined source tools contribute to the registry;
+            internal tools are ignored automatically.
             """
             result = await tool_node.ainvoke(state)
             for msg in result.get("messages", []):
                 if isinstance(msg, ToolMessage) and msg.content:
                     tool_name = getattr(msg, "name", "") or ""
-                    if tool_name in _internal_tools:
+                    if tool_name not in _source_tool_names:
                         continue
                     sources = extract_sources_from_tool_result(tool_name, str(msg.content))
                     for source in sources:

--- a/src/aiq_agent/agents/shallow_researcher/prompts/researcher.j2
+++ b/src/aiq_agent/agents/shallow_researcher/prompts/researcher.j2
@@ -74,14 +74,8 @@ Pass the **rewritten query** to the search tool. This greatly improves result re
 {% endif %}
 
 {#- 5. CITATION & FORMATTING -#}
-## Citation Rules (STRICT)
-Every claim must end with [1]. You MUST include a `**References:**` section.
-- **Format**: `- [N] Title/Filename - URL/Citation`
-
-
-
-**Example**:
-"The uploaded report shows a 5% margin [1].
-
-**References:**
-- [1] Q4_Review.pdf, p. 2 (Internal)"
+## Citation Rules
+Cite sources inline with [1], [2], etc. Include a `**References:**` section at the end.
+- **Format**: `- [N] Title - URL` or `- [N] filename.pdf, p.X` for internal documents
+- Use only URLs that appeared in tool results. Do not add URLs from memory.
+- Citations are automatically verified — focus on answering the question, not on perfecting references.

--- a/src/aiq_agent/agents/shallow_researcher/prompts/researcher.j2
+++ b/src/aiq_agent/agents/shallow_researcher/prompts/researcher.j2
@@ -79,3 +79,9 @@ Cite sources inline with [1], [2], etc. Include a `**References:**` section at t
 - **Format**: `- [N] Title - URL` or `- [N] filename.pdf, p.X` for internal documents
 - Use only URLs that appeared in tool results. Do not add URLs from memory.
 - Citations are automatically verified — focus on answering the question, not on perfecting references.
+
+**Example**:
+"The uploaded report shows a 5% margin [1].
+
+**References:**
+- [1] Q4_Review.pdf, p. 2 (Internal)"

--- a/src/aiq_agent/common/__init__.py
+++ b/src/aiq_agent/common/__init__.py
@@ -35,6 +35,10 @@ from nat.data_models.api_server import Usage
 from nat.data_models.api_server import UserMessageContentRoleType
 
 from .callbacks import VerboseTraceCallback
+from .citation_verification import SourceRegistry
+from .citation_verification import register_source_parser
+from .citation_verification import sanitize_report
+from .citation_verification import verify_citations
 from .data_sources import DEFAULT_DATA_SOURCES
 from .data_sources import extract_messages_and_sources
 from .data_sources import filter_tools_by_sources
@@ -59,6 +63,7 @@ __all__ = [
     "DEFAULT_DATA_SOURCES",
     "LLMProvider",
     "LLMRole",
+    "SourceRegistry",
     "VerboseTraceCallback",
     "extract_json",
     "extract_messages_and_sources",
@@ -70,8 +75,11 @@ __all__ = [
     "is_postgres_dsn",
     "load_prompt",
     "parse_data_sources",
+    "register_source_parser",
     "render_prompt_template",
+    "sanitize_report",
     "validate_tool_availability",
+    "verify_citations",
 ]
 
 

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -745,6 +745,15 @@ def sanitize_report(report_text: str) -> ReportSanitizationResult:
 
     sanitized_report = cleaned_body + ref_section
 
+    # --- Strip leaked tool-call XML fragments ---
+    # LLMs sometimes output raw tool-call syntax as text
+    sanitized_report = re.sub(
+        r"</?(parameter|function|tool_call|tool_use|invoke|antml:[\w]+)[\s>].*",
+        "",
+        sanitized_report,
+        flags=re.DOTALL,
+    )
+
     # --- Trim everything after the last citation in the Sources section ---
     # The LLM often appends meta-commentary after the references (e.g.,
     # "All citations refer to...", "This report meets..."). Rather than

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -194,14 +194,18 @@ class SourceRegistry:
         return None
 
     def has_citation_key(self, key: str) -> bool:
-        """Fuzzy-match a citation key against registry entries.
+        """Lenient match of a citation key against registry entries.
 
-        Matches if filename (case-insensitive) and page number both match.
+        Matches if filename (case-insensitive) matches ANY registry entry.
+        Page numbers are not required to match — the LLM may cite a different
+        page than what the knowledge layer returned, and that's acceptable
+        since the document itself was verified as a real source.
         """
-        target_file, target_page = _parse_citation_key(key)
+        target_file, _ = _parse_citation_key(key)
+        target_lower = target_file.lower()
         for entry in self._citation_keys:
-            entry_file, entry_page = _parse_citation_key(entry.citation_key)
-            if entry_file.lower() == target_file.lower() and entry_page == target_page:
+            entry_file, _ = _parse_citation_key(entry.citation_key)
+            if entry_file.lower() == target_lower:
                 return True
         return False
 
@@ -370,18 +374,36 @@ _URL_IN_LINE_RE = re.compile(r"https?://\S+")
 _KL_CITATION_PATTERN_RE = re.compile(r"^(.+\.\w{2,5})(?:,\s*(?:p\.?|page)\s*\d+)?$", re.IGNORECASE)
 
 
-def _is_knowledge_citation(ref_text: str) -> tuple[bool, str | None]:
+def _is_knowledge_citation(ref_text: str, registry: SourceRegistry | None = None) -> tuple[bool, str | None]:
     """Check if reference text looks like a knowledge-layer citation.
+
+    Uses a lenient matching strategy:
+    1. Try exact pattern match (filename.ext, p.N) after stripping markdown
+    2. If a registry is provided, check if ANY registered citation key's
+       filename appears anywhere in the reference text (very lenient —
+       handles all formatting variations the LLM might produce)
 
     Returns (is_kl, citation_key_or_none).
     """
     # Strip trailing "(Internal)" or similar parenthetical
     cleaned = re.sub(r"\s*\(.*?\)\s*$", "", ref_text).strip()
+    # Strip markdown bold/italic markers only (*, **) — preserve underscores in filenames
+    cleaned = re.sub(r"\*+", "", cleaned).strip()
     # Remove leading "Title - " or "Title: " prefix by taking last segment
     # if it contains a filename pattern
     for segment in [cleaned, cleaned.split(" - ")[-1].strip(), cleaned.split(": ")[-1].strip()]:
         if _KL_CITATION_PATTERN_RE.match(segment):
             return True, segment
+
+    # Lenient fallback: check if any registered knowledge-layer filename
+    # appears in the reference text (handles arbitrary LLM formatting)
+    if registry is not None:
+        ref_lower = cleaned.lower()
+        for entry in registry._citation_keys:
+            entry_file, _ = _parse_citation_key(entry.citation_key)
+            if entry_file.lower() in ref_lower:
+                return True, entry.citation_key
+
     return False, None
 
 
@@ -453,8 +475,8 @@ def verify_citations(report_text: str, registry: SourceRegistry) -> CitationVeri
                 removed_citations.append({"number": num, "line": full_line, "reason": "url_not_in_registry"})
             continue
 
-        # Try knowledge-layer citation key
-        is_kl, citation_key = _is_knowledge_citation(ref_text)
+        # Try knowledge-layer citation key (lenient — passes registry for fuzzy filename match)
+        is_kl, citation_key = _is_knowledge_citation(ref_text, registry)
         if is_kl and citation_key:
             if registry.has_citation_key(citation_key):
                 logger.info("[CitationVerify]   [%d] VALID  — %s", num, citation_key)

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -65,7 +65,6 @@ class CitationVerificationResult:
     verified_report: str
     removed_citations: list[dict] = field(default_factory=list)
     valid_citations: list[dict] = field(default_factory=list)
-    renumber_map: dict[int, int] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -407,6 +406,40 @@ def _is_knowledge_citation(ref_text: str, registry: SourceRegistry | None = None
     return False, None
 
 
+def _renumber_citations(body: str, ref_section: str) -> tuple[str, str, dict[int, int]]:
+    """Renumber [N] citations sequentially, closing any gaps.
+
+    Scans the references section for citation numbers, builds a mapping
+    from old to new sequential numbers, and applies it to both body and
+    references via collision-safe placeholders.
+
+    Returns:
+        (body, ref_section, renumber_map) where renumber_map maps every
+        old citation number to its new sequential number.
+    """
+    remaining = sorted(int(m.group(1)) for m in _CITATION_LINE_RE.finditer(ref_section))
+    renumber_map: dict[int, int] = {old: new for new, old in enumerate(remaining, 1)}
+
+    # Nothing to do if already sequential
+    if all(old == new for old, new in renumber_map.items()):
+        return body, ref_section, renumber_map
+
+    # Apply renumbering via placeholders (descending order avoids [1] matching inside [10])
+    for old_num in sorted(renumber_map, reverse=True):
+        new_num = renumber_map[old_num]
+        if old_num != new_num:
+            placeholder = f"__CITE_{new_num}__"
+            body = body.replace(f"[{old_num}]", placeholder)
+            ref_section = ref_section.replace(f"[{old_num}]", placeholder)
+
+    for new_num in sorted(renumber_map.values()):
+        placeholder = f"__CITE_{new_num}__"
+        body = body.replace(placeholder, f"[{new_num}]")
+        ref_section = ref_section.replace(placeholder, f"[{new_num}]")
+
+    return body, ref_section, renumber_map
+
+
 def verify_citations(report_text: str, registry: SourceRegistry) -> CitationVerificationResult:
     """Verify citations in a report against the source registry.
 
@@ -415,7 +448,9 @@ def verify_citations(report_text: str, registry: SourceRegistry) -> CitationVeri
     2. Parse each [N] reference line
     3. Validate URL or citation_key against registry
     4. Remove invalid references and orphaned inline citations
-    5. Renumber remaining citations sequentially
+
+    Renumbering is NOT done here — it is deferred to sanitize_report()
+    which always runs after this function and handles it in a single pass.
 
     Args:
         report_text: The full report text with citations.
@@ -497,18 +532,11 @@ def verify_citations(report_text: str, registry: SourceRegistry) -> CitationVeri
 
     if not removed_citations:
         logger.info("[CitationVerify] Result: all %d citation(s) valid — no changes", len(valid_citations))
-        # Still need to return with URL repairs applied
         verified = body + ref_section if url_replacements else report_text
         return CitationVerificationResult(
             verified_report=verified,
             valid_citations=valid_citations,
-            renumber_map={c["number"]: c["number"] for c in valid_citations},
         )
-
-    # Build renumber map
-    renumber_map: dict[int, int] = {}
-    for new_num, citation in enumerate(valid_citations, 1):
-        renumber_map[citation["number"]] = new_num
 
     removed_numbers = {c["number"] for c in removed_citations}
 
@@ -526,37 +554,20 @@ def verify_citations(report_text: str, registry: SourceRegistry) -> CitationVeri
     for num in removed_numbers:
         cleaned_body = re.sub(rf"\[{num}\]", "", cleaned_body)
 
-    # Renumber: apply in descending order to avoid collision
-    # (replacing [10] before [1] prevents [1] in "[10]" from being matched)
-    for old_num in sorted(renumber_map.keys(), reverse=True):
-        new_num = renumber_map[old_num]
-        if old_num != new_num:
-            # Use a temporary placeholder to avoid collisions
-            placeholder = f"__CITE_{new_num}__"
-            cleaned_body = cleaned_body.replace(f"[{old_num}]", placeholder)
-            cleaned_ref_section = cleaned_ref_section.replace(f"[{old_num}]", placeholder)
-
-    # Replace placeholders with final numbers
-    for new_num in sorted(renumber_map.values()):
-        placeholder = f"__CITE_{new_num}__"
-        cleaned_body = cleaned_body.replace(placeholder, f"[{new_num}]")
-        cleaned_ref_section = cleaned_ref_section.replace(placeholder, f"[{new_num}]")
-
+    # Note: renumbering is deferred to sanitize_report() which always runs after
+    # this function and handles renumbering in a single pass.
     verified_report = cleaned_body + cleaned_ref_section
 
-    if removed_citations:
-        logger.info(
-            "[CitationVerify] Result: kept %d, removed %d — renumber map: %s",
-            len(valid_citations),
-            len(removed_citations),
-            renumber_map,
-        )
+    logger.info(
+        "[CitationVerify] Result: kept %d, removed %d",
+        len(valid_citations),
+        len(removed_citations),
+    )
 
     return CitationVerificationResult(
         verified_report=verified_report,
         removed_citations=removed_citations,
         valid_citations=valid_citations,
-        renumber_map=renumber_map,
     )
 
 
@@ -594,6 +605,10 @@ _IP_ADDRESS_RE = re.compile(r"^https?://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}")
 _SUSPICIOUS_SCHEMES_RE = re.compile(r"^(?:javascript|data|vbscript|file):", re.IGNORECASE)
 _BARE_URL_RE = re.compile(r"https?://[^\s<>\"',\]]+")
 
+# Body URL patterns (used by sanitize_report)
+_MD_LINK_RE = re.compile(r"\[([^\]]*)\]\(\s*\w+://[^\s)]+\)")
+_BODY_URL_RE = re.compile(r"\w+://[^\s<>\"',\]]+")
+
 
 @dataclass
 class ReportSanitizationResult:
@@ -601,6 +616,7 @@ class ReportSanitizationResult:
 
     sanitized_report: str
     body_urls_removed: int
+    body_urls_replaced: int
     shortened_urls_removed: list[str]
     truncated_urls_removed: list[str]
     unsafe_urls_removed: list[str]
@@ -609,9 +625,9 @@ class ReportSanitizationResult:
 def sanitize_report(report_text: str) -> ReportSanitizationResult:
     """Deterministic sanitization of a research report.
 
-    Four checks:
-    1. Strip bare URLs from report body — only [N] citations allowed,
-       URLs belong exclusively in the References section.
+    Checks:
+    1. Strip body URLs — collapse markdown links to display text, replace
+       bare URLs that match a reference with ``[N]``, remove the rest.
     2. Remove shortened/obfuscated URLs from References — all URLs must
        be fully expanded (no bit.ly, t.co, etc.).
     3. Remove truncated/garbled URLs — URLs ending in '...' or with no
@@ -625,6 +641,7 @@ def sanitize_report(report_text: str) -> ReportSanitizationResult:
         ReportSanitizationResult with cleaned report and audit trail.
     """
     body_urls_removed = 0
+    body_urls_replaced = 0
     shortened_urls_removed: list[str] = []
     truncated_urls_removed: list[str] = []
     unsafe_urls_removed: list[str] = []
@@ -638,34 +655,39 @@ def sanitize_report(report_text: str) -> ReportSanitizationResult:
         body = report_text
         ref_section = ""
 
-    # --- Check 1: Strip bare URLs from body (preserving markdown links) ---
-    # Markdown links [text](url) should be kept; only bare URLs are stripped
-    _MD_LINK_RE = re.compile(r"\[([^\]]*)\]\(https?://[^\s)]+\)")
+    # --- Check 1: Strip body URLs ---
+    # Build URL → citation number map from references so matching body
+    # URLs are replaced with [N] instead of being deleted entirely.
+    url_to_citation: dict[str, int] = {}
+    if ref_section:
+        for m in _CITATION_LINE_RE.finditer(ref_section):
+            num = int(m.group(1))
+            url_m = _BARE_URL_RE.search(m.group(2))
+            if url_m:
+                url_to_citation[_normalize_url(url_m.group(0).rstrip(".,;)"))] = num
 
     def _replace_body_url(match: re.Match) -> str:
-        nonlocal body_urls_removed
+        nonlocal body_urls_removed, body_urls_replaced
+        url = match.group(0).rstrip(".,;)")
+        normalized = _normalize_url(url)
+        if normalized in url_to_citation:
+            body_urls_replaced += 1
+            return f"[{url_to_citation[normalized]}]"
         body_urls_removed += 1
         return ""
 
-    # Temporarily protect markdown link URLs from stripping
-    md_placeholders: list[str] = []
-
-    def _protect_md_link(match: re.Match) -> str:
-        placeholder = f"__MD_LINK_{len(md_placeholders)}__"
-        md_placeholders.append(match.group(0))
-        return placeholder
-
-    protected_body = _MD_LINK_RE.sub(_protect_md_link, body)
-    cleaned_body = _BARE_URL_RE.sub(_replace_body_url, protected_body)
-    # Restore markdown links
-    for i, original in enumerate(md_placeholders):
-        cleaned_body = cleaned_body.replace(f"__MD_LINK_{i}__", original)
-    # Clean up any leftover empty parentheses from removed bare URLs
+    # Collapse markdown links to display text
+    cleaned_body = _MD_LINK_RE.sub(r"\1", body)
+    # Replace matching bare URLs with [N], strip the rest
+    cleaned_body = _BODY_URL_RE.sub(_replace_body_url, cleaned_body)
+    # Clean up leftover empty parentheses and extra spaces
     cleaned_body = re.sub(r"\(\s*\)", "", cleaned_body)
     cleaned_body = re.sub(r"  +", " ", cleaned_body)
 
+    if body_urls_replaced:
+        logger.info("[ReportSanitize] Replaced %d body URL(s) with citation numbers", body_urls_replaced)
     if body_urls_removed:
-        logger.info("[ReportSanitize] Removed %d bare URL(s) from report body", body_urls_removed)
+        logger.info("[ReportSanitize] Removed %d unmatched URL(s) from report body", body_urls_removed)
 
     # --- Checks 2 & 3: Validate URLs in references section ---
     if ref_section:
@@ -727,24 +749,10 @@ def sanitize_report(report_text: str) -> ReportSanitizationResult:
             cleaned_ref_lines = [line for i, line in enumerate(ref_lines) if i not in lines_to_remove]
             ref_section = "\n".join(cleaned_ref_lines)
 
-            # Strip orphaned inline [N] from body and renumber
+            # Strip orphaned inline [N] from body
             if removed_numbers:
                 for num in removed_numbers:
                     cleaned_body = re.sub(rf"\[{num}\]", "", cleaned_body)
-
-                # Renumber remaining citations sequentially
-                remaining = sorted([int(m.group(1)) for m in _CITATION_LINE_RE.finditer(ref_section)])
-                renumber = {old: new for new, old in enumerate(remaining, 1) if old != new}
-                if renumber:
-                    for old_num in sorted(renumber.keys(), reverse=True):
-                        new_num = renumber[old_num]
-                        placeholder = f"__SANITIZE_CITE_{new_num}__"
-                        cleaned_body = cleaned_body.replace(f"[{old_num}]", placeholder)
-                        ref_section = ref_section.replace(f"[{old_num}]", placeholder)
-                    for new_num in sorted(renumber.values()):
-                        placeholder = f"__SANITIZE_CITE_{new_num}__"
-                        cleaned_body = cleaned_body.replace(placeholder, f"[{new_num}]")
-                        ref_section = ref_section.replace(placeholder, f"[{new_num}]")
 
         if shortened_urls_removed:
             logger.info(
@@ -764,6 +772,10 @@ def sanitize_report(report_text: str) -> ReportSanitizationResult:
                 len(unsafe_urls_removed),
                 unsafe_urls_removed,
             )
+
+    # Renumber citations to close any gaps (from verify_citations and/or sanitize removals)
+    if ref_section:
+        cleaned_body, ref_section, _ = _renumber_citations(cleaned_body, ref_section)
 
     sanitized_report = cleaned_body + ref_section
 
@@ -790,6 +802,7 @@ def sanitize_report(report_text: str) -> ReportSanitizationResult:
     return ReportSanitizationResult(
         sanitized_report=sanitized_report,
         body_urls_removed=body_urls_removed,
+        body_urls_replaced=body_urls_replaced,
         shortened_urls_removed=shortened_urls_removed,
         truncated_urls_removed=truncated_urls_removed,
         unsafe_urls_removed=unsafe_urls_removed,

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -1,0 +1,765 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deterministic citation verification for research agent reports.
+
+This module provides:
+- SourceRegistry: captures URLs/citation keys from tool call results
+- verify_citations(): validates report citations against the registry
+- Extensible parser registry for adding new source types
+
+Usage:
+    registry = SourceRegistry()
+    # ... populate via SourceRegistryMiddleware or manually ...
+    result = verify_citations(report_text, registry)
+    clean_report = result.verified_report
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from dataclasses import field
+from html import unescape
+from urllib.parse import parse_qs
+from urllib.parse import unquote
+from urllib.parse import urlparse
+from urllib.parse import urlunparse
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SourceEntry:
+    """A single source captured from a tool call result."""
+
+    url: str | None = None
+    title: str | None = None
+    citation_key: str | None = None
+    source_type: str = ""
+    tool_name: str = ""
+
+
+@dataclass
+class CitationVerificationResult:
+    """Result of running verify_citations()."""
+
+    verified_report: str
+    removed_citations: list[dict] = field(default_factory=list)
+    valid_citations: list[dict] = field(default_factory=list)
+    renumber_map: dict[int, int] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# URL normalization
+# ---------------------------------------------------------------------------
+
+_TRACKING_PARAMS = frozenset(
+    {
+        "utm_source",
+        "utm_medium",
+        "utm_campaign",
+        "utm_term",
+        "utm_content",
+        "ref",
+        "source",
+    }
+)
+
+
+def _normalize_url(url: str) -> str:
+    """Normalize a URL for comparison.
+
+    Lowercases scheme/host, strips trailing slash, removes fragments
+    and common tracking parameters.
+    """
+    url = unescape(url).strip()
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    netloc = parsed.netloc.lower()
+    path = unquote(parsed.path).rstrip("/") or "/"
+    # Remove tracking params
+    qs = parse_qs(parsed.query, keep_blank_values=True)
+    filtered_qs = {k: v for k, v in qs.items() if k.lower() not in _TRACKING_PARAMS}
+    query_str = "&".join(f"{k}={v[0]}" for k, v in sorted(filtered_qs.items()) if v)
+    return urlunparse((scheme, netloc, path, "", query_str, ""))
+
+
+# ---------------------------------------------------------------------------
+# Knowledge-layer fuzzy matching helpers
+# ---------------------------------------------------------------------------
+
+_PAGE_RE = re.compile(r"(?:p\.?|page)\s*(\d+)", re.IGNORECASE)
+
+
+def _parse_citation_key(key: str) -> tuple[str, int | None]:
+    """Extract (filename, page_number) from a citation key.
+
+    Handles: "report.pdf, p.15", "report.pdf, page 15", "report.pdf"
+    """
+    page_match = _PAGE_RE.search(key)
+    page = int(page_match.group(1)) if page_match else None
+    # Filename is everything before the page reference (or the whole key)
+    if page_match:
+        filename = key[: page_match.start()].rstrip(", ").strip()
+    else:
+        filename = key.strip()
+    return filename, page
+
+
+# ---------------------------------------------------------------------------
+# SourceRegistry
+# ---------------------------------------------------------------------------
+
+
+class SourceRegistry:
+    """Registry of sources captured from tool call results.
+
+    Not thread-safe. In practice this is fine because deepagents subagents
+    run as async coroutines on the same event loop, not separate threads.
+    """
+
+    def __init__(self) -> None:
+        self._urls: dict[str, SourceEntry] = {}
+        self._citation_keys: list[SourceEntry] = []
+        self._all: list[SourceEntry] = []
+
+    def add(self, entry: SourceEntry) -> None:
+        """Register a source entry."""
+        self._all.append(entry)
+        if entry.url:
+            normalized = _normalize_url(entry.url)
+            if normalized not in self._urls:
+                self._urls[normalized] = entry
+        if entry.citation_key:
+            self._citation_keys.append(entry)
+
+    def has_url(self, url: str) -> bool:
+        """Check if a URL (after normalization) is in the registry."""
+        return _normalize_url(url) in self._urls
+
+    def resolve_url(self, url: str) -> str | None:
+        """Find the canonical (full, original) URL from the registry for a possibly garbled URL.
+
+        Matching strategy:
+        1. Exact normalized match — always returned
+        2. Prefix match — only if exactly ONE registry URL matches
+           (ambiguous matches are rejected to avoid guessing wrong)
+
+        Returns the original full URL from the registry, or None if no match
+        or if multiple ambiguous matches exist.
+        """
+        normalized = _normalize_url(url)
+
+        # 1. Exact match — unambiguous, always return
+        if normalized in self._urls:
+            return self._urls[normalized].url
+
+        # 2. Prefix match — the LLM truncated the URL
+        # Collect ALL candidates where the report URL is a prefix of a registry URL
+        truncated_prefix = normalized.rstrip("/")
+        candidates: list[SourceEntry] = []
+        for reg_normalized, entry in self._urls.items():
+            if reg_normalized.startswith(truncated_prefix):
+                candidates.append(entry)
+
+        if len(candidates) == 1:
+            return candidates[0].url
+        if len(candidates) > 1:
+            logger.info(
+                "[CitationVerify] Ambiguous URL prefix match for '%s' — %d candidates, rejecting",
+                url,
+                len(candidates),
+            )
+            return None
+
+        return None
+
+    def has_citation_key(self, key: str) -> bool:
+        """Fuzzy-match a citation key against registry entries.
+
+        Matches if filename (case-insensitive) and page number both match.
+        """
+        target_file, target_page = _parse_citation_key(key)
+        for entry in self._citation_keys:
+            entry_file, entry_page = _parse_citation_key(entry.citation_key)
+            if entry_file.lower() == target_file.lower() and entry_page == target_page:
+                return True
+        return False
+
+    def all_sources(self) -> list[SourceEntry]:
+        """Return all registered sources."""
+        return list(self._all)
+
+    def clear(self) -> None:
+        """Reset the registry."""
+        self._urls.clear()
+        self._citation_keys.clear()
+        self._all.clear()
+
+
+# ---------------------------------------------------------------------------
+# Parser registry
+# ---------------------------------------------------------------------------
+
+SourceParser = Callable[[str, str], list[SourceEntry]]
+
+_PARSER_REGISTRY: list[tuple[Callable[[str], bool], SourceParser]] = []
+
+
+def register_source_parser(
+    match_fn: Callable[[str], bool],
+    parser_fn: SourceParser,
+) -> None:
+    """Register a parser for a tool name pattern.
+
+    Args:
+        match_fn: Predicate on lowercase tool name.
+        parser_fn: (content, tool_name) -> list[SourceEntry]
+    """
+    _PARSER_REGISTRY.append((match_fn, parser_fn))
+
+
+def extract_sources_from_tool_result(tool_name: str, content: str) -> list[SourceEntry]:
+    """Extract sources from a tool's output.
+
+    Strategy:
+    1. If a registered parser matches the tool name, use it (for special
+       formats like knowledge layer citation keys).
+    2. Otherwise, fall back to the generic URL extractor which finds all
+       URLs in any tool output regardless of format.
+
+    This means new sources (Bing, Perplexity, etc.) work automatically
+    without any parser registration — as long as their output contains URLs.
+    """
+    name_lower = tool_name.lower()
+    for match_fn, parser_fn in _PARSER_REGISTRY:
+        if match_fn(name_lower):
+            try:
+                return parser_fn(content, tool_name)
+            except Exception:
+                logger.warning("Parser failed for tool %s, falling back to generic", tool_name, exc_info=True)
+                break
+    # Generic fallback: extract all URLs from content
+    return _parse_generic_urls(content, tool_name)
+
+
+# ---------------------------------------------------------------------------
+# Built-in parsers
+# ---------------------------------------------------------------------------
+
+# Generic URL extractor — works for any tool output format
+_GENERIC_URL_RE = re.compile(r"https?://[^\s<>\"',\]]+")
+
+
+# Patterns for extracting titles near URLs in common tool output formats
+_TITLE_NEAR_URL_PATTERNS = [
+    # Tavily: <title>\nSome Title\n</title>
+    re.compile(r"<title>\s*\n?(.*?)\n?\s*</title>", re.DOTALL | re.IGNORECASE),
+    # Paper search: N. **Title** (Year)
+    re.compile(r"^\d+\.\s+\*\*(.+?)\*\*", re.MULTILINE),
+    # Additional title patterns: --- Title ---
+    re.compile(r"^---\s+(.+?)\s+---$", re.MULTILINE),
+    # Key-value: Title: Some Title
+    re.compile(r"^Title:\s*(.+)$", re.MULTILINE),
+]
+
+
+def _extract_title_for_url(content: str, url: str) -> str | None:
+    """Try to extract a title associated with a URL from the surrounding content.
+
+    Looks in the text block containing the URL for common title patterns.
+    """
+    # Find the block of text containing this URL (split by --- or double newlines)
+    blocks = re.split(r"\n\n---\n\n|\n\n\n", content)
+    for block in blocks:
+        if url not in block:
+            continue
+        for pattern in _TITLE_NEAR_URL_PATTERNS:
+            title_match = pattern.search(block)
+            if title_match:
+                title = title_match.group(1).strip()
+                if title and title != url:
+                    return title
+    return None
+
+
+def _parse_generic_urls(content: str, tool_name: str) -> list[SourceEntry]:
+    """Extract all URLs from any tool output, regardless of format.
+
+    This is the universal fallback. It finds every URL in the content
+    and registers it. Works for Tavily XML, paper search markdown,
+    plain text with links, or any future source format. Also attempts to
+    extract titles from common patterns near each URL.
+    """
+    seen: set[str] = set()
+    entries: list[SourceEntry] = []
+    for match in _GENERIC_URL_RE.finditer(content):
+        url = unescape(match.group(0)).rstrip(".,;)")
+        normalized = _normalize_url(url)
+        if normalized not in seen:
+            seen.add(normalized)
+            title = _extract_title_for_url(content, url)
+            entries.append(SourceEntry(url=url, title=title, source_type="generic", tool_name=tool_name))
+    return entries
+
+
+# Knowledge layer is the only source that needs a specific parser because
+# it uses citation keys (e.g., "report.pdf, p.15") instead of URLs.
+_KL_CITATION_RE = re.compile(r"^Citation:\s*(.+)$", re.MULTILINE)
+_KL_SOURCE_RE = re.compile(r"^Source:\s*(.+)$", re.MULTILINE)
+
+
+def _parse_knowledge_layer(content: str, tool_name: str) -> list[SourceEntry]:
+    """Parse knowledge layer retrieval output.
+
+    Extracts citation keys (filename + page) AND any URLs present.
+    Falls back to generic URL extraction if no Citation: fields found.
+    """
+    entries: list[SourceEntry] = []
+    citations = _KL_CITATION_RE.findall(content)
+    sources = _KL_SOURCE_RE.findall(content)
+    for i, citation_key in enumerate(citations):
+        title = sources[i].strip() if i < len(sources) else None
+        entries.append(
+            SourceEntry(
+                citation_key=citation_key.strip(), title=title, source_type="knowledge_layer", tool_name=tool_name
+            )
+        )
+    if not entries:
+        return _parse_generic_urls(content, tool_name)
+    return entries
+
+
+# Register knowledge layer as the only special-case parser.
+# All other tools (Tavily, paper search, etc.) use the generic URL fallback.
+register_source_parser(lambda name: "knowledge" in name, _parse_knowledge_layer)
+
+# ---------------------------------------------------------------------------
+# Citation verification
+# ---------------------------------------------------------------------------
+
+_REFERENCE_SECTION_RE = re.compile(
+    r"^(?:#{2,3}\s+(?:Sources|References)|Reference\s+List|\*\*References:?\*\*)",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+_CITATION_LINE_RE = re.compile(r"^\s*[-*]?\s*\[(\d+)\]\s*(.+)$", re.MULTILINE)
+
+_URL_IN_LINE_RE = re.compile(r"https?://\S+")
+
+# Knowledge-layer citation pattern: "filename.ext" optionally followed by ", p.N" or ", page N"
+_KL_CITATION_PATTERN_RE = re.compile(r"^(.+\.\w{2,5})(?:,\s*(?:p\.?|page)\s*\d+)?$", re.IGNORECASE)
+
+
+def _is_knowledge_citation(ref_text: str) -> tuple[bool, str | None]:
+    """Check if reference text looks like a knowledge-layer citation.
+
+    Returns (is_kl, citation_key_or_none).
+    """
+    # Strip trailing "(Internal)" or similar parenthetical
+    cleaned = re.sub(r"\s*\(.*?\)\s*$", "", ref_text).strip()
+    # Remove leading "Title - " or "Title: " prefix by taking last segment
+    # if it contains a filename pattern
+    for segment in [cleaned, cleaned.split(" - ")[-1].strip(), cleaned.split(": ")[-1].strip()]:
+        if _KL_CITATION_PATTERN_RE.match(segment):
+            return True, segment
+    return False, None
+
+
+def verify_citations(report_text: str, registry: SourceRegistry) -> CitationVerificationResult:
+    """Verify citations in a report against the source registry.
+
+    Algorithm:
+    1. Find the references section
+    2. Parse each [N] reference line
+    3. Validate URL or citation_key against registry
+    4. Remove invalid references and orphaned inline citations
+    5. Renumber remaining citations sequentially
+
+    Args:
+        report_text: The full report text with citations.
+        registry: SourceRegistry populated from tool call results.
+
+    Returns:
+        CitationVerificationResult with cleaned report and audit trail.
+    """
+    # Normalize Unicode fullwidth brackets to ASCII (LLMs sometimes use 【N】 instead of [N])
+    report_text = report_text.replace("【", "[").replace("】", "]")
+
+    # Early exit: nothing to validate against
+    all_sources = registry.all_sources()
+    if not all_sources:
+        logger.info("[CitationVerify] Skipping — registry is empty (no tool calls captured)")
+        return CitationVerificationResult(verified_report=report_text)
+
+    logger.info(
+        "[CitationVerify] Starting verification against %d registered source(s)",
+        len(all_sources),
+    )
+
+    # Find references section
+    ref_match = _REFERENCE_SECTION_RE.search(report_text)
+    if not ref_match:
+        logger.warning("[CitationVerify] No references section found in report; skipping")
+        return CitationVerificationResult(verified_report=report_text)
+
+    ref_start = ref_match.start()
+    body = report_text[:ref_start]
+    ref_section = report_text[ref_start:]
+
+    # Parse citation lines in the references section
+    valid_citations: list[dict] = []
+    removed_citations: list[dict] = []
+    url_replacements: dict[str, str] = {}  # garbled_url -> canonical_url
+
+    for line_match in _CITATION_LINE_RE.finditer(ref_section):
+        num = int(line_match.group(1))
+        ref_text = line_match.group(2).strip()
+        full_line = line_match.group(0)
+
+        # Try URL match first
+        url_match = _URL_IN_LINE_RE.search(ref_text)
+        if url_match:
+            url = url_match.group(0).rstrip(".,;)")
+            canonical = registry.resolve_url(url)
+            if canonical:
+                if canonical != url:
+                    logger.info("[CitationVerify]   [%d] VALID  — %s (repaired from: %s)", num, canonical, url)
+                    url_replacements[url] = canonical
+                else:
+                    logger.info("[CitationVerify]   [%d] VALID  — %s", num, url)
+                valid_citations.append({"number": num, "url": canonical, "citation_key": None, "line": full_line})
+            else:
+                logger.info("[CitationVerify]   [%d] REMOVE — url_not_in_registry: %s", num, url)
+                removed_citations.append({"number": num, "line": full_line, "reason": "url_not_in_registry"})
+            continue
+
+        # Try knowledge-layer citation key
+        is_kl, citation_key = _is_knowledge_citation(ref_text)
+        if is_kl and citation_key:
+            if registry.has_citation_key(citation_key):
+                logger.info("[CitationVerify]   [%d] VALID  — %s", num, citation_key)
+                valid_citations.append({"number": num, "url": None, "citation_key": citation_key, "line": full_line})
+            else:
+                logger.info("[CitationVerify]   [%d] REMOVE — citation_key_not_in_registry: %s", num, citation_key)
+                removed_citations.append({"number": num, "line": full_line, "reason": "citation_key_not_in_registry"})
+            continue
+
+        # Neither URL nor recognizable citation key
+        logger.info("[CitationVerify]   [%d] REMOVE — unverifiable: %s", num, ref_text[:80])
+        removed_citations.append({"number": num, "line": full_line, "reason": "unverifiable"})
+
+    # Apply URL replacements (garbled -> canonical) in the references section
+    if url_replacements:
+        for garbled, canonical in url_replacements.items():
+            ref_section = ref_section.replace(garbled, canonical)
+
+    if not removed_citations:
+        logger.info("[CitationVerify] Result: all %d citation(s) valid — no changes", len(valid_citations))
+        # Still need to return with URL repairs applied
+        verified = body + ref_section if url_replacements else report_text
+        return CitationVerificationResult(
+            verified_report=verified,
+            valid_citations=valid_citations,
+            renumber_map={c["number"]: c["number"] for c in valid_citations},
+        )
+
+    # Build renumber map
+    renumber_map: dict[int, int] = {}
+    for new_num, citation in enumerate(valid_citations, 1):
+        renumber_map[citation["number"]] = new_num
+
+    removed_numbers = {c["number"] for c in removed_citations}
+
+    # Remove invalid reference lines from the references section
+    cleaned_ref_lines = []
+    for line in ref_section.split("\n"):
+        line_match = _CITATION_LINE_RE.match(line)
+        if line_match and int(line_match.group(1)) in removed_numbers:
+            continue
+        cleaned_ref_lines.append(line)
+    cleaned_ref_section = "\n".join(cleaned_ref_lines)
+
+    # Remove orphaned inline citations from body
+    cleaned_body = body
+    for num in removed_numbers:
+        cleaned_body = re.sub(rf"\[{num}\]", "", cleaned_body)
+
+    # Renumber: apply in descending order to avoid collision
+    # (replacing [10] before [1] prevents [1] in "[10]" from being matched)
+    for old_num in sorted(renumber_map.keys(), reverse=True):
+        new_num = renumber_map[old_num]
+        if old_num != new_num:
+            # Use a temporary placeholder to avoid collisions
+            placeholder = f"__CITE_{new_num}__"
+            cleaned_body = cleaned_body.replace(f"[{old_num}]", placeholder)
+            cleaned_ref_section = cleaned_ref_section.replace(f"[{old_num}]", placeholder)
+
+    # Replace placeholders with final numbers
+    for new_num in sorted(renumber_map.values()):
+        placeholder = f"__CITE_{new_num}__"
+        cleaned_body = cleaned_body.replace(placeholder, f"[{new_num}]")
+        cleaned_ref_section = cleaned_ref_section.replace(placeholder, f"[{new_num}]")
+
+    verified_report = cleaned_body + cleaned_ref_section
+
+    if removed_citations:
+        logger.info(
+            "[CitationVerify] Result: kept %d, removed %d — renumber map: %s",
+            len(valid_citations),
+            len(removed_citations),
+            renumber_map,
+        )
+
+    return CitationVerificationResult(
+        verified_report=verified_report,
+        removed_citations=removed_citations,
+        valid_citations=valid_citations,
+        renumber_map=renumber_map,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Report sanitization (deterministic post-processing)
+# ---------------------------------------------------------------------------
+
+# Known URL shortener domains
+_SHORTENER_DOMAINS = frozenset(
+    {
+        "bit.ly",
+        "tinyurl.com",
+        "t.co",
+        "goo.gl",
+        "ow.ly",
+        "is.gd",
+        "buff.ly",
+        "short.io",
+        "rb.gy",
+        "cutt.ly",
+        "lnkd.in",
+        "soo.gd",
+        "s.coop",
+        "cli.gs",
+        "budurl.com",
+        "yourls.org",
+    }
+)
+
+# Patterns indicating a truncated/garbled URL
+_TRUNCATED_URL_RE = re.compile(r"\.\.\.$|…$")  # ends in ... or ellipsis
+
+# Suspicious URL patterns
+_IP_ADDRESS_RE = re.compile(r"^https?://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}")
+_SUSPICIOUS_SCHEMES_RE = re.compile(r"^(?:javascript|data|vbscript|file):", re.IGNORECASE)
+_BARE_URL_RE = re.compile(r"https?://[^\s<>\"',\]]+")
+
+
+@dataclass
+class ReportSanitizationResult:
+    """Result of running sanitize_report()."""
+
+    sanitized_report: str
+    body_urls_removed: int
+    shortened_urls_removed: list[str]
+    truncated_urls_removed: list[str]
+    unsafe_urls_removed: list[str]
+
+
+def sanitize_report(report_text: str) -> ReportSanitizationResult:
+    """Deterministic sanitization of a research report.
+
+    Four checks:
+    1. Strip bare URLs from report body — only [N] citations allowed,
+       URLs belong exclusively in the References section.
+    2. Remove shortened/obfuscated URLs from References — all URLs must
+       be fully expanded (no bit.ly, t.co, etc.).
+    3. Remove truncated/garbled URLs — URLs ending in '...' or with no
+       path (domain-only like 'https://arxiv.org') are incomplete.
+    4. Block unsafe URLs — no IP-address URLs, no non-http schemes.
+
+    Args:
+        report_text: Report text (ideally after verify_citations()).
+
+    Returns:
+        ReportSanitizationResult with cleaned report and audit trail.
+    """
+    body_urls_removed = 0
+    shortened_urls_removed: list[str] = []
+    truncated_urls_removed: list[str] = []
+    unsafe_urls_removed: list[str] = []
+
+    # Split into body and references section
+    ref_match = _REFERENCE_SECTION_RE.search(report_text)
+    if ref_match:
+        body = report_text[: ref_match.start()]
+        ref_section = report_text[ref_match.start() :]
+    else:
+        body = report_text
+        ref_section = ""
+
+    # --- Check 1: Strip bare URLs from body (preserving markdown links) ---
+    # Markdown links [text](url) should be kept; only bare URLs are stripped
+    _MD_LINK_RE = re.compile(r"\[([^\]]*)\]\(https?://[^\s)]+\)")
+
+    def _replace_body_url(match: re.Match) -> str:
+        nonlocal body_urls_removed
+        body_urls_removed += 1
+        return ""
+
+    # Temporarily protect markdown link URLs from stripping
+    md_placeholders: list[str] = []
+
+    def _protect_md_link(match: re.Match) -> str:
+        placeholder = f"__MD_LINK_{len(md_placeholders)}__"
+        md_placeholders.append(match.group(0))
+        return placeholder
+
+    protected_body = _MD_LINK_RE.sub(_protect_md_link, body)
+    cleaned_body = _BARE_URL_RE.sub(_replace_body_url, protected_body)
+    # Restore markdown links
+    for i, original in enumerate(md_placeholders):
+        cleaned_body = cleaned_body.replace(f"__MD_LINK_{i}__", original)
+    # Clean up any leftover empty parentheses from removed bare URLs
+    cleaned_body = re.sub(r"\(\s*\)", "", cleaned_body)
+    cleaned_body = re.sub(r"  +", " ", cleaned_body)
+
+    if body_urls_removed:
+        logger.info("[ReportSanitize] Removed %d bare URL(s) from report body", body_urls_removed)
+
+    # --- Checks 2 & 3: Validate URLs in references section ---
+    if ref_section:
+        lines_to_remove: set[int] = set()
+        ref_lines = ref_section.split("\n")
+
+        for i, line in enumerate(ref_lines):
+            url_match = _BARE_URL_RE.search(line)
+            if not url_match:
+                continue
+            url = url_match.group(0).rstrip(".,;)")
+
+            # Check for non-http schemes embedded in text
+            if _SUSPICIOUS_SCHEMES_RE.search(line):
+                unsafe_urls_removed.append(url)
+                lines_to_remove.add(i)
+                continue
+
+            parsed = urlparse(url)
+            domain = parsed.netloc.lower()
+
+            # Check 2: shortened URLs
+            # Strip www. and port for comparison
+            bare_domain = domain.split(":")[0]
+            if bare_domain.startswith("www."):
+                bare_domain = bare_domain[4:]
+            if bare_domain in _SHORTENER_DOMAINS:
+                shortened_urls_removed.append(url)
+                lines_to_remove.add(i)
+                continue
+
+            # Check 3: truncated/garbled URLs — only catch obvious truncation markers
+            raw_url = url_match.group(0)
+            if _TRUNCATED_URL_RE.search(raw_url) or "…" in raw_url:
+                truncated_urls_removed.append(raw_url)
+                lines_to_remove.add(i)
+                continue
+
+            # Check 4: IP address URLs
+            if _IP_ADDRESS_RE.match(url):
+                unsafe_urls_removed.append(url)
+                lines_to_remove.add(i)
+                continue
+
+            # Check 4: non-http schemes
+            if parsed.scheme not in ("http", "https"):
+                unsafe_urls_removed.append(url)
+                lines_to_remove.add(i)
+                continue
+
+        if lines_to_remove:
+            # Collect which [N] numbers were removed
+            removed_numbers: set[int] = set()
+            for i in lines_to_remove:
+                line_m = _CITATION_LINE_RE.match(ref_lines[i])
+                if line_m:
+                    removed_numbers.add(int(line_m.group(1)))
+
+            cleaned_ref_lines = [line for i, line in enumerate(ref_lines) if i not in lines_to_remove]
+            ref_section = "\n".join(cleaned_ref_lines)
+
+            # Strip orphaned inline [N] from body and renumber
+            if removed_numbers:
+                for num in removed_numbers:
+                    cleaned_body = re.sub(rf"\[{num}\]", "", cleaned_body)
+
+                # Renumber remaining citations sequentially
+                remaining = sorted([int(m.group(1)) for m in _CITATION_LINE_RE.finditer(ref_section)])
+                renumber = {old: new for new, old in enumerate(remaining, 1) if old != new}
+                if renumber:
+                    for old_num in sorted(renumber.keys(), reverse=True):
+                        new_num = renumber[old_num]
+                        placeholder = f"__SANITIZE_CITE_{new_num}__"
+                        cleaned_body = cleaned_body.replace(f"[{old_num}]", placeholder)
+                        ref_section = ref_section.replace(f"[{old_num}]", placeholder)
+                    for new_num in sorted(renumber.values()):
+                        placeholder = f"__SANITIZE_CITE_{new_num}__"
+                        cleaned_body = cleaned_body.replace(placeholder, f"[{new_num}]")
+                        ref_section = ref_section.replace(placeholder, f"[{new_num}]")
+
+        if shortened_urls_removed:
+            logger.info(
+                "[ReportSanitize] Removed %d shortened URL(s) from references: %s",
+                len(shortened_urls_removed),
+                shortened_urls_removed,
+            )
+        if truncated_urls_removed:
+            logger.info(
+                "[ReportSanitize] Removed %d truncated/incomplete URL(s) from references: %s",
+                len(truncated_urls_removed),
+                truncated_urls_removed,
+            )
+        if unsafe_urls_removed:
+            logger.info(
+                "[ReportSanitize] Removed %d unsafe URL(s) from references: %s",
+                len(unsafe_urls_removed),
+                unsafe_urls_removed,
+            )
+
+    sanitized_report = cleaned_body + ref_section
+
+    # --- Trim everything after the last citation in the Sources section ---
+    # The LLM often appends meta-commentary after the references (e.g.,
+    # "All citations refer to...", "This report meets..."). Rather than
+    # pattern-matching specific phrases, just cut after the last [N] line.
+    if ref_section:
+        last_citation_end = None
+        for m in _CITATION_LINE_RE.finditer(sanitized_report):
+            last_citation_end = m.end()
+        if last_citation_end is not None:
+            sanitized_report = sanitized_report[:last_citation_end].rstrip() + "\n"
+
+    return ReportSanitizationResult(
+        sanitized_report=sanitized_report,
+        body_urls_removed=body_urls_removed,
+        shortened_urls_removed=shortened_urls_removed,
+        truncated_urls_removed=truncated_urls_removed,
+        unsafe_urls_removed=unsafe_urls_removed,
+    )

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -183,7 +183,7 @@ class SourceRegistry:
         if len(candidates) == 1:
             return candidates[0].url
         if len(candidates) > 1:
-            logger.info(
+            logger.debug(
                 "[CitationVerify] Ambiguous URL prefix match for '%s' — %d candidates, rejecting",
                 url,
                 len(candidates),
@@ -465,10 +465,10 @@ def verify_citations(report_text: str, registry: SourceRegistry) -> CitationVeri
     # Early exit: nothing to validate against
     all_sources = registry.all_sources()
     if not all_sources:
-        logger.info("[CitationVerify] Skipping — registry is empty (no tool calls captured)")
+        logger.debug("[CitationVerify] Skipping — registry is empty (no tool calls captured)")
         return CitationVerificationResult(verified_report=report_text)
 
-    logger.info(
+    logger.debug(
         "[CitationVerify] Starting verification against %d registered source(s)",
         len(all_sources),
     )
@@ -500,13 +500,13 @@ def verify_citations(report_text: str, registry: SourceRegistry) -> CitationVeri
             canonical = registry.resolve_url(url)
             if canonical:
                 if canonical != url:
-                    logger.info("[CitationVerify]   [%d] VALID  — %s (repaired from: %s)", num, canonical, url)
+                    logger.debug("[CitationVerify]   [%d] VALID  — %s (repaired from: %s)", num, canonical, url)
                     url_replacements[url] = canonical
                 else:
-                    logger.info("[CitationVerify]   [%d] VALID  — %s", num, url)
+                    logger.debug("[CitationVerify]   [%d] VALID  — %s", num, url)
                 valid_citations.append({"number": num, "url": canonical, "citation_key": None, "line": full_line})
             else:
-                logger.info("[CitationVerify]   [%d] REMOVE — url_not_in_registry: %s", num, url)
+                logger.debug("[CitationVerify]   [%d] REMOVE — url_not_in_registry: %s", num, url)
                 removed_citations.append({"number": num, "line": full_line, "reason": "url_not_in_registry"})
             continue
 
@@ -514,15 +514,15 @@ def verify_citations(report_text: str, registry: SourceRegistry) -> CitationVeri
         is_kl, citation_key = _is_knowledge_citation(ref_text, registry)
         if is_kl and citation_key:
             if registry.has_citation_key(citation_key):
-                logger.info("[CitationVerify]   [%d] VALID  — %s", num, citation_key)
+                logger.debug("[CitationVerify]   [%d] VALID  — %s", num, citation_key)
                 valid_citations.append({"number": num, "url": None, "citation_key": citation_key, "line": full_line})
             else:
-                logger.info("[CitationVerify]   [%d] REMOVE — citation_key_not_in_registry: %s", num, citation_key)
+                logger.debug("[CitationVerify]   [%d] REMOVE — citation_key_not_in_registry: %s", num, citation_key)
                 removed_citations.append({"number": num, "line": full_line, "reason": "citation_key_not_in_registry"})
             continue
 
         # Neither URL nor recognizable citation key
-        logger.info("[CitationVerify]   [%d] REMOVE — unverifiable: %s", num, ref_text[:80])
+        logger.debug("[CitationVerify]   [%d] REMOVE — unverifiable: %s", num, ref_text[:80])
         removed_citations.append({"number": num, "line": full_line, "reason": "unverifiable"})
 
     # Apply URL replacements (garbled -> canonical) in the references section
@@ -531,7 +531,7 @@ def verify_citations(report_text: str, registry: SourceRegistry) -> CitationVeri
             ref_section = ref_section.replace(garbled, canonical)
 
     if not removed_citations:
-        logger.info("[CitationVerify] Result: all %d citation(s) valid — no changes", len(valid_citations))
+        logger.debug("[CitationVerify] Result: all %d citation(s) valid — no changes", len(valid_citations))
         verified = body + ref_section if url_replacements else report_text
         return CitationVerificationResult(
             verified_report=verified,
@@ -558,7 +558,7 @@ def verify_citations(report_text: str, registry: SourceRegistry) -> CitationVeri
     # this function and handles renumbering in a single pass.
     verified_report = cleaned_body + cleaned_ref_section
 
-    logger.info(
+    logger.debug(
         "[CitationVerify] Result: kept %d, removed %d",
         len(valid_citations),
         len(removed_citations),
@@ -685,9 +685,9 @@ def sanitize_report(report_text: str) -> ReportSanitizationResult:
     cleaned_body = re.sub(r"  +", " ", cleaned_body)
 
     if body_urls_replaced:
-        logger.info("[ReportSanitize] Replaced %d body URL(s) with citation numbers", body_urls_replaced)
+        logger.debug("[ReportSanitize] Replaced %d body URL(s) with citation numbers", body_urls_replaced)
     if body_urls_removed:
-        logger.info("[ReportSanitize] Removed %d unmatched URL(s) from report body", body_urls_removed)
+        logger.debug("[ReportSanitize] Removed %d unmatched URL(s) from report body", body_urls_removed)
 
     # --- Checks 2 & 3: Validate URLs in references section ---
     if ref_section:
@@ -755,19 +755,19 @@ def sanitize_report(report_text: str) -> ReportSanitizationResult:
                     cleaned_body = re.sub(rf"\[{num}\]", "", cleaned_body)
 
         if shortened_urls_removed:
-            logger.info(
+            logger.debug(
                 "[ReportSanitize] Removed %d shortened URL(s) from references: %s",
                 len(shortened_urls_removed),
                 shortened_urls_removed,
             )
         if truncated_urls_removed:
-            logger.info(
+            logger.debug(
                 "[ReportSanitize] Removed %d truncated/incomplete URL(s) from references: %s",
                 len(truncated_urls_removed),
                 truncated_urls_removed,
             )
         if unsafe_urls_removed:
-            logger.info(
+            logger.debug(
                 "[ReportSanitize] Removed %d unsafe URL(s) from references: %s",
                 len(unsafe_urls_removed),
                 unsafe_urls_removed,

--- a/src/aiq_agent/common/source_metadata.py
+++ b/src/aiq_agent/common/source_metadata.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Structured source metadata for tool returns.
+
+Tools return strings (NAT requirement) but can embed typed source metadata
+as an HTML comment at the end.  The SourceRegistryMiddleware extracts this
+metadata directly instead of regex-parsing the free-form string, then strips
+the block so the LLM never sees it.
+
+Usage in a tool:
+    from aiq_agent.common.source_metadata import SourceRef, encode_source_metadata
+
+    refs = [SourceRef(url="https://example.com", title="Example")]
+    return encode_source_metadata(formatted_string, refs)
+
+Usage in middleware:
+    from aiq_agent.common.source_metadata import extract_source_metadata
+
+    clean_content, refs = extract_source_metadata(tool_message.content)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+_METADATA_TAG = "TOOL_SOURCE_METADATA"
+_METADATA_RE = re.compile(
+    rf"\n?\n?<!-- {_METADATA_TAG}:(.*) -->$",
+    re.DOTALL,
+)
+
+
+class SourceRef(BaseModel):
+    """A single source reference from a tool result."""
+
+    url: str | None = None
+    title: str | None = None
+    citation_key: str | None = None
+
+
+def encode_source_metadata(content: str, sources: list[SourceRef]) -> str:
+    """Append structured source metadata to a tool's string return.
+
+    The metadata is encoded as an HTML comment that the middleware will
+    extract and strip before the LLM sees the content.
+    """
+    if not sources:
+        return content
+    payload = json.dumps([s.model_dump(exclude_none=True) for s in sources], separators=(",", ":"))
+    return f"{content}\n\n<!-- {_METADATA_TAG}:{payload} -->"
+
+
+def extract_source_metadata(content: str) -> tuple[str, list[SourceRef] | None]:
+    """Extract and strip structured source metadata from tool content.
+
+    Returns:
+        Tuple of (clean_content, sources_or_none).
+        If no metadata block is found, returns (original_content, None).
+    """
+    match = _METADATA_RE.search(content)
+    if not match:
+        return content, None
+    try:
+        raw = json.loads(match.group(1))
+        refs = [SourceRef(**item) for item in raw]
+        clean = content[: match.start()]
+        return clean, refs
+    except Exception:
+        logger.warning("Failed to parse tool source metadata; falling back to regex", exc_info=True)
+        return content, None

--- a/src/aiq_agent/knowledge/schema.py
+++ b/src/aiq_agent/knowledge/schema.py
@@ -17,7 +17,7 @@ Universal Schema for Knowledge Layer.
 
 This module defines the "Golden Record" - strict Pydantic models that all
 adapters must output. This ensures agents always see a consistent format
-regardless of the underlying backend (LlamaIndex, Foundational RAG, ECI, and so on).
+regardless of the underlying backend (LlamaIndex, Foundational RAG, and so on).
 
 Schema Rules (enforced by all adapters):
 1. Four Pillars: content_type MUST be exactly "text", "table", "chart", or "image"

--- a/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
@@ -20,8 +20,12 @@ from unittest.mock import MagicMock
 
 import pytest
 from langchain_core.messages import AIMessage
+from langchain_core.messages import ToolMessage
 
+from aiq_agent.agents.deep_researcher.custom_middleware import SourceRegistryMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import ToolNameSanitizationMiddleware
+from aiq_agent.common.source_metadata import SourceRef
+from aiq_agent.common.source_metadata import encode_source_metadata
 
 
 class TestToolNameSanitizationMiddleware:
@@ -115,3 +119,179 @@ class TestToolNameSanitizationMiddleware:
 
         assert result.result[0].content == "Just text, no tools"
         assert not result.result[0].tool_calls
+
+
+class TestSourceRegistryMiddleware:
+    """Tests for SourceRegistryMiddleware allowlist + structured metadata."""
+
+    @pytest.fixture
+    def source_tools(self):
+        return {"advanced_web_search_tool", "knowledge_search", "paper_search_tool"}
+
+    @pytest.fixture
+    def middleware(self, source_tools):
+        return SourceRegistryMiddleware(source_tool_names=source_tools)
+
+    def _make_request(self, tool_name: str):
+        req = MagicMock()
+        req.tool_call = {"name": tool_name}
+        return req
+
+    def _make_tool_result(self, content: str):
+        return ToolMessage(content=content, tool_call_id="tc1")
+
+    # -- Structured metadata path --
+
+    @pytest.mark.asyncio
+    async def test_structured_metadata_captured(self, middleware):
+        """Structured metadata is extracted and used instead of regex."""
+        refs = [SourceRef(url="https://arxiv.org/abs/2401.00001", title="My Paper")]
+        content = encode_source_metadata("Some search result text", refs)
+        handler = AsyncMock(return_value=self._make_tool_result(content))
+        request = self._make_request("advanced_web_search_tool")
+
+        await middleware.awrap_tool_call(request, handler)
+
+        sources = middleware.registry.all_sources()
+        assert len(sources) == 1
+        assert sources[0].url == "https://arxiv.org/abs/2401.00001"
+        assert sources[0].title == "My Paper"
+        assert sources[0].source_type == "structured"
+
+    @pytest.mark.asyncio
+    async def test_structured_metadata_stripped_from_content(self, middleware):
+        """Metadata block is stripped so the LLM never sees it."""
+        refs = [SourceRef(url="https://example.com")]
+        content = encode_source_metadata("Clean content for LLM", refs)
+        handler = AsyncMock(return_value=self._make_tool_result(content))
+        request = self._make_request("advanced_web_search_tool")
+
+        result = await middleware.awrap_tool_call(request, handler)
+
+        assert "TOOL_SOURCE_METADATA" not in result.content
+        assert result.content == "Clean content for LLM"
+
+    @pytest.mark.asyncio
+    async def test_structured_citation_key_captured(self, middleware):
+        """Knowledge layer citation keys are captured via structured metadata."""
+        refs = [SourceRef(citation_key="report.pdf, p.5", title="report.pdf")]
+        content = encode_source_metadata("Knowledge result", refs)
+        handler = AsyncMock(return_value=self._make_tool_result(content))
+        request = self._make_request("knowledge_search")
+
+        await middleware.awrap_tool_call(request, handler)
+
+        sources = middleware.registry.all_sources()
+        assert len(sources) == 1
+        assert sources[0].citation_key == "report.pdf, p.5"
+
+    @pytest.mark.asyncio
+    async def test_multiple_structured_refs(self, middleware):
+        """Multiple structured refs from a single tool call."""
+        refs = [
+            SourceRef(url="https://a.com", title="A"),
+            SourceRef(url="https://b.com", title="B"),
+        ]
+        content = encode_source_metadata("results", refs)
+        handler = AsyncMock(return_value=self._make_tool_result(content))
+        request = self._make_request("advanced_web_search_tool")
+
+        await middleware.awrap_tool_call(request, handler)
+
+        urls = {s.url for s in middleware.registry.all_sources()}
+        assert urls == {"https://a.com", "https://b.com"}
+
+    # -- Regex fallback path --
+
+    @pytest.mark.asyncio
+    async def test_regex_fallback_when_no_metadata(self, middleware):
+        """Without metadata block, falls back to regex extraction."""
+        content = "Result from https://arxiv.org/abs/2401.00001"
+        handler = AsyncMock(return_value=self._make_tool_result(content))
+        request = self._make_request("advanced_web_search_tool")
+
+        await middleware.awrap_tool_call(request, handler)
+
+        sources = middleware.registry.all_sources()
+        assert len(sources) == 1
+        assert sources[0].url == "https://arxiv.org/abs/2401.00001"
+        assert sources[0].source_type != "structured"
+
+    # -- Allowlist filtering --
+
+    @pytest.mark.asyncio
+    async def test_think_tool_ignored_even_with_metadata(self, middleware):
+        """Internal tools are filtered out before metadata is checked."""
+        refs = [SourceRef(url="https://hallucinated.com")]
+        content = encode_source_metadata("thinking...", refs)
+        handler = AsyncMock(return_value=self._make_tool_result(content))
+        request = self._make_request("think")
+
+        result = await middleware.awrap_tool_call(request, handler)
+
+        assert len(middleware.registry.all_sources()) == 0
+        # Metadata is NOT stripped for non-source tools (they skip entirely)
+        assert "TOOL_SOURCE_METADATA" in result.content
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_ignored(self, middleware):
+        """Tools not in the allowlist are ignored."""
+        content = "https://unknown.com/data"
+        handler = AsyncMock(return_value=self._make_tool_result(content))
+        request = self._make_request("some_random_tool")
+
+        await middleware.awrap_tool_call(request, handler)
+
+        assert len(middleware.registry.all_sources()) == 0
+
+    @pytest.mark.asyncio
+    async def test_mixed_structured_and_regex(self, middleware):
+        """One tool with metadata, another without -- both captured correctly."""
+        refs = [SourceRef(url="https://structured.com", title="Structured")]
+        structured_content = encode_source_metadata("structured result", refs)
+        regex_content = "Result from https://regex-extracted.com/page"
+
+        h1 = AsyncMock(return_value=self._make_tool_result(structured_content))
+        h2 = AsyncMock(return_value=self._make_tool_result(regex_content))
+
+        await middleware.awrap_tool_call(self._make_request("advanced_web_search_tool"), h1)
+        await middleware.awrap_tool_call(self._make_request("paper_search_tool"), h2)
+
+        urls = {s.url for s in middleware.registry.all_sources()}
+        assert "https://structured.com" in urls
+        assert "https://regex-extracted.com/page" in urls
+
+    @pytest.mark.asyncio
+    async def test_empty_content_skipped(self, middleware):
+        """Empty content is ignored gracefully."""
+        handler = AsyncMock(return_value=self._make_tool_result(""))
+        request = self._make_request("advanced_web_search_tool")
+
+        await middleware.awrap_tool_call(request, handler)
+
+        assert len(middleware.registry.all_sources()) == 0
+
+    @pytest.mark.asyncio
+    async def test_non_tool_message_passthrough(self, middleware):
+        """Non-ToolMessage results pass through without error."""
+        handler = AsyncMock(return_value=AIMessage(content="just an AI reply"))
+        request = self._make_request("advanced_web_search_tool")
+
+        result = await middleware.awrap_tool_call(request, handler)
+
+        assert isinstance(result, AIMessage)
+        assert len(middleware.registry.all_sources()) == 0
+
+    @pytest.mark.asyncio
+    async def test_default_empty_allowlist_captures_nothing(self):
+        """Middleware with no source_tool_names captures nothing."""
+        mw = SourceRegistryMiddleware()
+        refs = [SourceRef(url="https://should-not-be-captured.com")]
+        content = encode_source_metadata("content", refs)
+        handler = AsyncMock(return_value=ToolMessage(content=content, tool_call_id="tc1"))
+        request = MagicMock()
+        request.tool_call = {"name": "advanced_web_search_tool"}
+
+        await mw.awrap_tool_call(request, handler)
+
+        assert len(mw.registry.all_sources()) == 0

--- a/tests/aiq_agent/common/test_citation_verification.py
+++ b/tests/aiq_agent/common/test_citation_verification.py
@@ -394,7 +394,8 @@ class TestVerifyCitations:
         # [1] stays as [1]
         assert "[1]" in result.verified_report
 
-    def test_renumbering_after_removal(self, registry):
+    def test_removal_leaves_gaps_for_sanitize(self, registry):
+        """verify_citations removes invalid refs but does NOT renumber — gaps are left for sanitize_report."""
         report = (
             "A [1]. B [2]. C [3].\n\n"
             "## Sources\n"
@@ -403,10 +404,10 @@ class TestVerifyCitations:
             "[3] Article 2: https://valid.com/article2"
         )
         result = verify_citations(report, registry)
-        assert result.renumber_map == {1: 1, 3: 2}
         assert "A [1]" in result.verified_report
-        assert "C [2]" in result.verified_report
-        assert "[3]" not in result.verified_report
+        assert "[2]" not in result.verified_report
+        # [3] is NOT renumbered — gaps are closed by sanitize_report()
+        assert "C [3]" in result.verified_report
 
     def test_knowledge_layer_citation_validated(self, registry):
         report = "Internal finding [1].\n\n## Sources\n[1] report.pdf, p.15"
@@ -435,8 +436,8 @@ class TestVerifyCitations:
             "[3] Article 2: https://valid.com/article2"
         )
         result = verify_citations(report, registry)
-        # [2] removed, [3] renumbered to [2]
-        assert "Finding [1][2]." in result.verified_report
+        # [2] removed, [3] stays (renumbering deferred to sanitize_report)
+        assert "Finding [1][3]." in result.verified_report
 
     def test_references_with_dashes(self, registry):
         """Shallow researcher uses '- [N] Title - URL' format."""
@@ -515,7 +516,8 @@ class TestVerifyCitations:
 class TestSanitizeReport:
     """Tests for deterministic report sanitization."""
 
-    def test_bare_urls_stripped_from_body(self):
+    def test_body_url_not_in_refs_stripped(self):
+        """Bare body URL with no matching reference is removed."""
         report = (
             "NVIDIA is great (see https://nvidia.com/gpus for details) [1].\n\n"
             "## Sources\n"
@@ -526,17 +528,33 @@ class TestSanitizeReport:
         # URL in references preserved
         assert "https://nvidia.com/article" in result.sanitized_report
         assert result.body_urls_removed == 1
+        assert result.body_urls_replaced == 0
 
-    def test_markdown_links_preserved_in_body(self):
-        """Markdown hyperlinks [text](url) should NOT be stripped from body."""
+    def test_body_url_matching_ref_replaced_with_citation(self):
+        """Bare body URL matching a reference is replaced with [N]."""
+        report = (
+            "Visit https://arxiv.org/abs/1706.03762 for the paper [1].\n\n"
+            "## Sources\n"
+            "[1] Paper: https://arxiv.org/abs/1706.03762"
+        )
+        result = sanitize_report(report)
+        # Body URL replaced with citation number
+        assert "Visit [1] for the paper [1]" in result.sanitized_report
+        # Reference section URL preserved
+        assert "[1] Paper: https://arxiv.org/abs/1706.03762" in result.sanitized_report
+        assert result.body_urls_replaced == 1
+        assert result.body_urls_removed == 0
+
+    def test_markdown_links_collapsed_to_text_in_body(self):
+        """Markdown hyperlinks [text](url) should be collapsed to display text."""
         report = (
             "Read the [NVIDIA docs](https://nvidia.com/docs/guide) for details [1].\n\n"
             "## Sources\n"
             "[1] Article: https://example.com/article"
         )
         result = sanitize_report(report)
-        assert "[NVIDIA docs](https://nvidia.com/docs/guide)" in result.sanitized_report
-        assert result.body_urls_removed == 0
+        assert "NVIDIA docs" in result.sanitized_report
+        assert "https://nvidia.com/docs/guide" not in result.sanitized_report
 
     def test_body_without_urls_unchanged(self):
         report = (
@@ -625,6 +643,38 @@ class TestSanitizeReport:
         assert "arxiv.org/abs/1706.03762" in result.sanitized_report
         assert len(result.truncated_urls_removed) == 0
 
+    def test_renumbering_closes_gaps_from_verify(self):
+        """sanitize_report renumbers to close gaps left by verify_citations."""
+        # Simulate output of verify_citations that removed [2]: gaps [1], [3]
+        report = (
+            "A [1]. C [3].\n\n"
+            "## Sources\n"
+            "[1] Article 1: https://valid.com/article1\n"
+            "[3] Article 2: https://valid.com/article2"
+        )
+        result = sanitize_report(report)
+        assert "A [1]" in result.sanitized_report
+        assert "C [2]" in result.sanitized_report
+        assert "[3]" not in result.sanitized_report
+
+    def test_full_pipeline_verify_then_sanitize(self):
+        """End-to-end: verify removes invalid, sanitize renumbers and cleans."""
+        registry = SourceRegistry()
+        registry.add(SourceEntry(url="https://valid.com/article1", source_type="tavily"))
+        registry.add(SourceEntry(url="https://valid.com/article2", source_type="tavily"))
+        report = (
+            "A [1]. B [2]. C [3].\n\n"
+            "## Sources\n"
+            "[1] Article 1: https://valid.com/article1\n"
+            "[2] Fake: https://fake.com\n"
+            "[3] Article 2: https://valid.com/article2"
+        )
+        verified = verify_citations(report, registry).verified_report
+        sanitized = sanitize_report(verified).sanitized_report
+        assert "A [1]" in sanitized
+        assert "C [2]" in sanitized
+        assert "[3]" not in sanitized
+
     def test_mixed_issues(self):
         """Body URL + shortened reference + valid references."""
         report = (
@@ -637,5 +687,20 @@ class TestSanitizeReport:
         assert "https://nvidia.com" not in result.sanitized_report
         assert "arxiv.org/abs/paper" in result.sanitized_report
         assert "bit.ly" not in result.sanitized_report
+        # nvidia.com/gpus doesn't match any reference → removed
         assert result.body_urls_removed == 1
         assert len(result.shortened_urls_removed) == 1
+
+    def test_mixed_body_urls_some_match_some_not(self):
+        """Body has two URLs: one matches a reference, one doesn't."""
+        report = (
+            "See https://arxiv.org/abs/paper and https://unknown.com for details [1].\n\n"
+            "## Sources\n"
+            "[1] Paper: https://arxiv.org/abs/paper"
+        )
+        result = sanitize_report(report)
+        # Matching URL replaced with [1], unknown URL stripped
+        assert "See [1] and for details [1]" in result.sanitized_report
+        assert "https://unknown.com" not in result.sanitized_report
+        assert result.body_urls_replaced == 1
+        assert result.body_urls_removed == 1

--- a/tests/aiq_agent/common/test_citation_verification.py
+++ b/tests/aiq_agent/common/test_citation_verification.py
@@ -140,7 +140,12 @@ class TestSourceRegistry:
         registry.add(SourceEntry(citation_key="report.pdf"))
         assert registry.has_citation_key("report.pdf")
 
-    def test_has_citation_key_mismatch(self, registry):
+    def test_has_citation_key_different_page_matches(self, registry):
+        """Same file, different page — still matches (lenient)."""
+        registry.add(SourceEntry(citation_key="report.pdf, p.15"))
+        assert registry.has_citation_key("report.pdf, p.5")
+
+    def test_has_citation_key_different_file_no_match(self, registry):
         registry.add(SourceEntry(citation_key="report.pdf, p.15"))
         assert not registry.has_citation_key("other.pdf, p.15")
 
@@ -474,6 +479,13 @@ class TestVerifyCitations:
         report = "Finding [1].\n\n**References:**\n- [1] report.pdf, p.15 (Internal)"
         result = verify_citations(report, registry)
         assert len(result.valid_citations) == 1
+
+    def test_knowledge_citation_with_markdown_italics(self, registry):
+        """LLM wraps citation in markdown italics *filename.pdf*."""
+        report = "Finding [1].\n\n**References**\n- [1] *report.pdf*, p.15"
+        result = verify_citations(report, registry)
+        assert len(result.valid_citations) == 1
+        assert len(result.removed_citations) == 0
 
     def test_garbled_url_repaired_to_canonical(self):
         """LLM truncated a URL — verify_citations repairs it to the full canonical URL."""

--- a/tests/aiq_agent/common/test_citation_verification.py
+++ b/tests/aiq_agent/common/test_citation_verification.py
@@ -1,0 +1,629 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for citation verification module."""
+
+import pytest
+
+from aiq_agent.common.citation_verification import _PARSER_REGISTRY
+from aiq_agent.common.citation_verification import SourceEntry
+from aiq_agent.common.citation_verification import SourceRegistry
+from aiq_agent.common.citation_verification import _normalize_url
+from aiq_agent.common.citation_verification import _parse_citation_key
+from aiq_agent.common.citation_verification import extract_sources_from_tool_result
+from aiq_agent.common.citation_verification import register_source_parser
+from aiq_agent.common.citation_verification import sanitize_report
+from aiq_agent.common.citation_verification import verify_citations
+
+
+@pytest.fixture(autouse=True)
+def fixture_restore_parser_registry():
+    """Restore the parser registry after each test to prevent leaks."""
+    original = list(_PARSER_REGISTRY)
+    yield
+    _PARSER_REGISTRY.clear()
+    _PARSER_REGISTRY.extend(original)
+
+
+# ---------------------------------------------------------------------------
+# URL normalization tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeUrl:
+    """Tests for URL normalization."""
+
+    def test_lowercase_scheme_and_host(self):
+        assert _normalize_url("HTTPS://Example.COM/path") == "https://example.com/path"
+
+    def test_strip_trailing_slash(self):
+        assert _normalize_url("https://example.com/path/") == "https://example.com/path"
+
+    def test_strip_fragment(self):
+        assert _normalize_url("https://example.com/page#section") == "https://example.com/page"
+
+    def test_remove_utm_params(self):
+        result = _normalize_url("https://example.com/page?utm_source=twitter&key=val")
+        assert "utm_source" not in result
+        assert "key=val" in result
+
+    def test_unescape_html_entities(self):
+        assert _normalize_url("https://example.com/page?a=1&amp;b=2") == "https://example.com/page?a=1&b=2"
+
+    def test_root_path_preserved(self):
+        assert _normalize_url("https://example.com") == "https://example.com/"
+
+    def test_identical_urls_match(self):
+        url1 = "https://example.com/article?id=42"
+        url2 = "https://example.com/article?id=42"
+        assert _normalize_url(url1) == _normalize_url(url2)
+
+
+# ---------------------------------------------------------------------------
+# Citation key parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseCitationKey:
+    """Tests for knowledge-layer citation key parsing."""
+
+    def test_filename_with_page(self):
+        filename, page = _parse_citation_key("report.pdf, p.15")
+        assert filename == "report.pdf"
+        assert page == 15
+
+    def test_filename_with_page_word(self):
+        filename, page = _parse_citation_key("report.pdf, page 15")
+        assert filename == "report.pdf"
+        assert page == 15
+
+    def test_filename_only(self):
+        filename, page = _parse_citation_key("report.pdf")
+        assert filename == "report.pdf"
+        assert page is None
+
+    def test_filename_with_spaces(self):
+        filename, page = _parse_citation_key("my report.pdf, p.3")
+        assert filename == "my report.pdf"
+        assert page == 3
+
+
+# ---------------------------------------------------------------------------
+# SourceRegistry tests
+# ---------------------------------------------------------------------------
+
+
+class TestSourceRegistry:
+    """Tests for SourceRegistry."""
+
+    @pytest.fixture(name="registry")
+    def fixture_registry(self):
+        return SourceRegistry()
+
+    def test_add_and_has_url(self, registry):
+        registry.add(SourceEntry(url="https://example.com/article", source_type="tavily"))
+        assert registry.has_url("https://example.com/article")
+
+    def test_url_normalization_on_lookup(self, registry):
+        registry.add(SourceEntry(url="https://Example.COM/path/"))
+        assert registry.has_url("https://example.com/path")
+
+    def test_missing_url_returns_false(self, registry):
+        registry.add(SourceEntry(url="https://example.com/a"))
+        assert not registry.has_url("https://example.com/b")
+
+    def test_has_citation_key_exact(self, registry):
+        registry.add(SourceEntry(citation_key="report.pdf, p.15", source_type="knowledge_layer"))
+        assert registry.has_citation_key("report.pdf, p.15")
+
+    def test_has_citation_key_fuzzy_page_format(self, registry):
+        registry.add(SourceEntry(citation_key="report.pdf, p.15"))
+        assert registry.has_citation_key("report.pdf, page 15")
+
+    def test_has_citation_key_case_insensitive(self, registry):
+        registry.add(SourceEntry(citation_key="Report.PDF, p.15"))
+        assert registry.has_citation_key("report.pdf, p.15")
+
+    def test_has_citation_key_no_page(self, registry):
+        registry.add(SourceEntry(citation_key="report.pdf"))
+        assert registry.has_citation_key("report.pdf")
+
+    def test_has_citation_key_mismatch(self, registry):
+        registry.add(SourceEntry(citation_key="report.pdf, p.15"))
+        assert not registry.has_citation_key("other.pdf, p.15")
+
+    def test_all_sources(self, registry):
+        e1 = SourceEntry(url="https://a.com")
+        e2 = SourceEntry(citation_key="doc.pdf")
+        registry.add(e1)
+        registry.add(e2)
+        assert len(registry.all_sources()) == 2
+
+    def test_clear(self, registry):
+        registry.add(SourceEntry(url="https://a.com"))
+        registry.clear()
+        assert not registry.has_url("https://a.com")
+        assert len(registry.all_sources()) == 0
+
+    def test_deduplicates_urls(self, registry):
+        registry.add(SourceEntry(url="https://example.com/page"))
+        registry.add(SourceEntry(url="https://example.com/page"))
+        # all_sources has both but internal URL dict deduplicates
+        assert registry.has_url("https://example.com/page")
+        assert len(registry.all_sources()) == 2  # all_sources keeps both
+
+    def test_resolve_url_exact_match(self, registry):
+        registry.add(SourceEntry(url="https://arxiv.org/abs/1706.03762"))
+        assert registry.resolve_url("https://arxiv.org/abs/1706.03762") == "https://arxiv.org/abs/1706.03762"
+
+    def test_resolve_url_truncated_path(self, registry):
+        """LLM truncated the URL path — resolve to full canonical URL."""
+        registry.add(SourceEntry(url="https://arxiv.org/abs/1706.03762"))
+        assert registry.resolve_url("https://arxiv.org/abs/1706") == "https://arxiv.org/abs/1706.03762"
+
+    def test_resolve_url_domain_only(self, registry):
+        """LLM kept domain but dropped entire path."""
+        registry.add(SourceEntry(url="https://arxiv.org/abs/1706.03762"))
+        assert registry.resolve_url("https://arxiv.org") == "https://arxiv.org/abs/1706.03762"
+
+    def test_resolve_url_no_match(self, registry):
+        registry.add(SourceEntry(url="https://arxiv.org/abs/1706.03762"))
+        assert registry.resolve_url("https://totally-different.com") is None
+
+    def test_resolve_url_with_ellipsis_truncation(self, registry):
+        """LLM wrote URL with trailing '...' which gets stripped."""
+        registry.add(SourceEntry(url="https://example.com/very/long/path/article"))
+        # After stripping "...", the truncated URL should match
+        resolved = registry.resolve_url("https://example.com/very/long")
+        assert resolved == "https://example.com/very/long/path/article"
+
+    def test_resolve_url_ambiguous_returns_none(self, registry):
+        """Multiple registry URLs match the prefix — reject to avoid guessing."""
+        registry.add(SourceEntry(url="https://arxiv.org/abs/1706.03762"))
+        registry.add(SourceEntry(url="https://arxiv.org/abs/1706.08500"))
+        # "https://arxiv.org/abs/1706" is a prefix of both — ambiguous
+        assert registry.resolve_url("https://arxiv.org/abs/1706") is None
+
+    def test_resolve_url_unique_prefix_succeeds(self, registry):
+        """Single registry URL matches the prefix — unambiguous, return it."""
+        registry.add(SourceEntry(url="https://arxiv.org/abs/1706.03762"))
+        registry.add(SourceEntry(url="https://arxiv.org/abs/2301.00001"))
+        # "https://arxiv.org/abs/1706" only matches the first
+        assert registry.resolve_url("https://arxiv.org/abs/1706") == "https://arxiv.org/abs/1706.03762"
+
+
+# ---------------------------------------------------------------------------
+# Parser tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenericUrlExtractor:
+    """Tests for the generic URL extractor (works for all tool output formats)."""
+
+    def test_tavily_xml_format(self):
+        content = (
+            '<Document href="https://example.com/article">\n'
+            "<title>\nTest Article\n</title>\n"
+            "Some content here.\n</Document>"
+        )
+        entries = extract_sources_from_tool_result("tavily_web_search", content)
+        assert len(entries) == 1
+        assert entries[0].url == "https://example.com/article"
+
+    def test_multiple_urls_deduplicated(self):
+        content = (
+            '<Document href="https://a.com">\nContent A\n</Document>'
+            "\n\n---\n\n"
+            '<Document href="https://b.com">\nContent B\n</Document>'
+        )
+        entries = extract_sources_from_tool_result("any_tool", content)
+        assert len(entries) == 2
+        assert entries[0].url == "https://a.com"
+        assert entries[1].url == "https://b.com"
+
+    def test_paper_search_markdown_format(self):
+        content = (
+            "1. **Attention Is All You Need** (2017)\n"
+            "   - **Publication**: NeurIPS\n"
+            "   - **Link**: https://arxiv.org/abs/1706.03762"
+        )
+        entries = extract_sources_from_tool_result("paper_search_tool", content)
+        assert len(entries) == 1
+        assert entries[0].url == "https://arxiv.org/abs/1706.03762"
+
+    def test_plain_text_with_urls(self):
+        """Generic extractor works even for unknown tool formats."""
+        content = "Check out https://example.com/page and also https://other.com/doc for details."
+        entries = extract_sources_from_tool_result("totally_new_tool", content)
+        assert len(entries) == 2
+
+    def test_config_tool_names_work(self):
+        """Tools named 'web_search_tool' or 'advanced_web_search_tool' work."""
+        content = '<Document href="https://example.com">\nContent\n</Document>'
+        for name in ["web_search_tool", "advanced_web_search_tool", "my_custom_search"]:
+            entries = extract_sources_from_tool_result(name, content)
+            assert len(entries) == 1, f"Failed for tool name: {name}"
+
+    def test_empty_content_returns_empty(self):
+        entries = extract_sources_from_tool_result("any_tool", "Search returned no results")
+        assert len(entries) == 0
+
+    def test_duplicate_urls_deduplicated(self):
+        content = "See https://example.com/page and also https://example.com/page for reference."
+        entries = extract_sources_from_tool_result("any_tool", content)
+        assert len(entries) == 1
+
+
+class TestKnowledgeLayerParser:
+    """Tests for knowledge layer output parser."""
+
+    def test_parse_single_result(self):
+        content = (
+            "Found 1 relevant document(s):\n\n"
+            "--- Result 1 ---\n"
+            "Source: report.pdf\n"
+            "Page: 15\n"
+            "Citation: report.pdf, p.15\n"
+            "Content Type: text\n"
+            "Relevance Score: 0.85\n\n"
+            "Some content from the document."
+        )
+        entries = extract_sources_from_tool_result("knowledge_retrieval", content)
+        assert len(entries) == 1
+        assert entries[0].citation_key == "report.pdf, p.15"
+        assert entries[0].title == "report.pdf"
+        assert entries[0].url is None
+        assert entries[0].source_type == "knowledge_layer"
+
+    def test_parse_multiple_results(self):
+        content = (
+            "Found 2 relevant document(s):\n\n"
+            "--- Result 1 ---\n"
+            "Source: doc1.pdf\n"
+            "Citation: doc1.pdf\n\n"
+            "Content 1.\n\n"
+            "--- Result 2 ---\n"
+            "Source: doc2.pdf\n"
+            "Page: 3\n"
+            "Citation: doc2.pdf, p.3\n\n"
+            "Content 2."
+        )
+        entries = extract_sources_from_tool_result("knowledge_retrieval", content)
+        assert len(entries) == 2
+        assert entries[0].citation_key == "doc1.pdf"
+        assert entries[1].citation_key == "doc2.pdf, p.3"
+
+
+class TestParserDispatcher:
+    """Tests for parser dispatcher and fallback behavior."""
+
+    def test_unknown_tool_no_urls_returns_empty(self):
+        entries = extract_sources_from_tool_result("totally_unknown_tool", "some content without links")
+        assert entries == []
+
+    def test_unknown_tool_with_urls_extracts_them(self):
+        """Generic fallback extracts URLs from any unknown tool."""
+        entries = extract_sources_from_tool_result("future_tool", "See https://example.com for details")
+        assert len(entries) == 1
+        assert entries[0].url == "https://example.com"
+
+    def test_custom_parser_takes_priority(self):
+        """Registered parsers take priority over generic fallback."""
+
+        def _parse_custom(content: str, tool_name: str) -> list[SourceEntry]:
+            return [SourceEntry(url="https://custom.com", source_type="custom", tool_name=tool_name)]
+
+        register_source_parser(lambda name: "my_custom" in name, _parse_custom)
+        entries = extract_sources_from_tool_result("my_custom_tool", "anything")
+        assert len(entries) == 1
+        assert entries[0].url == "https://custom.com"
+        assert entries[0].source_type == "custom"
+
+
+# ---------------------------------------------------------------------------
+# verify_citations tests
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyCitations:
+    """Tests for verify_citations()."""
+
+    @pytest.fixture(name="registry")
+    def fixture_registry(self):
+        reg = SourceRegistry()
+        reg.add(SourceEntry(url="https://valid.com/article1", title="Article 1", source_type="tavily"))
+        reg.add(SourceEntry(url="https://valid.com/article2", title="Article 2", source_type="tavily"))
+        reg.add(SourceEntry(citation_key="report.pdf, p.15", title="report.pdf", source_type="knowledge_layer"))
+        return reg
+
+    def test_empty_registry_returns_unchanged(self):
+        registry = SourceRegistry()
+        report = "Some report with [1] citations.\n\n## Sources\n[1] Fake: https://fake.com"
+        result = verify_citations(report, registry)
+        assert result.verified_report == report
+        assert len(result.removed_citations) == 0
+
+    def test_no_references_section_returns_unchanged(self, registry):
+        report = "A report without any references section."
+        result = verify_citations(report, registry)
+        assert result.verified_report == report
+
+    def test_valid_citations_preserved(self, registry):
+        report = (
+            "Finding one [1]. Finding two [2].\n\n"
+            "## Sources\n"
+            "[1] Article 1: https://valid.com/article1\n"
+            "[2] Article 2: https://valid.com/article2"
+        )
+        result = verify_citations(report, registry)
+        assert "[1]" in result.verified_report
+        assert "[2]" in result.verified_report
+        assert len(result.valid_citations) == 2
+        assert len(result.removed_citations) == 0
+
+    def test_invalid_citation_removed(self, registry):
+        report = (
+            "Good finding [1]. Bad finding [2].\n\n"
+            "## Sources\n"
+            "[1] Article 1: https://valid.com/article1\n"
+            "[2] Fake Source: https://fake.com/nonexistent"
+        )
+        result = verify_citations(report, registry)
+        assert len(result.removed_citations) == 1
+        assert result.removed_citations[0]["number"] == 2
+        assert result.removed_citations[0]["reason"] == "url_not_in_registry"
+        # Body should have [2] removed
+        assert "[2]" not in result.verified_report
+        # [1] stays as [1]
+        assert "[1]" in result.verified_report
+
+    def test_renumbering_after_removal(self, registry):
+        report = (
+            "A [1]. B [2]. C [3].\n\n"
+            "## Sources\n"
+            "[1] Article 1: https://valid.com/article1\n"
+            "[2] Fake: https://fake.com\n"
+            "[3] Article 2: https://valid.com/article2"
+        )
+        result = verify_citations(report, registry)
+        assert result.renumber_map == {1: 1, 3: 2}
+        assert "A [1]" in result.verified_report
+        assert "C [2]" in result.verified_report
+        assert "[3]" not in result.verified_report
+
+    def test_knowledge_layer_citation_validated(self, registry):
+        report = "Internal finding [1].\n\n## Sources\n[1] report.pdf, p.15"
+        result = verify_citations(report, registry)
+        assert len(result.valid_citations) == 1
+        assert len(result.removed_citations) == 0
+
+    def test_knowledge_layer_citation_fuzzy_match(self, registry):
+        report = "Finding [1].\n\n## Sources\n[1] report.pdf, page 15"
+        result = verify_citations(report, registry)
+        assert len(result.valid_citations) == 1
+
+    def test_all_citations_removed(self, registry):
+        report = "Bad finding [1].\n\n## Sources\n[1] Totally Fake: https://fake.com/nothing"
+        result = verify_citations(report, registry)
+        assert len(result.valid_citations) == 0
+        assert len(result.removed_citations) == 1
+        assert "[1]" not in result.verified_report
+
+    def test_grouped_inline_citations(self, registry):
+        report = (
+            "Finding [1][2][3].\n\n"
+            "## Sources\n"
+            "[1] Article 1: https://valid.com/article1\n"
+            "[2] Fake: https://fake.com\n"
+            "[3] Article 2: https://valid.com/article2"
+        )
+        result = verify_citations(report, registry)
+        # [2] removed, [3] renumbered to [2]
+        assert "Finding [1][2]." in result.verified_report
+
+    def test_references_with_dashes(self, registry):
+        """Shallow researcher uses '- [N] Title - URL' format."""
+        report = "Finding [1].\n\n**References:**\n- [1] Article 1 - https://valid.com/article1"
+        result = verify_citations(report, registry)
+        assert len(result.valid_citations) == 1
+
+    def test_references_bold_without_colon(self, registry):
+        """Model sometimes outputs **References** without the colon."""
+        report = "Finding [1].\n\n**References**\n- [1] Article 1 - https://valid.com/article1"
+        result = verify_citations(report, registry)
+        assert len(result.valid_citations) == 1
+
+    def test_references_bold_with_trailing_spaces(self, registry):
+        """Model outputs **References** followed by trailing spaces."""
+        report = "Finding [1].\n\n**References**  \n- [1] Article 1 - https://valid.com/article1"
+        result = verify_citations(report, registry)
+        assert len(result.valid_citations) == 1
+
+    def test_references_with_hash_header_variants(self, registry):
+        """Test ### Sources header variant."""
+        report = "Finding [1].\n\n### Sources\n[1] Article 1: https://valid.com/article1"
+        result = verify_citations(report, registry)
+        assert len(result.valid_citations) == 1
+
+    def test_unverifiable_citation_removed(self, registry):
+        """Citation with no URL and no recognizable citation key is removed."""
+        report = (
+            "Finding [1]. Other [2].\n\n"
+            "## Sources\n"
+            "[1] Article 1: https://valid.com/article1\n"
+            "[2] Some vague reference with no URL"
+        )
+        result = verify_citations(report, registry)
+        assert len(result.removed_citations) == 1
+        assert result.removed_citations[0]["reason"] == "unverifiable"
+
+    def test_knowledge_citation_with_internal_label(self, registry):
+        """Knowledge citation with '(Internal)' suffix."""
+        report = "Finding [1].\n\n**References:**\n- [1] report.pdf, p.15 (Internal)"
+        result = verify_citations(report, registry)
+        assert len(result.valid_citations) == 1
+
+    def test_garbled_url_repaired_to_canonical(self):
+        """LLM truncated a URL — verify_citations repairs it to the full canonical URL."""
+        reg = SourceRegistry()
+        reg.add(SourceEntry(url="https://example.com/papers/deep-learning-2024", source_type="generic"))
+        report = "Finding [1].\n\n## Sources\n[1] Paper: https://example.com/papers/deep-learning"
+        result = verify_citations(report, reg)
+        assert len(result.valid_citations) == 1
+        # The truncated URL should be repaired to the full canonical URL
+        assert "https://example.com/papers/deep-learning-2024" in result.verified_report
+
+    def test_garbled_url_domain_only_repaired(self):
+        """LLM dropped entire path — repair to full URL."""
+        reg = SourceRegistry()
+        reg.add(SourceEntry(url="https://arxiv.org/abs/1706.03762", source_type="generic"))
+        report = "Finding [1].\n\n## Sources\n[1] Paper: https://arxiv.org"
+        result = verify_citations(report, reg)
+        assert len(result.valid_citations) == 1
+        assert "https://arxiv.org/abs/1706.03762" in result.verified_report
+
+
+# ---------------------------------------------------------------------------
+# sanitize_report tests
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeReport:
+    """Tests for deterministic report sanitization."""
+
+    def test_bare_urls_stripped_from_body(self):
+        report = (
+            "NVIDIA is great (see https://nvidia.com/gpus for details) [1].\n\n"
+            "## Sources\n"
+            "[1] NVIDIA: https://nvidia.com/article"
+        )
+        result = sanitize_report(report)
+        assert "https://nvidia.com/gpus" not in result.sanitized_report
+        # URL in references preserved
+        assert "https://nvidia.com/article" in result.sanitized_report
+        assert result.body_urls_removed == 1
+
+    def test_markdown_links_preserved_in_body(self):
+        """Markdown hyperlinks [text](url) should NOT be stripped from body."""
+        report = (
+            "Read the [NVIDIA docs](https://nvidia.com/docs/guide) for details [1].\n\n"
+            "## Sources\n"
+            "[1] Article: https://example.com/article"
+        )
+        result = sanitize_report(report)
+        assert "[NVIDIA docs](https://nvidia.com/docs/guide)" in result.sanitized_report
+        assert result.body_urls_removed == 0
+
+    def test_body_without_urls_unchanged(self):
+        report = (
+            "Finding [1]. Another finding [2].\n\n"
+            "## Sources\n"
+            "[1] Title: https://example.com/article\n"
+            "[2] Title: https://other.com/page"
+        )
+        result = sanitize_report(report)
+        assert result.body_urls_removed == 0
+        assert "Finding [1]" in result.sanitized_report
+
+    def test_shortened_url_removed_from_references(self):
+        report = "Finding [1].\n\n## Sources\n[1] Article: https://bit.ly/abc123"
+        result = sanitize_report(report)
+        assert "bit.ly" not in result.sanitized_report
+        assert len(result.shortened_urls_removed) == 1
+        assert "bit.ly" in result.shortened_urls_removed[0]
+
+    def test_tco_shortened_url_removed(self):
+        report = "Finding [1].\n\n## Sources\n[1] Tweet: https://t.co/xyz789"
+        result = sanitize_report(report)
+        assert "t.co" not in result.sanitized_report
+        assert len(result.shortened_urls_removed) == 1
+
+    def test_ip_address_url_removed(self):
+        report = "Finding [1].\n\n## Sources\n[1] Suspicious: https://192.168.1.1/malware"
+        result = sanitize_report(report)
+        assert "192.168.1.1" not in result.sanitized_report
+        assert len(result.unsafe_urls_removed) == 1
+
+    def test_legitimate_urls_preserved(self):
+        report = (
+            "Finding [1] and [2].\n\n"
+            "## Sources\n"
+            "[1] Paper: https://arxiv.org/abs/1706.03762\n"
+            "[2] News: https://www.reuters.com/technology/nvidia-2026"
+        )
+        result = sanitize_report(report)
+        assert "arxiv.org" in result.sanitized_report
+        assert "reuters.com" in result.sanitized_report
+        assert result.body_urls_removed == 0
+        assert len(result.shortened_urls_removed) == 0
+        assert len(result.unsafe_urls_removed) == 0
+
+    def test_multiple_shorteners_all_removed(self):
+        report = (
+            "Finding [1][2][3].\n\n"
+            "## Sources\n"
+            "[1] A: https://bit.ly/abc\n"
+            "[2] B: https://tinyurl.com/def\n"
+            "[3] C: https://arxiv.org/real-paper"
+        )
+        result = sanitize_report(report)
+        assert "bit.ly" not in result.sanitized_report
+        assert "tinyurl.com" not in result.sanitized_report
+        assert "arxiv.org" in result.sanitized_report
+        assert len(result.shortened_urls_removed) == 2
+
+    def test_no_references_section(self):
+        """Report without references — only body URL stripping applies."""
+        report = "Check https://example.com for more info."
+        result = sanitize_report(report)
+        assert "https://example.com" not in result.sanitized_report
+        assert result.body_urls_removed == 1
+
+    def test_truncated_url_with_ellipsis_removed(self):
+        """URL ending in ... is truncated/garbled — entire reference line removed."""
+        report = "Finding [1].\n\n## Sources\n[1] Paper: https://arxiv.org/abs/1706.037..."
+        result = sanitize_report(report)
+        # The entire reference line with the truncated URL should be gone
+        assert "[1] Paper:" not in result.sanitized_report
+        assert len(result.truncated_urls_removed) == 1
+
+    def test_domain_only_url_preserved(self):
+        """Domain-only URLs are legitimate if they came from tool results."""
+        report = "Finding [1].\n\n## Sources\n[1] Weather API: https://www.weatherapi.com/"
+        result = sanitize_report(report)
+        assert "weatherapi.com" in result.sanitized_report
+        assert len(result.truncated_urls_removed) == 0
+
+    def test_full_url_not_flagged_as_truncated(self):
+        """URLs with actual paths are fine."""
+        report = "Finding [1].\n\n## Sources\n[1] Paper: https://arxiv.org/abs/1706.03762"
+        result = sanitize_report(report)
+        assert "arxiv.org/abs/1706.03762" in result.sanitized_report
+        assert len(result.truncated_urls_removed) == 0
+
+    def test_mixed_issues(self):
+        """Body URL + shortened reference + valid references."""
+        report = (
+            "See https://nvidia.com/gpus inline [1][2].\n\n"
+            "## Sources\n"
+            "[1] Good: https://arxiv.org/abs/paper\n"
+            "[2] Short: https://bit.ly/short"
+        )
+        result = sanitize_report(report)
+        assert "https://nvidia.com" not in result.sanitized_report
+        assert "arxiv.org/abs/paper" in result.sanitized_report
+        assert "bit.ly" not in result.sanitized_report
+        assert result.body_urls_removed == 1
+        assert len(result.shortened_urls_removed) == 1

--- a/tests/aiq_agent/common/test_data_sources.py
+++ b/tests/aiq_agent/common/test_data_sources.py
@@ -194,7 +194,7 @@ class TestFilterToolsBySourcesMixed:
         assert other_tool in result
 
     def test_filter_all_three_source_types(self):
-        """Test filtering with web_search, knowledge_layer, and ECI sources."""
+        """Test filtering with web_search and knowledge_layer sources."""
         web_tool = MagicMock()
         web_tool.name = "tavily_search"
         knowledge_tool = MagicMock()
@@ -219,7 +219,7 @@ class TestFilterToolsBySourcesMixed:
         assert web_tool in result
 
     def test_filter_preserves_other_tools(self):
-        """Test that non-search/ECI tools are always included."""
+        """Test that non-search tools are always included."""
         calculator = MagicMock()
         calculator.name = "calculator"
         code_executor = MagicMock()

--- a/tests/aiq_agent/common/test_source_metadata.py
+++ b/tests/aiq_agent/common/test_source_metadata.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for source_metadata encode/extract helpers."""
+
+from aiq_agent.common.source_metadata import SourceRef
+from aiq_agent.common.source_metadata import encode_source_metadata
+from aiq_agent.common.source_metadata import extract_source_metadata
+
+
+class TestEncodeSourceMetadata:
+    """Tests for encode_source_metadata."""
+
+    def test_appends_metadata_block(self):
+        refs = [SourceRef(url="https://example.com", title="Example")]
+        result = encode_source_metadata("Hello world", refs)
+        assert result.startswith("Hello world")
+        assert "TOOL_SOURCE_METADATA" in result
+        assert "https://example.com" in result
+
+    def test_empty_sources_returns_content_unchanged(self):
+        result = encode_source_metadata("Hello world", [])
+        assert result == "Hello world"
+
+    def test_multiple_sources(self):
+        refs = [
+            SourceRef(url="https://a.com", title="A"),
+            SourceRef(url="https://b.com", title="B"),
+        ]
+        result = encode_source_metadata("content", refs)
+        assert "https://a.com" in result
+        assert "https://b.com" in result
+
+    def test_citation_key_sources(self):
+        refs = [SourceRef(citation_key="report.pdf, p.5", title="report.pdf")]
+        result = encode_source_metadata("content", refs)
+        assert "report.pdf" in result
+        assert "citation_key" in result
+
+    def test_excludes_none_fields(self):
+        refs = [SourceRef(url="https://x.com")]
+        result = encode_source_metadata("content", refs)
+        assert "title" not in result
+        assert "citation_key" not in result
+
+
+class TestExtractSourceMetadata:
+    """Tests for extract_source_metadata."""
+
+    def test_extracts_metadata_and_strips(self):
+        refs = [SourceRef(url="https://example.com", title="Example")]
+        encoded = encode_source_metadata("Hello world", refs)
+        clean, extracted = extract_source_metadata(encoded)
+        assert clean == "Hello world"
+        assert extracted is not None
+        assert len(extracted) == 1
+        assert extracted[0].url == "https://example.com"
+        assert extracted[0].title == "Example"
+
+    def test_no_metadata_returns_none(self):
+        clean, extracted = extract_source_metadata("Just plain text")
+        assert clean == "Just plain text"
+        assert extracted is None
+
+    def test_roundtrip_multiple_sources(self):
+        refs = [
+            SourceRef(url="https://a.com", title="A"),
+            SourceRef(url="https://b.com", title="B"),
+            SourceRef(citation_key="doc.pdf, p.3"),
+        ]
+        encoded = encode_source_metadata("content", refs)
+        clean, extracted = extract_source_metadata(encoded)
+        assert clean == "content"
+        assert len(extracted) == 3
+        assert extracted[0].url == "https://a.com"
+        assert extracted[2].citation_key == "doc.pdf, p.3"
+
+    def test_malformed_json_returns_none(self):
+        bad = "content\n\n<!-- TOOL_SOURCE_METADATA:{not valid json -->"
+        clean, extracted = extract_source_metadata(bad)
+        assert clean == bad
+        assert extracted is None
+
+    def test_empty_string(self):
+        clean, extracted = extract_source_metadata("")
+        assert clean == ""
+        assert extracted is None
+
+    def test_content_with_html_comments_not_confused(self):
+        text = "Some <!-- regular comment --> text"
+        clean, extracted = extract_source_metadata(text)
+        assert clean == text
+        assert extracted is None
+
+    def test_preserves_multiline_content(self):
+        content = "Line 1\n\nLine 2\n\nLine 3"
+        refs = [SourceRef(url="https://x.com")]
+        encoded = encode_source_metadata(content, refs)
+        clean, extracted = extract_source_metadata(encoded)
+        assert clean == content
+        assert len(extracted) == 1


### PR DESCRIPTION
- Tools (Tavily, Serper, knowledge layer) now embed typed url/title/citation_key data as a JSON comment in their string output. The middleware reads it directly instead of regex-parsing. Falls back to regex for tools without metadata

- Metadata stripped before LLM -- The JSON comment is removed from the content before the LLM sees it, so agent behavior is unchanged.

- On top of Ajays current citation branch
