### PR TITLE
Bug fixes aiq-agent

### DIFF
--- a/frontends/aiq_api/src/aiq_api/plugin.py
+++ b/frontends/aiq_api/src/aiq_api/plugin.py
@@ -188,10 +188,14 @@ class AIQAPIWorker(FastApiFrontEndPluginWorker):
 
         @app.on_event("shutdown")
         async def shutdown_sse_connections():
-            """Gracefully close all active SSE connections on shutdown."""
+            """Gracefully close all active SSE connections and background tasks on shutdown."""
             logger.info("Shutting down SSE connections...")
             connection_manager = get_connection_manager()
             await connection_manager.shutdown(timeout=5.0)
+
+            from .routes.jobs import stop_periodic_cleanup
+
+            await stop_periodic_cleanup()
 
             await EventStore.dispose_all_engines_async()
             logger.info("SSE shutdown complete")

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -492,6 +492,11 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
     # Start the ghost job reaper background task
     asyncio.create_task(_reap_ghost_jobs(job_store, db_url))
 
+    # Start periodic cleanup of expired jobs (NAT's job_info table) and old events (job_events table).
+    # NAT provides periodic_cleanup as a Dask task for job_info, but it must be explicitly submitted.
+    # We also run a local asyncio task for job_events cleanup since NAT doesn't manage that table.
+    _start_periodic_cleanup(job_store, scheduler_address, db_url, default_expiry_seconds, log_level, use_threads)
+
 
 GHOST_JOB_TIMEOUT_SECONDS = 300  # 5 minutes without events = ghost job
 GHOST_REAPER_INTERVAL_SECONDS = 60  # check every 60 seconds
@@ -592,6 +597,177 @@ async def _reap_ghost_jobs(job_store, db_url: str) -> None:
             break
         except Exception as e:
             logger.warning("Ghost job reaper error: %s", e)
