### PR TITLE
Fix citation verification regression: session-scoped SourceRegistry

### DIFF
--- a/frontends/aiq_api/src/aiq_api/jobs/callbacks.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/callbacks.py
@@ -230,7 +230,6 @@ class AgentEventCallback(BaseCallbackHandler):
         self._job_id = event_store.job_id if event_store else None
         self._instance_discovered_urls: set[str] = set()
         self._instance_cited_urls: set[str] = set()
-        self._source_registry = None  # Set via set_source_registry() for verified citation tracking
         self._init_job_url_sets()
 
     def _init_job_url_sets(self) -> None:
@@ -346,22 +345,8 @@ class AgentEventCallback(BaseCallbackHandler):
                 return name
         return kwargs.get("name", "unknown")
 
-    def set_source_registry(self, registry) -> None:
-        """Attach a SourceRegistry for verified citation tracking.
-
-        When set, citation_source events use the registry (which captures
-        URLs from ALL tool calls via middleware) instead of the callback's
-        own pattern-based _is_search_tool check. This means:
-        - All tools are covered, not just ones matching SEARCH_TOOL_PATTERNS
-        - URL normalization is consistent with verify_citations()
-        - citation_use validation uses the same registry as post-processing
-        """
-        self._source_registry = registry
-
     def _get_source_registry(self):
-        """Return the active SourceRegistry: explicit > session ContextVar > None."""
-        if self._source_registry is not None:
-            return self._source_registry
+        """Return the session-scoped SourceRegistry if set, otherwise None."""
         try:
             from aiq_agent.common.citation_verification import get_session_registry
 

--- a/frontends/aiq_api/src/aiq_api/jobs/callbacks.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/callbacks.py
@@ -358,6 +358,17 @@ class AgentEventCallback(BaseCallbackHandler):
         """
         self._source_registry = registry
 
+    def _get_source_registry(self):
+        """Return the active SourceRegistry: explicit > session ContextVar > None."""
+        if self._source_registry is not None:
+            return self._source_registry
+        try:
+            from aiq_agent.common.citation_verification import get_session_registry
+
+            return get_session_registry()
+        except ImportError:
+            return None
+
     def emit_final_report(self, content: str) -> None:
         """Emit the post-processed final report as an OUTPUT artifact.
 
@@ -465,8 +476,9 @@ class AgentEventCallback(BaseCallbackHandler):
                 continue
 
             is_valid = False
-            if self._source_registry is not None:
-                is_valid = self._source_registry.has_url(url)
+            registry = self._get_source_registry()
+            if registry is not None:
+                is_valid = registry.has_url(url)
             else:
                 is_valid = normalized in self._discovered_urls
 

--- a/frontends/aiq_api/src/aiq_api/jobs/callbacks.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/callbacks.py
@@ -41,6 +41,8 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 
+from aiq_agent.common.citation_verification import get_session_registry
+
 if TYPE_CHECKING:
     from .event_store import EventStore
 
@@ -347,12 +349,7 @@ class AgentEventCallback(BaseCallbackHandler):
 
     def _get_source_registry(self):
         """Return the session-scoped SourceRegistry if set, otherwise None."""