+
+
+_cleanup_task: asyncio.Task | None = None
+"""Module-level reference for graceful shutdown cancellation."""
+
+# Advisory lock ID for PostgreSQL — ensures only one pod runs cleanup at a time.
+# Arbitrary constant; change if it collides with another lock in your deployment.
+_PG_ADVISORY_LOCK_ID = 0x41495143_4C45414E  # "AIQCLEAN" in hex
+
+
+def _start_periodic_cleanup(
+    job_store,
+    scheduler_address: str,
+    db_url: str,
+    expiry_seconds: int,
+    log_level: int,
+    use_threads: bool,
+) -> None:
+    """
+    Start periodic cleanup of expired jobs and old events.
+
+    Submits NAT's periodic_cleanup as a Dask task (handles job_info expiry)
+    and starts a local asyncio task for coordinated event cleanup.
+    """
+    global _cleanup_task
+
+    from dask.distributed import fire_and_forget
+
+    from nat.front_ends.fastapi.async_job import periodic_cleanup
+
+    # Cleanup interval: half the expiry time, clamped to [60s, 3600s]
+    cleanup_interval = max(60, min(expiry_seconds // 2, 3600))
+
+    # Submit NAT's periodic_cleanup as a long-running Dask task for job_info table
+    try:
+        cleanup_future = job_store.dask_client.submit(
+            periodic_cleanup,
+            scheduler_address=scheduler_address,
+            db_url=db_url,
+            sleep_time_sec=cleanup_interval,
+            configure_logging=not use_threads,
+            log_level=log_level,
+        )
+        fire_and_forget(cleanup_future)
+        logger.info(
+            "Submitted periodic job cleanup task to Dask (interval=%ds, expiry=%ds)",
+            cleanup_interval,
+            expiry_seconds,
+        )
+    except Exception as e:
+        logger.warning("Failed to submit periodic cleanup to Dask: %s", e)
+
+    # Start local asyncio task for job_events table cleanup (NAT doesn't manage this table).
+    # Uses pg_try_advisory_lock on PostgreSQL so only one pod runs cleanup per cycle.
+    _cleanup_task = asyncio.create_task(_cleanup_old_events_loop(db_url, expiry_seconds, cleanup_interval))
+
+
+async def stop_periodic_cleanup() -> None:
+    """Cancel the event cleanup background task. Call from shutdown handler."""
+    global _cleanup_task
+    if _cleanup_task and not _cleanup_task.done():
+        _cleanup_task.cancel()
+        try:
+            await _cleanup_task
+        except asyncio.CancelledError:
+            pass
+        _cleanup_task = None
+        logger.info("Event cleanup task cancelled")
+
+
+async def _cleanup_old_events_loop(db_url: str, retention_seconds: int, interval_seconds: int) -> None:
+    """
+    Background task that periodically deletes old events from the job_events table
+    and removes events for jobs already marked as expired in job_info.
+
+    On PostgreSQL, uses pg_try_advisory_lock so only one pod runs cleanup per cycle
+    when multiple pods share the same database.
+    """
+
+    is_postgres = db_url.startswith("postgresql")
+
+    logger.info(
+        "Event cleanup task started (retention=%ds, interval=%ds, advisory_lock=%s)",
+        retention_seconds,
+        interval_seconds,
+        is_postgres,
+    )
+
+    # Run once immediately on startup to catch anything that aged out during downtime.
+    await _run_event_cleanup(db_url, retention_seconds, is_postgres)
+
+    while True:
+        try:
+            await asyncio.sleep(interval_seconds)
+            await _run_event_cleanup(db_url, retention_seconds, is_postgres)
+        except asyncio.CancelledError:
+            logger.info("Event cleanup task stopped")
+            break
+        except Exception as e:
+            logger.warning("Event cleanup error: %s", e)
+
+
+async def _run_event_cleanup(db_url: str, retention_seconds: int, is_postgres: bool) -> None:
+    """
+    Execute one cleanup cycle: time-based event pruning + removal of events for expired jobs.
+
+    On PostgreSQL, acquires a session-level advisory lock so concurrent pods skip the cycle
+    rather than doing redundant work.
+    """
+    import asyncio
+
+    from ..jobs import EventStore
+
+    loop = asyncio.get_running_loop()
+
+    def _do_cleanup() -> tuple[int, int]:
+        from sqlalchemy import text
+
+        engine = EventStore._get_or_create_sync_engine(db_url)
+
+        with engine.connect() as conn:
+            # On PostgreSQL, try to acquire an advisory lock. If another pod already holds
+            # it, skip this cycle — the other pod is handling cleanup.
+            if is_postgres:
+                locked = conn.execute(
+                    text("SELECT pg_try_advisory_lock(:lock_id)"),
+                    {"lock_id": _PG_ADVISORY_LOCK_ID},
+                ).scalar()
+                if not locked:
+                    return (0, 0)
+
+            try:
+                # 1. Time-based: delete events older than retention period
+                if is_postgres:
+                    result = conn.execute(
+                        text("DELETE FROM job_events WHERE created_at < NOW() - :seconds * INTERVAL '1 second'"),
+                        {"seconds": retention_seconds},
+                    )
+                else:
+                    result = conn.execute(
+                        text("DELETE FROM job_events WHERE created_at < datetime('now', :interval)"),
+                        {"interval": f"-{retention_seconds} seconds"},
+                    )
+                time_deleted = result.rowcount
+
+                # 2. Coordinated: delete events for jobs already marked expired in job_info.
+                # This catches events that haven't aged out yet but whose parent job is
+                # already expired (e.g. short-lived jobs with long event retention).
+                expired_result = conn.execute(
+                    text("DELETE FROM job_events WHERE job_id IN (SELECT job_id FROM job_info WHERE is_expired = true)")
+                )
+                expired_deleted = expired_result.rowcount
+
+                conn.commit()
+                return (time_deleted, expired_deleted)
+            finally:
+                if is_postgres:
+                    conn.execute(
+                        text("SELECT pg_advisory_unlock(:lock_id)"),
+                        {"lock_id": _PG_ADVISORY_LOCK_ID},
+                    )
+                    conn.commit()
+
+    time_deleted, expired_deleted = await loop.run_in_executor(None, _do_cleanup)
+
+    if time_deleted > 0 or expired_deleted > 0:
+        logger.info(
+            "Event cleanup: %d old events removed, %d events for expired jobs removed",
+            time_deleted,
+            expired_deleted,
+        )
 
 
 async def _cancel_dask_task(scheduler_address: str, job_id: str) -> bool:

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -623,15 +623,15 @@ def _start_periodic_cleanup(
     """
     global _cleanup_task
 
-    from dask.distributed import fire_and_forget
-
-    from nat.front_ends.fastapi.async_job import periodic_cleanup
-
     # Cleanup interval: half the expiry time, clamped to [60s, 3600s]
     cleanup_interval = max(60, min(expiry_seconds // 2, 3600))
 
     # Submit NAT's periodic_cleanup as a long-running Dask task for job_info table
     try:
+        from dask.distributed import fire_and_forget
+
+        from nat.front_ends.fastapi.async_job import periodic_cleanup
+
         cleanup_future = job_store.dask_client.submit(
             periodic_cleanup,
             scheduler_address=scheduler_address,
@@ -679,7 +679,7 @@ async def _cleanup_old_events_loop(db_url: str, retention_seconds: int, interval
     when multiple pods share the same database.
     """
 
-    is_postgres = db_url.startswith("postgresql")
+    is_postgres = db_url.startswith("postgres")
 
     logger.info(
         "Event cleanup task started (retention=%ds, interval=%ds, advisory_lock=%s)",

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -650,7 +650,10 @@ def _start_periodic_cleanup(
         logger.warning("Failed to submit periodic cleanup to Dask: %s", e)
 
     # Start local asyncio task for job_events table cleanup (NAT doesn't manage this table).
-    # Uses pg_try_advisory_lock on PostgreSQL so only one pod runs cleanup per cycle.
+    # Uses pg_try_advisory_xact_lock on PostgreSQL so only one pod runs cleanup per cycle.
+    # Cancel any previously-started task before overwriting the reference.
+    if _cleanup_task and not _cleanup_task.done():
+        _cleanup_task.cancel()
     _cleanup_task = asyncio.create_task(_cleanup_old_events_loop(db_url, expiry_seconds, cleanup_interval))
 
 
@@ -672,7 +675,7 @@ async def _cleanup_old_events_loop(db_url: str, retention_seconds: int, interval
     Background task that periodically deletes old events from the job_events table
     and removes events for jobs already marked as expired in job_info.
 
-    On PostgreSQL, uses pg_try_advisory_lock so only one pod runs cleanup per cycle
+    On PostgreSQL, uses pg_try_advisory_xact_lock so only one pod runs cleanup per cycle
     when multiple pods share the same database.
     """
 
@@ -703,11 +706,10 @@ async def _run_event_cleanup(db_url: str, retention_seconds: int, is_postgres: b
     """
     Execute one cleanup cycle: time-based event pruning + removal of events for expired jobs.
 
-    On PostgreSQL, acquires a session-level advisory lock so concurrent pods skip the cycle
-    rather than doing redundant work.
+    On PostgreSQL, acquires a transaction-level advisory lock (pg_try_advisory_xact_lock)
+    so concurrent pods skip the cycle rather than doing redundant work. The lock is
+    automatically released on commit/rollback, avoiding leak risks.
     """
-    import asyncio
-
     from ..jobs import EventStore
 
     loop = asyncio.get_running_loop()
@@ -718,47 +720,40 @@ async def _run_event_cleanup(db_url: str, retention_seconds: int, is_postgres: b
         engine = EventStore._get_or_create_sync_engine(db_url)
 
         with engine.connect() as conn:
-            # On PostgreSQL, try to acquire an advisory lock. If another pod already holds
-            # it, skip this cycle — the other pod is handling cleanup.
+            # On PostgreSQL, acquire a transaction-level advisory lock. If another pod
+            # already holds it, skip this cycle. The lock is automatically released
+            # on commit/rollback — no manual unlock needed.
             if is_postgres:
                 locked = conn.execute(
-                    text("SELECT pg_try_advisory_lock(:lock_id)"),
+                    text("SELECT pg_try_advisory_xact_lock(:lock_id)"),
                     {"lock_id": _PG_ADVISORY_LOCK_ID},
                 ).scalar()
                 if not locked:
                     return (0, 0)
 
-            try:
-                # 1. Time-based: delete events older than retention period
-                if is_postgres:
-                    result = conn.execute(
-                        text("DELETE FROM job_events WHERE created_at < NOW() - :seconds * INTERVAL '1 second'"),
-                        {"seconds": retention_seconds},
-                    )
-                else:
-                    result = conn.execute(
-                        text("DELETE FROM job_events WHERE created_at < datetime('now', :interval)"),
-                        {"interval": f"-{retention_seconds} seconds"},
-                    )
-                time_deleted = result.rowcount
-
-                # 2. Coordinated: delete events for jobs already marked expired in job_info.
-                # This catches events that haven't aged out yet but whose parent job is
-                # already expired (e.g. short-lived jobs with long event retention).
-                expired_result = conn.execute(
-                    text("DELETE FROM job_events WHERE job_id IN (SELECT job_id FROM job_info WHERE is_expired = true)")
+            # 1. Time-based: delete events older than retention period
+            if is_postgres:
+                result = conn.execute(
+                    text("DELETE FROM job_events WHERE created_at < NOW() - :seconds * INTERVAL '1 second'"),
+                    {"seconds": retention_seconds},
                 )
-                expired_deleted = expired_result.rowcount
+            else:
+                result = conn.execute(
+                    text("DELETE FROM job_events WHERE created_at < datetime('now', :interval)"),
+                    {"interval": f"-{retention_seconds} seconds"},
+                )
+            time_deleted = result.rowcount
 
-                conn.commit()
-                return (time_deleted, expired_deleted)
-            finally:
-                if is_postgres:
-                    conn.execute(
-                        text("SELECT pg_advisory_unlock(:lock_id)"),
-                        {"lock_id": _PG_ADVISORY_LOCK_ID},
-                    )
-                    conn.commit()
+            # 2. Coordinated: delete events for jobs already marked expired in job_info.
+            # This catches events that haven't aged out yet but whose parent job is
+            # already expired (e.g. short-lived jobs with long event retention).
+            expired_result = conn.execute(
+                text("DELETE FROM job_events WHERE job_id IN (SELECT job_id FROM job_info WHERE is_expired = true)")
+            )
+            expired_deleted = expired_result.rowcount
+
+            conn.commit()
+            return (time_deleted, expired_deleted)
 
     time_deleted, expired_deleted = await loop.run_in_executor(None, _do_cleanup)
 

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -689,7 +689,12 @@ async def _cleanup_old_events_loop(db_url: str, retention_seconds: int, interval
     )
 
     # Run once immediately on startup to catch anything that aged out during downtime.
-    await _run_event_cleanup(db_url, retention_seconds, is_postgres)
+    try:
+        await _run_event_cleanup(db_url, retention_seconds, is_postgres)
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning("Event cleanup startup run failed: %s", e)
 
     while True:
         try:

--- a/frontends/aiq_api/tests/__init__.py
+++ b/frontends/aiq_api/tests/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the aiq_api package."""

--- a/frontends/aiq_api/tests/test_periodic_cleanup.py
+++ b/frontends/aiq_api/tests/test_periodic_cleanup.py
@@ -1,0 +1,467 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for periodic cleanup of expired jobs and old events."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC
+from datetime import datetime
+from datetime import timedelta
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from aiq_api.jobs.event_store import EventStore
+
+
+@pytest.fixture
+def db_url(tmp_path):
+    """Return an async SQLite database URL."""
+    return f"sqlite+aiosqlite:///{tmp_path / 'test_cleanup.db'}"
+
+
+@pytest.fixture(autouse=True)
+def clear_event_store_caches():
+    """Clear EventStore caches between tests."""
+    EventStore._tables_initialized.clear()
+    yield
+    EventStore._tables_initialized.clear()
+
+
+def _backdate_events(db_url: str, hours: int, where_clause: str = "1=1"):
+    """Helper to backdate events in the test DB."""
+    from sqlalchemy import text
+
+    engine = EventStore._get_or_create_sync_engine(db_url)
+    old_time = datetime.now(UTC) - timedelta(hours=hours)
+    with engine.connect() as conn:
+        conn.execute(
+            text(f"UPDATE job_events SET created_at = :ts WHERE {where_clause}"),
+            {"ts": old_time.replace(tzinfo=None)},
+        )
+        conn.commit()
+
+
+def _create_expired_job(db_url: str, job_id: str):
+    """Helper to create a fake expired job in the job_info table."""
+    from sqlalchemy import text
+
+    engine = EventStore._get_or_create_sync_engine(db_url)
+    with engine.connect() as conn:
+        # Ensure job_info table exists (simplified schema for tests)
+        conn.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS job_info ("
+                "  job_id TEXT PRIMARY KEY,"
+                "  status TEXT,"
+                "  config_file TEXT,"
+                "  error TEXT,"
+                "  output_path TEXT,"
+                "  created_at DATETIME,"
+                "  updated_at DATETIME,"
+                "  expiry_seconds INTEGER,"
+                "  output TEXT,"
+                "  is_expired BOOLEAN DEFAULT 0"
+                ")"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT OR REPLACE INTO job_info "
+                "(job_id, status, expiry_seconds, is_expired, created_at, updated_at) "
+                "VALUES (:job_id, 'success', 3600, :is_expired, :ts, :ts)"
+            ),
+            {
+                "job_id": job_id,
+                "is_expired": True,
+                "ts": datetime.now(UTC).replace(tzinfo=None),
+            },
+        )
+        conn.commit()
+
+
+# =========================================================================
+# EventStore.cleanup_old_events (time-based)
+# =========================================================================
+
+
+class TestCleanupOldEvents:
+    """Tests for EventStore.cleanup_old_events."""
+
+    def test_cleanup_deletes_old_events(self, db_url):
+        """Events older than retention period should be deleted."""
+        store = EventStore(db_url, job_id="job-1")
+        store.store({"type": "test.event", "data": {"msg": "hello"}})
+        store.store({"type": "test.event", "data": {"msg": "world"}})
+
+        _backdate_events(db_url, hours=2)
+
+        deleted = EventStore.cleanup_old_events(db_url, retention_seconds=3600)
+        assert deleted == 2
+        assert len(EventStore.get_events(db_url, "job-1")) == 0
+
+    def test_cleanup_preserves_recent_events(self, db_url):
+        """Events within retention period should not be deleted."""
+        store = EventStore(db_url, job_id="job-1")
+        store.store({"type": "test.event", "data": {"msg": "recent"}})
+
+        deleted = EventStore.cleanup_old_events(db_url, retention_seconds=3600)
+        assert deleted == 0
+        assert len(EventStore.get_events(db_url, "job-1")) == 1
+
+    def test_cleanup_mixed_old_and_new(self, db_url):
+        """Only old events should be deleted when both old and new exist."""
+        store = EventStore(db_url, job_id="job-1")
+        store.store({"type": "old.event", "data": {"msg": "old"}})
+        store.store({"type": "new.event", "data": {"msg": "new"}})
+
+        _backdate_events(db_url, hours=2, where_clause="id = 1")
+
+        deleted = EventStore.cleanup_old_events(db_url, retention_seconds=3600)
+        assert deleted == 1
+        assert len(EventStore.get_events(db_url, "job-1")) == 1
+
+    def test_cleanup_multiple_jobs(self, db_url):
+        """Cleanup should delete old events across all jobs."""
+        EventStore(db_url, job_id="job-1").store({"type": "test", "data": {}})
+        EventStore(db_url, job_id="job-2").store({"type": "test", "data": {}})
+
+        _backdate_events(db_url, hours=2)
+
+        deleted = EventStore.cleanup_old_events(db_url, retention_seconds=3600)
+        assert deleted == 2
+
+    def test_cleanup_empty_table(self, db_url):
+        """Cleanup on empty table should return 0."""
+        EventStore(db_url, job_id="job-1")  # ensures table exists
+        assert EventStore.cleanup_old_events(db_url, retention_seconds=3600) == 0
+
+
+class TestCleanupOldEventsAsync:
+    """Tests for EventStore.cleanup_old_events_async."""
+
+    @pytest.mark.asyncio
+    async def test_async_cleanup_delegates_to_sync(self, db_url):
+        """Async cleanup should produce same results as sync."""
+        store = EventStore(db_url, job_id="job-1")
+        store.store({"type": "test", "data": {}})
+        _backdate_events(db_url, hours=2)
+
+        deleted = await EventStore.cleanup_old_events_async(db_url, retention_seconds=3600)
+        assert deleted == 1
+
+
+class TestCleanupJobEvents:
+    """Tests for EventStore.cleanup_job_events (targeted per-job deletion)."""
+
+    def test_cleanup_specific_job(self, db_url):
+        """Should delete events for a specific job only."""
+        EventStore(db_url, job_id="job-1").store({"type": "test", "data": {}})
+        EventStore(db_url, job_id="job-1").store({"type": "test", "data": {}})
+        EventStore(db_url, job_id="job-2").store({"type": "test", "data": {}})
+
+        deleted = EventStore.cleanup_job_events(db_url, "job-1")
+        assert deleted == 2
+        assert len(EventStore.get_events(db_url, "job-2")) == 1
+
+
+# =========================================================================
+# _run_event_cleanup (coordinated: time-based + expired-job events)
+# =========================================================================
+
+
+class TestRunEventCleanup:
+    """Tests for _run_event_cleanup coordinated cleanup cycle."""
+
+    @pytest.mark.asyncio
+    async def test_removes_events_for_expired_jobs(self, db_url):
+        """Events for jobs marked is_expired=True in job_info should be deleted."""
+        from aiq_api.routes.jobs import _run_event_cleanup
+
+        store = EventStore(db_url, job_id="expired-job")
+        store.store({"type": "test", "data": {"msg": "should be deleted"}})
+
+        _create_expired_job(db_url, "expired-job")
+
+        await _run_event_cleanup(db_url, retention_seconds=86400, is_postgres=False)
+
+        remaining = EventStore.get_events(db_url, "expired-job")
+        assert len(remaining) == 0
+
+    @pytest.mark.asyncio
+    async def test_preserves_events_for_non_expired_jobs(self, db_url):
+        """Events for jobs NOT marked expired should be preserved (if within retention)."""
+        from aiq_api.routes.jobs import _run_event_cleanup
+
+        store = EventStore(db_url, job_id="active-job")
+        store.store({"type": "test", "data": {"msg": "keep me"}})
+
+        # Create job_info table but no expired jobs
+        _create_expired_job(db_url, "some-other-job")
+
+        await _run_event_cleanup(db_url, retention_seconds=86400, is_postgres=False)
+
+        remaining = EventStore.get_events(db_url, "active-job")
+        assert len(remaining) == 1
+
+    @pytest.mark.asyncio
+    async def test_combined_time_and_expired_cleanup(self, db_url):
+        """Both time-based and expired-job cleanup should run in one cycle."""
+        from aiq_api.routes.jobs import _run_event_cleanup
+
+        # Old event for a non-expired job (should be cleaned by time)
+        store1 = EventStore(db_url, job_id="old-job")
+        store1.store({"type": "test", "data": {}})
+        _backdate_events(db_url, hours=2, where_clause="job_id = 'old-job'")
+
+        # Recent event for an expired job (should be cleaned by expired-job logic)
+        store2 = EventStore(db_url, job_id="expired-job")
+        store2.store({"type": "test", "data": {}})
+        _create_expired_job(db_url, "expired-job")
+
+        # Recent event for a live job (should survive)
+        store3 = EventStore(db_url, job_id="live-job")
+        store3.store({"type": "test", "data": {}})
+
+        await _run_event_cleanup(db_url, retention_seconds=3600, is_postgres=False)
+
+        assert len(EventStore.get_events(db_url, "old-job")) == 0
+        assert len(EventStore.get_events(db_url, "expired-job")) == 0
+        assert len(EventStore.get_events(db_url, "live-job")) == 1
+
+
+# =========================================================================
+# _cleanup_old_events_loop (background task)
+# =========================================================================
+
+
+class TestCleanupOldEventsLoop:
+    """Tests for _cleanup_old_events_loop background task."""
+
+    @pytest.mark.asyncio
+    async def test_runs_immediately_on_startup(self):
+        """The loop should run one cleanup cycle before the first sleep."""
+        from aiq_api.routes.jobs import _cleanup_old_events_loop
+
+        calls = []
+
+        async def mock_run(db_url, retention_seconds, is_postgres):
+            calls.append(("run", retention_seconds))
+            if len(calls) >= 2:
+                raise asyncio.CancelledError()
+
+        with patch("aiq_api.routes.jobs._run_event_cleanup", side_effect=mock_run):
+            task = asyncio.create_task(
+                _cleanup_old_events_loop(
+                    db_url="sqlite+aiosqlite:///test.db",
+                    retention_seconds=3600,
+                    interval_seconds=9999,  # long interval — shouldn't matter if startup run works
+                )
+            )
+            # Give the startup run time to execute
+            await asyncio.sleep(0.05)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert len(calls) >= 1, "Should have run at least once immediately on startup"
+
+    @pytest.mark.asyncio
+    async def test_loop_survives_cleanup_errors(self):
+        """The loop should continue running even if cleanup raises."""
+        from aiq_api.routes.jobs import _cleanup_old_events_loop
+
+        call_count = 0
+
+        async def mock_run(db_url, retention_seconds, is_postgres):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                pass  # startup run — succeeds
+            elif call_count == 2:
+                raise RuntimeError("DB connection failed")
+            elif call_count >= 4:
+                raise asyncio.CancelledError()
+
+        with patch("aiq_api.routes.jobs._run_event_cleanup", side_effect=mock_run):
+            task = asyncio.create_task(
+                _cleanup_old_events_loop(
+                    db_url="sqlite+aiosqlite:///test.db",
+                    retention_seconds=3600,
+                    interval_seconds=0,
+                )
+            )
+            try:
+                await asyncio.wait_for(task, timeout=1.0)
+            except (TimeoutError, asyncio.CancelledError):
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+        assert call_count >= 3, "Should have continued past the error"
+
+
+# =========================================================================
+# _start_periodic_cleanup (orchestration)
+# =========================================================================
+
+
+class TestStartPeriodicCleanup:
+    """Tests for _start_periodic_cleanup orchestration function."""
+
+    def test_submits_dask_cleanup_task(self):
+        """Should submit NAT's periodic_cleanup to Dask."""
+        from aiq_api.routes.jobs import _start_periodic_cleanup
+
+        mock_job_store = MagicMock()
+        mock_future = MagicMock()
+        mock_job_store.dask_client.submit.return_value = mock_future
+
+        with patch("aiq_api.routes.jobs.asyncio.create_task"):
+            with patch("dask.distributed.fire_and_forget") as mock_faf:
+                _start_periodic_cleanup(
+                    job_store=mock_job_store,
+                    scheduler_address="tcp://localhost:8786",
+                    db_url="sqlite:///test.db",
+                    expiry_seconds=3600,
+                    log_level=20,
+                    use_threads=False,
+                )
+
+        mock_job_store.dask_client.submit.assert_called_once()
+        call_kwargs = mock_job_store.dask_client.submit.call_args[1]
+        assert call_kwargs["scheduler_address"] == "tcp://localhost:8786"
+        assert call_kwargs["db_url"] == "sqlite:///test.db"
+        assert call_kwargs["sleep_time_sec"] == 1800  # 3600 // 2
+        mock_faf.assert_called_once_with(mock_future)
+
+    def test_starts_event_cleanup_task(self):
+        """Should start a local asyncio task for event cleanup."""
+        from aiq_api.routes.jobs import _start_periodic_cleanup
+
+        mock_job_store = MagicMock()
+        mock_job_store.dask_client.submit.return_value = MagicMock()
+
+        with patch("aiq_api.routes.jobs.asyncio.create_task") as mock_create_task:
+            with patch("dask.distributed.fire_and_forget"):
+                _start_periodic_cleanup(
+                    job_store=mock_job_store,
+                    scheduler_address="tcp://localhost:8786",
+                    db_url="sqlite:///test.db",
+                    expiry_seconds=7200,
+                    log_level=20,
+                    use_threads=False,
+                )
+
+        mock_create_task.assert_called_once()
+
+    def test_cleanup_interval_clamped_max(self):
+        """Cleanup interval should be clamped to 3600s max."""
+        from aiq_api.routes.jobs import _start_periodic_cleanup
+
+        mock_job_store = MagicMock()
+        mock_job_store.dask_client.submit.return_value = MagicMock()
+
+        with patch("aiq_api.routes.jobs.asyncio.create_task"):
+            with patch("dask.distributed.fire_and_forget"):
+                _start_periodic_cleanup(
+                    job_store=mock_job_store,
+                    scheduler_address="tcp://localhost:8786",
+                    db_url="sqlite:///test.db",
+                    expiry_seconds=604800,  # 7 days
+                    log_level=20,
+                    use_threads=False,
+                )
+
+        call_kwargs = mock_job_store.dask_client.submit.call_args[1]
+        assert call_kwargs["sleep_time_sec"] == 3600
+
+    def test_cleanup_interval_clamped_min(self):
+        """Cleanup interval should be at least 60s."""
+        from aiq_api.routes.jobs import _start_periodic_cleanup
+
+        mock_job_store = MagicMock()
+        mock_job_store.dask_client.submit.return_value = MagicMock()
+
+        with patch("aiq_api.routes.jobs.asyncio.create_task"):
+            with patch("dask.distributed.fire_and_forget"):
+                _start_periodic_cleanup(
+                    job_store=mock_job_store,
+                    scheduler_address="tcp://localhost:8786",
+                    db_url="sqlite:///test.db",
+                    expiry_seconds=60,
+                    log_level=20,
+                    use_threads=False,
+                )
+
+        call_kwargs = mock_job_store.dask_client.submit.call_args[1]
+        assert call_kwargs["sleep_time_sec"] == 60
+
+    def test_dask_submit_failure_doesnt_block_event_cleanup(self):
+        """If Dask submit fails, event cleanup should still start."""
+        from aiq_api.routes.jobs import _start_periodic_cleanup
+
+        mock_job_store = MagicMock()
+        mock_job_store.dask_client.submit.side_effect = RuntimeError("Dask unavailable")
+
+        with patch("aiq_api.routes.jobs.asyncio.create_task") as mock_create_task:
+            _start_periodic_cleanup(
+                job_store=mock_job_store,
+                scheduler_address="tcp://localhost:8786",
+                db_url="sqlite:///test.db",
+                expiry_seconds=3600,
+                log_level=20,
+                use_threads=False,
+            )
+
+        mock_create_task.assert_called_once()
+
+
+# =========================================================================
+# stop_periodic_cleanup (graceful shutdown)
+# =========================================================================
+
+
+class TestStopPeriodicCleanup:
+    """Tests for stop_periodic_cleanup shutdown function."""
+
+    @pytest.mark.asyncio
+    async def test_cancels_running_task(self):
+        """Should cancel the background cleanup task."""
+        import aiq_api.routes.jobs as jobs_module
+
+        async def long_running():
+            await asyncio.sleep(9999)
+
+        jobs_module._cleanup_task = asyncio.create_task(long_running())
+        assert not jobs_module._cleanup_task.done()
+
+        await jobs_module.stop_periodic_cleanup()
+
+        assert jobs_module._cleanup_task is None
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_task(self):
+        """Should not raise if no task is running."""
+        import aiq_api.routes.jobs as jobs_module
+
+        jobs_module._cleanup_task = None
+        await jobs_module.stop_periodic_cleanup()  # should not raise

--- a/frontends/aiq_api/tests/test_periodic_cleanup.py
+++ b/frontends/aiq_api/tests/test_periodic_cleanup.py
@@ -42,17 +42,23 @@ def clear_event_store_caches():
     EventStore._tables_initialized.clear()
 
 
-def _backdate_events(db_url: str, hours: int, where_clause: str = "1=1"):
+def _backdate_events(db_url: str, hours: int, *, job_id: str | None = None, event_id: int | None = None):
     """Helper to backdate events in the test DB."""
     from sqlalchemy import text
 
     engine = EventStore._get_or_create_sync_engine(db_url)
     old_time = datetime.now(UTC) - timedelta(hours=hours)
     with engine.connect() as conn:
-        conn.execute(
-            text(f"UPDATE job_events SET created_at = :ts WHERE {where_clause}"),
-            {"ts": old_time.replace(tzinfo=None)},
-        )
+        params: dict = {"ts": old_time.replace(tzinfo=None)}
+        if event_id is not None:
+            query = "UPDATE job_events SET created_at = :ts WHERE id = :event_id"
+            params["event_id"] = event_id
+        elif job_id is not None:
+            query = "UPDATE job_events SET created_at = :ts WHERE job_id = :job_id"
+            params["job_id"] = job_id
+        else:
+            query = "UPDATE job_events SET created_at = :ts"
+        conn.execute(text(query), params)
         conn.commit()
 
 
@@ -129,7 +135,7 @@ class TestCleanupOldEvents:
         store.store({"type": "old.event", "data": {"msg": "old"}})
         store.store({"type": "new.event", "data": {"msg": "new"}})
 
-        _backdate_events(db_url, hours=2, where_clause="id = 1")
+        _backdate_events(db_url, hours=2, event_id=1)
 
         deleted = EventStore.cleanup_old_events(db_url, retention_seconds=3600)
         assert deleted == 1
@@ -226,7 +232,7 @@ class TestRunEventCleanup:
         # Old event for a non-expired job (should be cleaned by time)
         store1 = EventStore(db_url, job_id="old-job")
         store1.store({"type": "test", "data": {}})
-        _backdate_events(db_url, hours=2, where_clause="job_id = 'old-job'")
+        _backdate_events(db_url, hours=2, job_id="old-job")
 
         # Recent event for an expired job (should be cleaned by expired-job logic)
         store2 = EventStore(db_url, job_id="expired-job")

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -305,7 +305,11 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
             logger.info("Using fresh conversation ID for --input mode: %s", nat_context_conversation_id)
         else:
             nat_context_conversation_id = Context.get().conversation_id
-            logger.info("Thread ID for checkpointing: %s", nat_context_conversation_id)
+            if not nat_context_conversation_id:
+                nat_context_conversation_id = str(uuid.uuid4())
+                logger.info("No conversation-id header; generated thread ID: %s", nat_context_conversation_id)
+            else:
+                logger.info("Thread ID for checkpointing: %s", nat_context_conversation_id)
 
         from aiq_agent.auth import get_current_user_info
 


### PR DESCRIPTION
This PR fixes a couple of issues:

- PostgreSQL checkpointer enforces NOT NULL on thread_id in checkpoint_blobs, but requests without a conversation-id header leave it as None. SQLite is permissive so this only fails in Docker deployments using Postgres.

- NAT provides `periodic_cleanup` as a Dask task for job_info expiry but it was never submitted. The job_events table (managed by our EventStore) had cleanup methods defined but no caller.