-        try:
-            from aiq_agent.common.citation_verification import get_session_registry
-
-            return get_session_registry()
-        except ImportError:
-            return None
+        return get_session_registry()
 
     def emit_final_report(self, content: str) -> None:
         """Emit the post-processed final report as an OUTPUT artifact.

--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -290,11 +290,11 @@ class ChatResearcherAgent:
                 return END
 
             # Respect explicit escalation decision from shallow research.
-            # Note: successful shallow paths set shallow_result=None so this
-            # guard only fires when shallow explicitly set escalate_to_deep.
-            # With persistent checkpointers, ensure stale shallow_result from
-            # a prior turn is cleared before relying on this check.
-            if state.shallow_result is not None and not state.shallow_result.escalate_to_deep:
+            # Successful shallow paths set shallow_result=None so this guard
+            # only fires when shallow explicitly set escalate_to_deep.
+            if state.shallow_result is not None:
+                if state.shallow_result.escalate_to_deep:
+                    return "deep_research"
                 return END
 
             messages = state.messages

--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -44,6 +44,7 @@ from aiq_agent.agents.clarifier.models import ClarifierResult
 from aiq_agent.agents.deep_researcher.models import DeepResearchAgentState
 from aiq_agent.agents.shallow_researcher.models import ShallowResearchAgentState
 from aiq_agent.common import get_latest_user_query
+from aiq_agent.common.citation_verification import EmptySourceRegistryError
 
 from .models import ChatResearcherState
 from .models import ShallowResult
@@ -196,10 +197,32 @@ class ChatResearcherAgent:
                     available_documents=state.available_documents,
                 )
                 result = await self.shallow_research_fn(shallow_state)
+            except EmptySourceRegistryError:
+                logger.warning("Shallow research produced no verifiable sources")
+                err_msg = (
+                    "The search tools did not return any results for this question. "
+                    "This may be due to a temporary issue or the question may need to be rephrased. "
+                    "Please try again."
+                )
+                return {
+                    "messages": [AIMessage(content=err_msg)],
+                    "shallow_result": ShallowResult(
+                        answer=err_msg,
+                        confidence="high",
+                        escalate_to_deep=False,
+                    ),
+                }
             except Exception as e:
                 logger.exception("Error in shallow research: %s", e)
                 err_msg = "An error occurred while researching your question. Please try again."
-                return {"messages": [AIMessage(content=err_msg)]}
+                return {
+                    "messages": [AIMessage(content=err_msg)],
+                    "shallow_result": ShallowResult(
+                        answer=err_msg,
+                        confidence="high",
+                        escalate_to_deep=False,
+                    ),
+                }
 
             if not result.messages:
                 logger.error("Shallow research agent returned no messages")
@@ -217,10 +240,10 @@ class ChatResearcherAgent:
                 None,
             )
             if final_ai_message:
-                return {"messages": [final_ai_message]}
+                return {"messages": [final_ai_message], "shallow_result": None}
             if new_messages:
-                return {"messages": [new_messages[-1]]}
-            return {"messages": []}
+                return {"messages": [new_messages[-1]], "shallow_result": None}
+            return {"messages": [], "shallow_result": None}
 
         async def deep_research_node(state: ChatResearcherState) -> dict[str, Any]:
             trimmed_messages: list[BaseMessage] = trim_message_history(state.messages, self.max_history)
@@ -236,7 +259,16 @@ class ChatResearcherAgent:
                 clarifier_result=state.clarifier_result,
                 available_documents=state.available_documents,
             )
-            result = await self.deep_research_fn(deep_state)
+            try:
+                result = await self.deep_research_fn(deep_state)
+            except EmptySourceRegistryError:
+                logger.warning("Deep research produced no verifiable sources")
+                err_msg = (
+                    "The search tools did not return any results for this question. "
+                    "This may be due to a temporary issue or the question may need to be rephrased. "
+                    "Please try again."
+                )
+                return {"messages": [AIMessage(content=err_msg)]}
             if not result.messages:
                 error_message = "An error occurred during deep research."
                 logger.error(error_message)
@@ -255,6 +287,10 @@ class ChatResearcherAgent:
 
         def should_escalate(state: ChatResearcherState) -> str:
             if not self.enable_escalation:
+                return END
+
+            # Respect explicit escalation decision from shallow research
+            if state.shallow_result is not None and not state.shallow_result.escalate_to_deep:
                 return END
 
             messages = state.messages

--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -376,6 +376,7 @@ class ChatResearcherAgent:
                 "user_info": state.user_info,
                 "data_sources": state.data_sources,
                 "available_documents": state.available_documents,
+                "shallow_result": None,  # reset at turn boundary to avoid stale checkpoint state
             }
             messages = state.messages
 

--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -289,7 +289,11 @@ class ChatResearcherAgent:
             if not self.enable_escalation:
                 return END
 
-            # Respect explicit escalation decision from shallow research
+            # Respect explicit escalation decision from shallow research.
+            # Note: successful shallow paths set shallow_result=None so this
+            # guard only fires when shallow explicitly set escalate_to_deep.
+            # With persistent checkpointers, ensure stale shallow_result from
+            # a prior turn is cleared before relying on this check.
             if state.shallow_result is not None and not state.shallow_result.escalate_to_deep:
                 return END
 

--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -204,6 +204,10 @@ class ChatResearcherAgent:
                     "This may be due to a temporary issue or the question may need to be rephrased. "
                     "Please try again."
                 )
+                # confidence="high" reflects certainty that an error occurred and that the error
+                # message is the correct response — not uncertainty about the answer quality.
+                # escalate_to_deep=False because retrying deep research will not resolve a
+                # source registry or transient failure; the user should rephrase and retry.
                 return {
                     "messages": [AIMessage(content=err_msg)],
                     "shallow_result": ShallowResult(
@@ -215,6 +219,8 @@ class ChatResearcherAgent:
             except Exception as e:
                 logger.exception("Error in shallow research: %s", e)
                 err_msg = "An error occurred while researching your question. Please try again."
+                # Same rationale as EmptySourceRegistryError: the system is certain an error
+                # occurred; escalating to deep research will not resolve an unexpected exception.
                 return {
                     "messages": [AIMessage(content=err_msg)],
                     "shallow_result": ShallowResult(

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -26,6 +26,9 @@ from aiq_agent.common import _create_chat_response
 from aiq_agent.common import format_data_source_tools
 from aiq_agent.common import get_checkpointer
 from aiq_agent.common import is_verbose
+from aiq_agent.common.citation_verification import get_or_create_session_registry
+from aiq_agent.common.citation_verification import reset_session_registry
+from aiq_agent.common.citation_verification import set_session_registry
 from aiq_agent.observability.otel_header_redaction_exporter import (
     ensure_registered as _ensure_otel_redaction_registered,
 )
@@ -348,10 +351,6 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
         except Exception as e:
             logger.warning("Could not fetch available documents: %s", e)
         # Set session-scoped source registry for citation verification across turns
-        from aiq_agent.common.citation_verification import get_or_create_session_registry
-        from aiq_agent.common.citation_verification import reset_session_registry
-        from aiq_agent.common.citation_verification import set_session_registry
-
         session_registry = get_or_create_session_registry(nat_context_conversation_id)
         token = set_session_registry(session_registry)
         try:

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -347,13 +347,23 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
                 logger.debug("No session context - cannot determine collection")
         except Exception as e:
             logger.warning("Could not fetch available documents: %s", e)
+        # Set session-scoped source registry for citation verification across turns
+        from aiq_agent.common.citation_verification import get_or_create_session_registry
+        from aiq_agent.common.citation_verification import set_session_registry
+
+        session_registry = get_or_create_session_registry(nat_context_conversation_id)
+        set_session_registry(session_registry)
+
         state = ChatResearcherState(
             messages=[HumanMessage(content=query_text)],
             user_info=user_info_dict,
             data_sources=data_sources,
             available_documents=available_documents,
         )
-        result = await agent.run(state, thread_id=nat_context_conversation_id)
+        try:
+            result = await agent.run(state, thread_id=nat_context_conversation_id)
+        finally:
+            set_session_registry(None)
 
         if isinstance(result, dict):
             messages = result.get("messages", [])

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -350,7 +350,9 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
                 logger.debug("No session context - cannot determine collection")
         except Exception as e:
             logger.warning("Could not fetch available documents: %s", e)
-        # Set session-scoped source registry for citation verification across turns
+        # Set session-scoped source registry for citation verification across turns.
+        # When no conversation ID is available, get_or_create_session_registry returns a
+        # fresh per-request registry to prevent anonymous sessions from sharing state.
         session_registry = get_or_create_session_registry(nat_context_conversation_id)
         token = set_session_registry(session_registry)
         try:

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -349,21 +349,21 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
             logger.warning("Could not fetch available documents: %s", e)
         # Set session-scoped source registry for citation verification across turns
         from aiq_agent.common.citation_verification import get_or_create_session_registry
+        from aiq_agent.common.citation_verification import reset_session_registry
         from aiq_agent.common.citation_verification import set_session_registry
 
         session_registry = get_or_create_session_registry(nat_context_conversation_id)
-        set_session_registry(session_registry)
-
-        state = ChatResearcherState(
-            messages=[HumanMessage(content=query_text)],
-            user_info=user_info_dict,
-            data_sources=data_sources,
-            available_documents=available_documents,
-        )
+        token = set_session_registry(session_registry)
         try:
+            state = ChatResearcherState(
+                messages=[HumanMessage(content=query_text)],
+                user_info=user_info_dict,
+                data_sources=data_sources,
+                available_documents=available_documents,
+            )
             result = await agent.run(state, thread_id=nat_context_conversation_id)
         finally:
-            set_session_registry(None)
+            reset_session_registry(token)
 
         if isinstance(result, dict):
             messages = result.get("messages", [])

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -24,7 +24,6 @@ from aiq_agent.common import LLMRole
 from aiq_agent.common import load_prompt
 from aiq_agent.common import render_prompt_template
 from aiq_agent.common.citation_verification import EmptySourceRegistryError
-from aiq_agent.common.citation_verification import get_session_registry
 from aiq_agent.common.citation_verification import sanitize_report
 from aiq_agent.common.citation_verification import verify_citations
 
@@ -162,11 +161,6 @@ class DeepResearcherAgent:
             ModelRetryMiddleware(max_retries=10, backoff_factor=2.0, initial_delay=1.0),
         ]
 
-        # Share source registry with SSE callbacks for consistent citation tracking
-        for cb in self.callbacks:
-            if hasattr(cb, "set_source_registry"):
-                cb.set_source_registry(self.source_registry_middleware.registry)
-
     def _load_prompts(self) -> dict[str, str]:
         """Load all prompts for subagents."""
         prompts = {}
@@ -288,7 +282,7 @@ class DeepResearcherAgent:
 
         # Quick citation quality check — only reject if ALL citations are invalid
         # (full verification with repair/renumbering happens in run() post-processing)
-        if self.source_registry_middleware.registry.all_sources():
+        if self.source_registry_middleware._get_registry().all_sources():
             from aiq_agent.common.citation_verification import _CITATION_LINE_RE
             from aiq_agent.common.citation_verification import _REFERENCE_SECTION_RE
             from aiq_agent.common.citation_verification import _URL_IN_LINE_RE
@@ -298,7 +292,7 @@ class DeepResearcherAgent:
             if ref_match:
                 ref_section = content[ref_match.start() :]
                 has_any_valid = False
-                registry = self.source_registry_middleware.registry
+                registry = self.source_registry_middleware._get_registry()
                 for line_match in _CITATION_LINE_RE.finditer(ref_section):
                     ref_text = line_match.group(2).strip()
                     # Check URL citations
@@ -343,14 +337,6 @@ class DeepResearcherAgent:
         """
 
         agent = self._build_orchestrator_agent(state)
-
-        # Use session-scoped registry if available (conversation mode)
-        session_registry = get_session_registry()
-        if session_registry is not None:
-            self.source_registry_middleware.registry = session_registry
-            for cb in self.callbacks:
-                if hasattr(cb, "set_source_registry"):
-                    cb.set_source_registry(session_registry)
 
         messages = state.messages
         if messages:
@@ -428,8 +414,8 @@ class DeepResearcherAgent:
                 final_message = final_content if isinstance(final_content, str) else str(final_content)
 
             # Post-process: verify citations against source registry
-            if self.source_registry_middleware.registry.all_sources():
-                verification = verify_citations(final_message, self.source_registry_middleware.registry)
+            if self.source_registry_middleware._get_registry().all_sources():
+                verification = verify_citations(final_message, self.source_registry_middleware._get_registry())
                 if verification.removed_citations:
                     logger.info(
                         "Citation verification removed %d invalid citations: %s",

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -282,7 +282,8 @@ class DeepResearcherAgent:
 
         # Quick citation quality check — only reject if ALL citations are invalid
         # (full verification with repair/renumbering happens in run() post-processing)
-        if self.source_registry_middleware._get_registry().all_sources():
+        registry = self.source_registry_middleware._get_registry()
+        if registry.all_sources():
             from aiq_agent.common.citation_verification import _CITATION_LINE_RE
             from aiq_agent.common.citation_verification import _REFERENCE_SECTION_RE
             from aiq_agent.common.citation_verification import _URL_IN_LINE_RE
@@ -292,7 +293,6 @@ class DeepResearcherAgent:
             if ref_match:
                 ref_section = content[ref_match.start() :]
                 has_any_valid = False
-                registry = self.source_registry_middleware._get_registry()
                 for line_match in _CITATION_LINE_RE.finditer(ref_section):
                     ref_text = line_match.group(2).strip()
                     # Check URL citations

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -24,6 +24,7 @@ from aiq_agent.common import LLMRole
 from aiq_agent.common import load_prompt
 from aiq_agent.common import render_prompt_template
 from aiq_agent.common.citation_verification import EmptySourceRegistryError
+from aiq_agent.common.citation_verification import get_session_registry
 from aiq_agent.common.citation_verification import sanitize_report
 from aiq_agent.common.citation_verification import verify_citations
 
@@ -342,6 +343,14 @@ class DeepResearcherAgent:
         """
 
         agent = self._build_orchestrator_agent(state)
+
+        # Use session-scoped registry if available (conversation mode)
+        session_registry = get_session_registry()
+        if session_registry is not None:
+            self.source_registry_middleware.registry = session_registry
+            for cb in self.callbacks:
+                if hasattr(cb, "set_source_registry"):
+                    cb.set_source_registry(session_registry)
 
         messages = state.messages
         if messages:

--- a/src/aiq_agent/agents/deep_researcher/custom_middleware.py
+++ b/src/aiq_agent/agents/deep_researcher/custom_middleware.py
@@ -222,6 +222,12 @@ class SourceRegistryMiddleware(AgentMiddleware):
         self.registry = SourceRegistry()
         self._source_tool_names = source_tool_names or set()
 
+    def _get_registry(self) -> SourceRegistry:
+        """Return the session-scoped registry if set, otherwise the instance registry."""
+        from aiq_agent.common.citation_verification import get_session_registry
+
+        return get_session_registry() or self.registry
+
     async def awrap_tool_call(self, request, handler):
         """Capture sources from tool results after execution."""
         result = await handler(request)
@@ -232,8 +238,9 @@ class SourceRegistryMiddleware(AgentMiddleware):
             if tool_name not in self._source_tool_names:
                 return result
             sources = extract_sources_from_tool_result(tool_name, str(result.content))
+            active_registry = self._get_registry()
             for source in sources:
-                self.registry.add(source)
+                active_registry.add(source)
             if sources:
                 logger.info(
                     "[CitationRegistry] Captured %d source(s) from %s: %s",
@@ -254,7 +261,7 @@ class SourceRegistryMiddleware(AgentMiddleware):
 
         from aiq_agent.common.citation_verification import _normalize_url
 
-        sources = self.registry.all_sources()
+        sources = self._get_registry().all_sources()
         if not sources:
             return None
 

--- a/src/aiq_agent/agents/shallow_researcher/agent.py
+++ b/src/aiq_agent/agents/shallow_researcher/agent.py
@@ -114,13 +114,8 @@ class ShallowResearcherAgent:
         # Build tools info for prompt rendering
         self.tools_info = self._build_tools_info()
 
-        # Source registry for citation verification
+        # Source registry for citation verification (standalone mode fallback)
         self.source_registry = SourceRegistry()
-
-        # Share source registry with SSE callbacks for consistent citation tracking
-        for cb in self.callbacks:
-            if hasattr(cb, "set_source_registry"):
-                cb.set_source_registry(self.source_registry)
 
         # Build the LangGraph
         self._graph = self._build_graph()
@@ -240,6 +235,9 @@ class ShallowResearcherAgent:
             internal tools are ignored automatically.
             """
             result = await tool_node.ainvoke(state)
+            # Resolve registry at call time (not build time) so each request
+            # writes to its own session-scoped registry when available.
+            active_registry = get_session_registry() or self.source_registry
             for msg in result.get("messages", []):
                 if isinstance(msg, ToolMessage) and msg.content:
                     tool_name = getattr(msg, "name", "") or ""
@@ -247,7 +245,7 @@ class ShallowResearcherAgent:
                         continue
                     sources = extract_sources_from_tool_result(tool_name, str(msg.content))
                     for source in sources:
-                        self.source_registry.add(source)
+                        active_registry.add(source)
                     if sources:
                         logger.info(
                             "[CitationRegistry] Captured %d source(s) from %s: %s",
@@ -279,17 +277,15 @@ class ShallowResearcherAgent:
         Returns:
             Updated state with response in messages.
         """
-        # Use session-scoped registry if available (conversation mode),
-        # otherwise use instance registry with clear (standalone mode).
+        # Resolve the registry for this request: session-scoped (conversation
+        # mode) or instance-scoped with clear (standalone mode).  We use a
+        # local variable so we never mutate the shared agent instance.
         session_registry = get_session_registry()
         if session_registry is not None:
-            self.source_registry = session_registry
-            # Re-bind callbacks to use the session registry
-            for cb in self.callbacks:
-                if hasattr(cb, "set_source_registry"):
-                    cb.set_source_registry(self.source_registry)
+            registry = session_registry
         else:
             self.source_registry.clear()
+            registry = self.source_registry
 
         recursion_limit = (self.max_llm_turns * 2) + 10
         config = {"recursion_limit": recursion_limit}
@@ -305,14 +301,14 @@ class ShallowResearcherAgent:
                 content = str(last_msg.content)
 
                 # Step 1: verify citations against registry
-                if self.source_registry.all_sources():
-                    verification = verify_citations(content, self.source_registry)
+                if registry.all_sources():
+                    verification = verify_citations(content, registry)
                     logger.debug(
                         "Shallow researcher: citation verification complete — "
                         "%d valid, %d removed, %d sources in registry",
                         len(verification.valid_citations),
                         len(verification.removed_citations),
-                        len(self.source_registry.all_sources()),
+                        len(registry.all_sources()),
                     )
                     content = verification.verified_report
                 else:

--- a/src/aiq_agent/agents/shallow_researcher/agent.py
+++ b/src/aiq_agent/agents/shallow_researcher/agent.py
@@ -39,6 +39,7 @@ from aiq_agent.common import render_prompt_template
 from aiq_agent.common.citation_verification import EmptySourceRegistryError
 from aiq_agent.common.citation_verification import SourceRegistry
 from aiq_agent.common.citation_verification import extract_sources_from_tool_result
+from aiq_agent.common.citation_verification import get_session_registry
 from aiq_agent.common.citation_verification import sanitize_report
 from aiq_agent.common.citation_verification import verify_citations
 
@@ -278,7 +279,17 @@ class ShallowResearcherAgent:
         Returns:
             Updated state with response in messages.
         """
-        self.source_registry.clear()
+        # Use session-scoped registry if available (conversation mode),
+        # otherwise use instance registry with clear (standalone mode).
+        session_registry = get_session_registry()
+        if session_registry is not None:
+            self.source_registry = session_registry
+            # Re-bind callbacks to use the session registry
+            for cb in self.callbacks:
+                if hasattr(cb, "set_source_registry"):
+                    cb.set_source_registry(self.source_registry)
+        else:
+            self.source_registry.clear()
 
         recursion_limit = (self.max_llm_turns * 2) + 10
         config = {"recursion_limit": recursion_limit}
@@ -296,11 +307,13 @@ class ShallowResearcherAgent:
                 # Step 1: verify citations against registry
                 if self.source_registry.all_sources():
                     verification = verify_citations(content, self.source_registry)
-                    if verification.removed_citations:
-                        logger.info(
-                            "Shallow researcher: removed %d invalid citations",
-                            len(verification.removed_citations),
-                        )
+                    logger.debug(
+                        "Shallow researcher: citation verification complete — "
+                        "%d valid, %d removed, %d sources in registry",
+                        len(verification.valid_citations),
+                        len(verification.removed_citations),
+                        len(self.source_registry.all_sources()),
+                    )
                     content = verification.verified_report
                 else:
                     raise EmptySourceRegistryError("shallow research")

--- a/src/aiq_agent/common/__init__.py
+++ b/src/aiq_agent/common/__init__.py
@@ -39,6 +39,7 @@ from .citation_verification import SourceRegistry
 from .citation_verification import get_or_create_session_registry
 from .citation_verification import get_session_registry
 from .citation_verification import register_source_parser
+from .citation_verification import reset_session_registry
 from .citation_verification import sanitize_report
 from .citation_verification import set_session_registry
 from .citation_verification import verify_citations
@@ -82,6 +83,7 @@ __all__ = [
     "parse_data_sources",
     "register_source_parser",
     "render_prompt_template",
+    "reset_session_registry",
     "sanitize_report",
     "set_session_registry",
     "validate_tool_availability",

--- a/src/aiq_agent/common/__init__.py
+++ b/src/aiq_agent/common/__init__.py
@@ -36,8 +36,11 @@ from nat.data_models.api_server import UserMessageContentRoleType
 
 from .callbacks import VerboseTraceCallback
 from .citation_verification import SourceRegistry
+from .citation_verification import get_or_create_session_registry
+from .citation_verification import get_session_registry
 from .citation_verification import register_source_parser
 from .citation_verification import sanitize_report
+from .citation_verification import set_session_registry
 from .citation_verification import verify_citations
 from .data_sources import DEFAULT_DATA_SOURCES
 from .data_sources import extract_messages_and_sources
@@ -71,6 +74,8 @@ __all__ = [
     "format_data_source_tools",
     "format_tool_unavailability_error",
     "get_checkpointer",
+    "get_or_create_session_registry",
+    "get_session_registry",
     "get_latest_user_query",
     "is_postgres_dsn",
     "load_prompt",
@@ -78,6 +83,7 @@ __all__ = [
     "register_source_parser",
     "render_prompt_template",
     "sanitize_report",
+    "set_session_registry",
     "validate_tool_availability",
     "verify_citations",
 ]

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -267,8 +267,15 @@ _session_registries: OrderedDict[str, SourceRegistry] = OrderedDict()
 _session_registries_lock = threading.Lock()
 
 
-def get_or_create_session_registry(session_id: str) -> SourceRegistry:
-    """Get or create a session-scoped SourceRegistry (LRU, max 1000 sessions)."""
+def get_or_create_session_registry(session_id: str | None) -> SourceRegistry:
+    """Get or create a session-scoped SourceRegistry (LRU, max 1000 sessions).
+
+    When session_id is None (e.g. CLI or batch modes with no conversation context),
+    a fresh isolated SourceRegistry is returned on every call to prevent anonymous
+    sessions from sharing state and leaking citations across concurrent requests.
+    """
+    if session_id is None:
+        return SourceRegistry()
     with _session_registries_lock:
         if session_id in _session_registries:
             _session_registries.move_to_end(session_id)

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -147,8 +147,11 @@ def _parse_citation_key(key: str) -> tuple[str, int | None]:
 class SourceRegistry:
     """Registry of sources captured from tool call results.
 
-    Not thread-safe. In practice this is fine because deepagents subagents
-    run as async coroutines on the same event loop, not separate threads.
+    Not thread-safe — this is intentional.  All access happens on a single
+    asyncio event loop (cooperative concurrency), and Python's GIL already
+    protects the underlying dict/list/set operations from corruption.
+    The module-level ``_session_registries`` dict *is* lock-protected because
+    it is accessed across event loops when creating/looking up sessions.
     """
 
     def __init__(self) -> None:
@@ -158,7 +161,14 @@ class SourceRegistry:
         self._all: list[SourceEntry] = []
 
     def add(self, entry: SourceEntry) -> None:
-        """Register a source entry (deduplicated by normalized URL and citation key filename)."""
+        """Register a source entry (deduplicated by normalized URL and citation key filename).
+
+        Note: when an entry has both a url and a citation_key, and the URL
+        is new but the citation_key filename is already known, the entry is
+        added to _all (via the URL branch) but the citation_key is NOT
+        appended to _citation_keys.  This is intentional — in practice
+        entries carry either a URL or a citation_key, never both.
+        """
         added = False
         if entry.url:
             normalized = _normalize_url(entry.url)
@@ -273,6 +283,11 @@ def get_or_create_session_registry(session_id: str) -> SourceRegistry:
 def set_session_registry(registry: SourceRegistry | None) -> contextvars.Token:
     """Set the session-scoped SourceRegistry for the current async context."""
     return _session_source_registry.set(registry)
+
+
+def reset_session_registry(token: contextvars.Token) -> None:
+    """Restore the session-scoped SourceRegistry to its previous value."""
+    _session_source_registry.reset(token)
 
 
 def get_session_registry() -> SourceRegistry | None:

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -29,8 +29,11 @@ Usage:
 
 from __future__ import annotations
 
+import contextvars
 import logging
 import re
+import threading
+from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass
 from dataclasses import field
@@ -151,17 +154,27 @@ class SourceRegistry:
     def __init__(self) -> None:
         self._urls: dict[str, SourceEntry] = {}
         self._citation_keys: list[SourceEntry] = []
+        self._citation_key_files: set[str] = set()
         self._all: list[SourceEntry] = []
 
     def add(self, entry: SourceEntry) -> None:
-        """Register a source entry."""
-        self._all.append(entry)
+        """Register a source entry (deduplicated by normalized URL and citation key filename)."""
+        added = False
         if entry.url:
             normalized = _normalize_url(entry.url)
             if normalized not in self._urls:
                 self._urls[normalized] = entry
+                added = True
         if entry.citation_key:
-            self._citation_keys.append(entry)
+            filename, _ = _parse_citation_key(entry.citation_key)
+            key_lower = filename.lower()
+            if key_lower not in self._citation_key_files:
+                self._citation_key_files.add(key_lower)
+                self._citation_keys.append(entry)
+                if not added:
+                    added = True
+        if added:
+            self._all.append(entry)
 
     def has_url(self, url: str) -> bool:
         """Check if a URL (after normalization) is in the registry."""
@@ -227,7 +240,44 @@ class SourceRegistry:
         """Reset the registry."""
         self._urls.clear()
         self._citation_keys.clear()
+        self._citation_key_files.clear()
         self._all.clear()
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped registry (ContextVar)
+# ---------------------------------------------------------------------------
+
+_session_source_registry: contextvars.ContextVar[SourceRegistry | None] = contextvars.ContextVar(
+    "_session_source_registry", default=None
+)
+
+_MAX_SESSION_REGISTRIES = 1000
+_session_registries: OrderedDict[str, SourceRegistry] = OrderedDict()
+_session_registries_lock = threading.Lock()
+
+
+def get_or_create_session_registry(session_id: str) -> SourceRegistry:
+    """Get or create a session-scoped SourceRegistry (LRU, max 1000 sessions)."""
+    with _session_registries_lock:
+        if session_id in _session_registries:
+            _session_registries.move_to_end(session_id)
+            return _session_registries[session_id]
+        registry = SourceRegistry()
+        _session_registries[session_id] = registry
+        while len(_session_registries) > _MAX_SESSION_REGISTRIES:
+            _session_registries.popitem(last=False)
+        return registry
+
+
+def set_session_registry(registry: SourceRegistry | None) -> contextvars.Token:
+    """Set the session-scoped SourceRegistry for the current async context."""
+    return _session_source_registry.set(registry)
+
+
+def get_session_registry() -> SourceRegistry | None:
+    """Get the session-scoped SourceRegistry for the current async context."""
+    return _session_source_registry.get()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/aiq_agent/agents/shallow_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/shallow_researcher/test_agent.py
@@ -573,3 +573,29 @@ class TestShallowResearcherSessionRegistry:
 
         with pytest.raises(EmptySourceRegistryError):
             await agent.run(state)
+
+    @pytest.mark.asyncio
+    async def test_session_registry_does_not_mutate_shared_instance(self, mock_llm_provider, mock_llm):
+        """Setting a session registry must NOT overwrite self.source_registry on the agent."""
+        from aiq_agent.common.citation_verification import set_session_registry
+
+        session_reg = SourceRegistry()
+        session_reg.add(SourceEntry(url="https://session.example.com/doc"))
+
+        agent_response = AIMessage(content=("Answer [1].\n\n## Sources\n[1] Doc: https://session.example.com/doc"))
+        mock_llm.ainvoke = AsyncMock(return_value=agent_response)
+
+        agent = ShallowResearcherAgent(
+            llm_provider=mock_llm_provider,
+            tools=[web_search_tool],
+        )
+        original_registry = agent.source_registry
+
+        set_session_registry(session_reg)
+        try:
+            state = ShallowResearchAgentState(messages=[HumanMessage(content="Q")])
+            await agent.run(state)
+            # The instance attribute must remain unchanged
+            assert agent.source_registry is original_registry
+        finally:
+            set_session_registry(None)

--- a/tests/aiq_agent/agents/shallow_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/shallow_researcher/test_agent.py
@@ -489,3 +489,87 @@ class TestShallowResearcherSourceCaptureIntegration:
         assert "totally-fabricated.example.com" not in output
         # The valid citation should survive
         assert "docs.nvidia.com/cuda" in output
+
+
+# ---------------------------------------------------------------------------
+# Session registry integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestShallowResearcherSessionRegistry:
+    """Tests verifying session-scoped SourceRegistry integration.
+
+    These tests do NOT use the _bypass_citation_pipeline fixture — they verify
+    the actual ContextVar-based session registry behavior.
+    """
+
+    @pytest.fixture
+    def mock_llm(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock()
+        llm.bind_tools = MagicMock(return_value=llm)
+        return llm
+
+    @pytest.fixture
+    def mock_llm_provider(self, mock_llm):
+        provider = MagicMock(spec=LLMProvider)
+        provider.get = MagicMock(return_value=mock_llm)
+        return provider
+
+    @pytest.mark.asyncio
+    async def test_run_uses_session_registry_when_set(self, mock_llm_provider, mock_llm):
+        """When session registry is set via ContextVar, run() uses it and doesn't raise."""
+        from aiq_agent.common.citation_verification import set_session_registry
+
+        # Pre-populate a session registry with a source from a "prior turn"
+        session_reg = SourceRegistry()
+        session_reg.add(SourceEntry(url="https://prior-turn.example.com/article"))
+
+        # LLM answers from memory (no tool calls) citing the prior-turn URL
+        agent_response = AIMessage(
+            content=(
+                "Answer based on prior context [1].\n\n"
+                "## Sources\n"
+                "[1] Prior Article: https://prior-turn.example.com/article"
+            )
+        )
+        mock_llm.ainvoke = AsyncMock(return_value=agent_response)
+
+        agent = ShallowResearcherAgent(
+            llm_provider=mock_llm_provider,
+            tools=[web_search_tool],
+        )
+
+        set_session_registry(session_reg)
+        try:
+            state = ShallowResearchAgentState(messages=[HumanMessage(content="Follow-up question")])
+            result = await agent.run(state)
+            # Should NOT raise EmptySourceRegistryError because session registry has sources
+            assert result is not None
+            assert "prior-turn.example.com/article" in result.messages[-1].content
+        finally:
+            set_session_registry(None)
+
+    @pytest.mark.asyncio
+    async def test_run_clears_registry_in_standalone_mode(self, mock_llm_provider, mock_llm):
+        """Without session registry ContextVar, run() clears instance registry and raises."""
+        from aiq_agent.common.citation_verification import EmptySourceRegistryError
+        from aiq_agent.common.citation_verification import set_session_registry
+
+        set_session_registry(None)  # Ensure no session registry
+
+        # LLM answers without calling tools
+        agent_response = AIMessage(content="Answer without sources")
+        mock_llm.ainvoke = AsyncMock(return_value=agent_response)
+
+        agent = ShallowResearcherAgent(
+            llm_provider=mock_llm_provider,
+            tools=[web_search_tool],
+        )
+        # Pre-populate the instance registry (simulating stale data)
+        agent.source_registry.add(SourceEntry(url="https://stale.example.com"))
+
+        state = ShallowResearchAgentState(messages=[HumanMessage(content="Test")])
+
+        with pytest.raises(EmptySourceRegistryError):
+            await agent.run(state)

--- a/tests/aiq_agent/common/test_citation_verification.py
+++ b/tests/aiq_agent/common/test_citation_verification.py
@@ -166,9 +166,20 @@ class TestSourceRegistry:
     def test_deduplicates_urls(self, registry):
         registry.add(SourceEntry(url="https://example.com/page"))
         registry.add(SourceEntry(url="https://example.com/page"))
-        # all_sources has both but internal URL dict deduplicates
         assert registry.has_url("https://example.com/page")
-        assert len(registry.all_sources()) == 2  # all_sources keeps both
+        assert len(registry.all_sources()) == 1  # deduplicated by normalized URL
+
+    def test_deduplicates_citation_keys_by_filename(self, registry):
+        registry.add(SourceEntry(citation_key="report.pdf, p.5"))
+        registry.add(SourceEntry(citation_key="report.pdf, p.10"))
+        # Same file, different pages — deduplicated by filename
+        assert len(registry.all_sources()) == 1
+        assert registry.has_citation_key("report.pdf")
+
+    def test_different_citation_key_files_not_deduped(self, registry):
+        registry.add(SourceEntry(citation_key="report.pdf, p.5"))
+        registry.add(SourceEntry(citation_key="other.pdf, p.5"))
+        assert len(registry.all_sources()) == 2
 
     def test_resolve_url_exact_match(self, registry):
         registry.add(SourceEntry(url="https://arxiv.org/abs/1706.03762"))
@@ -728,3 +739,68 @@ class TestEmptySourceRegistryError:
     def test_is_exception(self):
         with pytest.raises(EmptySourceRegistryError):
             raise EmptySourceRegistryError("test")
+
+
+# ---------------------------------------------------------------------------
+# Session Registry
+# ---------------------------------------------------------------------------
+
+
+class TestSessionRegistry:
+    """Tests for session-scoped registry management."""
+
+    def setup_method(self):
+        """Clear session registries before each test."""
+        from aiq_agent.common.citation_verification import _session_registries
+        from aiq_agent.common.citation_verification import _session_registries_lock
+
+        with _session_registries_lock:
+            _session_registries.clear()
+
+    def test_get_or_create_returns_same_instance(self):
+        from aiq_agent.common.citation_verification import get_or_create_session_registry
+
+        r1 = get_or_create_session_registry("session-1")
+        r2 = get_or_create_session_registry("session-1")
+        assert r1 is r2
+
+    def test_different_sessions_different_registries(self):
+        from aiq_agent.common.citation_verification import get_or_create_session_registry
+
+        r1 = get_or_create_session_registry("session-a")
+        r2 = get_or_create_session_registry("session-b")
+        assert r1 is not r2
+
+    def test_contextvar_set_and_get(self):
+        from aiq_agent.common.citation_verification import get_session_registry
+        from aiq_agent.common.citation_verification import set_session_registry
+
+        assert get_session_registry() is None
+        reg = SourceRegistry()
+        set_session_registry(reg)
+        assert get_session_registry() is reg
+        set_session_registry(None)
+        assert get_session_registry() is None
+
+    def test_lru_eviction(self):
+        from aiq_agent.common.citation_verification import _MAX_SESSION_REGISTRIES
+        from aiq_agent.common.citation_verification import _session_registries
+        from aiq_agent.common.citation_verification import _session_registries_lock
+        from aiq_agent.common.citation_verification import get_or_create_session_registry
+
+        # Fill to max + 10
+        for i in range(_MAX_SESSION_REGISTRIES + 10):
+            get_or_create_session_registry(f"evict-{i}")
+        with _session_registries_lock:
+            assert len(_session_registries) == _MAX_SESSION_REGISTRIES
+
+    def test_sources_persist_across_calls(self):
+        """Sources added to a session registry persist when retrieved again."""
+        from aiq_agent.common.citation_verification import get_or_create_session_registry
+
+        reg = get_or_create_session_registry("persist-test")
+        reg.add(SourceEntry(url="https://example.com/first"))
+
+        reg2 = get_or_create_session_registry("persist-test")
+        assert reg2.has_url("https://example.com/first")
+        assert len(reg2.all_sources()) == 1


### PR DESCRIPTION
  ### Problem                                                                                                                                                                                                      
   
  PR #112 introduced `EmptySourceRegistryError` to prevent hallucinated citations in research reports. However, `SourceRegistry.clear()` is called at the start of every `ShallowResearcherAgent.run()`, wiping all sources from prior conversation turns. For follow-up questions where the LLM answers from memory (without calling tools), the registry is empty → `EmptySourceRegistryError` → crash → generic error message to user.

  Additionally, the error message contained the phrase "unable to find" which matched the escalation keyword heuristic in `should_escalate()`, causing failed shallow research to escalate to the clarifier/deep research pipeline instead of returning the error to the user.

  ### Root Cause

  **Trace — follow-up question crashes (before fix):**
  ```
[AGENT] ChatNVIDIA
  [Agent Response]
  The product announced for industrial digital-twin software tools is Omniverse Cloud for Industrial Digital Twin...

  References
  - [1] Valid Blog — https://valid.blog.link.com

  [Chain End] agent
  ERROR - aiq_agent.agents.shallow_researcher.register:114 - Error in shallow research execution.
    File "shallow_researcher/agent.py", line 306, in run
      raise EmptySourceRegistryError("shallow research")
  EmptySourceRegistryError: Research failed: no sources were captured during shallow research.

  The LLM answered from chat history context (prior turns had real tool results with URLs), but since no tools were called on this turn, the registry was empty.
```

  **Trace — tool auth failure escalates to clarifier (before fix):**
  ```
[Tool Start] web_search_tool
  [Tool Result] {'error': Exception('Error 401: Unauthorized')}
  [Tool Result] content='Search error: Error 401: Unauthorized'

  [Agent Response]
  Seattle in early March typically has cool, damp spring weather...

  ERROR - EmptySourceRegistryError: Research failed: no sources were captured
  WARNING - Shallow research produced no verifiable sources
  INFO - Clarifier: Starting (max 3 turns)    ← should NOT escalate here
```
  ### Changes

  **Session-scoped SourceRegistry (`citation_verification.py`)**
  - New `ContextVar` + LRU `OrderedDict` (max 1000 sessions) keyed by `conversation_id`
  - `get_or_create_session_registry()`, `get_session_registry()`, `set_session_registry()` APIs
  - Thread-safe via `threading.Lock` on the session dict

  **SourceRegistry dedup fix (`citation_verification.py`)**
  - `add()` now deduplicates by normalized URL AND citation key filename (via `set`)
  - `_all` list no longer accumulates duplicate entries across tool calls

  **Session registry wiring**
  - `chat_researcher/register.py`: Sets ContextVar per conversation turn in `_run()`, clears in `finally`
  - `shallow_researcher/agent.py`: Uses session registry if ContextVar set (no `clear()`); falls back to instance registry with `clear()` for standalone mode
  - `deep_researcher/agent.py`: Replaces middleware registry with session registry if ContextVar set

  **Error handling (`chat_researcher/agent.py`)**
  - Catches `EmptySourceRegistryError` specifically (before generic `Exception`)
  - Returns user-friendly message: "The search tools did not return any results for this question..."
  - Sets `ShallowResult(escalate_to_deep=False)` to prevent escalation
  - `should_escalate()` checks `shallow_result.escalate_to_deep` before keyword heuristic
  - Success paths explicitly clear `shallow_result` to avoid stale state blocking legitimate escalation

  **Observability (`shallow_researcher/agent.py`)**
  - Debug log on every verification run: `"citation verification complete — N valid, N removed, N sources in registry"`

  ### Traces after fix
```
  **Follow-up question — session registry has prior-turn sources:**
  [AGENT] ChatNVIDIA
  [Agent Response]
  The most recent weather reading for Seattle (5:30 am on March 4 2026) was:
  - Temperature: 9.4 °C (48.9 °F)
  - Condition: Light rain
  ...

  References:
  - [1] Weather in Seattle – weatherapi.com – https://www.weatherapi.com/
  - [2] Seattle weather in March 2026 – Weather25.com – https://www.weather25.com/...

  [Chain End] agent
  Shallow researcher: citation verification complete — 4 valid, 0 removed, 5 sources in registry
  ChatResearcherAgent: Workflow complete
```

  **Tool auth failure — error returned to user, no escalation:**
```
  [Tool Result] {'error': Exception('Error 401: Unauthorized')}
  [Agent Response] Seattle in early March typically has cool, damp spring weather...

  ERROR - EmptySourceRegistryError: Research failed: no sources were captured
  WARNING - Shallow research produced no verifiable sources
  ChatResearcherAgent: Workflow complete    ← goes to END, no clarifier

  Answer: The search tools did not return any results for this question.
  This may be due to a temporary issue or the question may need to be rephrased.
  Please try again.
```