### PR TITLE
update citation verification by adding URL expansion functionality

### DIFF
--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -24,6 +24,7 @@ from aiq_agent.common import LLMRole
 from aiq_agent.common import load_prompt
 from aiq_agent.common import render_prompt_template
 from aiq_agent.common.citation_verification import EmptySourceRegistryError
+from aiq_agent.common.citation_verification import expand_reference_urls
 from aiq_agent.common.citation_verification import sanitize_report
 from aiq_agent.common.citation_verification import verify_citations
 
@@ -415,7 +416,9 @@ class DeepResearcherAgent:
 
             # Post-process: verify citations against source registry
             if self.source_registry_middleware._get_registry().all_sources():
-                verification = verify_citations(final_message, self.source_registry_middleware._get_registry())
+                registry = self.source_registry_middleware._get_registry()
+                final_message = expand_reference_urls(final_message, registry)
+                verification = verify_citations(final_message, registry)
                 if verification.removed_citations:
                     logger.info(
                         "Citation verification removed %d invalid citations: %s",

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -415,8 +415,8 @@ class DeepResearcherAgent:
                 final_message = final_content if isinstance(final_content, str) else str(final_content)
 
             # Post-process: verify citations against source registry
-            if self.source_registry_middleware._get_registry().all_sources():
-                registry = self.source_registry_middleware._get_registry()
+            registry = self.source_registry_middleware._get_registry()
+            if registry.all_sources():
                 final_message = expand_reference_urls(final_message, registry)
                 verification = verify_citations(final_message, registry)
                 if verification.removed_citations:

--- a/src/aiq_agent/agents/deep_researcher/prompts/source_registry.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/source_registry.j2
@@ -1,5 +1,5 @@
 ## Consolidated Source Registry (auto-generated from tool calls)
-Use ONLY these sources when writing the final report. Each has been verified as a real tool result. You may use these [N] numbers directly or assign your own — citations will be auto-verified and renumbered.
+These are all verified sources from your research. Cite ONLY the ones you actually reference in the report body — do not list sources you did not use. You may use these [N] numbers directly or assign your own — citations will be auto-verified and renumbered.
 
 {% for source in sources %}
 [{{ loop.index }}] {{ source.title }}: {{ source.url }}

--- a/src/aiq_agent/agents/shallow_researcher/agent.py
+++ b/src/aiq_agent/agents/shallow_researcher/agent.py
@@ -38,6 +38,7 @@ from aiq_agent.common import load_prompt
 from aiq_agent.common import render_prompt_template
 from aiq_agent.common.citation_verification import EmptySourceRegistryError
 from aiq_agent.common.citation_verification import SourceRegistry
+from aiq_agent.common.citation_verification import expand_reference_urls
 from aiq_agent.common.citation_verification import extract_sources_from_tool_result
 from aiq_agent.common.citation_verification import get_session_registry
 from aiq_agent.common.citation_verification import sanitize_report
@@ -302,6 +303,7 @@ class ShallowResearcherAgent:
 
                 # Step 1: verify citations against registry
                 if registry.all_sources():
+                    content = expand_reference_urls(content, registry)
                     verification = verify_citations(content, registry)
                     logger.debug(
                         "Shallow researcher: citation verification complete — "

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -860,6 +860,18 @@ def sanitize_report(report_text: str) -> ReportSanitizationResult:
     if ref_section:
         cleaned_body, ref_section, _ = _renumber_citations(cleaned_body, ref_section)
 
+        # Sort reference lines by [N] number (LLM may have emitted them out of order)
+        ref_lines = ref_section.split("\n")
+        citation_lines = [(i, line) for i, line in enumerate(ref_lines) if _CITATION_LINE_RE.match(line)]
+        if citation_lines:
+            first_idx = citation_lines[0][0]
+            non_citation_before = ref_lines[:first_idx]
+            sorted_citations = sorted(
+                [line for _, line in citation_lines],
+                key=lambda line: int(_CITATION_LINE_RE.match(line).group(1)),
+            )
+            ref_section = "\n".join(non_citation_before + sorted_citations) + "\n"
+
     sanitized_report = cleaned_body + ref_section
 
     # --- Strip leaked tool-call XML fragments ---

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -933,7 +933,7 @@ def expand_reference_urls(report_text: str, registry: SourceRegistry) -> str:
         if canonical and canonical != url:
             # Reattach structural punctuation (e.g. ")" in markdown links),
             # but drop truncation markers ("...", "…")
-            keep = "" if re.fullmatch(r"[.…]+", trailing) else trailing
+            keep = "" if re.fullmatch(r"\.{2,}|…+", trailing) else trailing
             return canonical + keep
         return raw
 

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -913,10 +913,9 @@ def expand_reference_urls(report_text: str, registry: SourceRegistry) -> str:
     # Find every URL in the references section and replace with canonical
     def _replace_url(m: re.Match) -> str:
         url = m.group(0).rstrip(".,;)")
-        trailing = m.group(0)[len(url) :]
         canonical = registry.resolve_url(url)
         if canonical and canonical != url:
-            return canonical + trailing
+            return canonical
         return m.group(0)
 
     ref_section = _GENERIC_URL_RE.sub(_replace_url, ref_section)

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -860,7 +860,9 @@ def sanitize_report(report_text: str) -> ReportSanitizationResult:
     if ref_section:
         cleaned_body, ref_section, _ = _renumber_citations(cleaned_body, ref_section)
 
-        # Sort reference lines by [N] number (LLM may have emitted them out of order)
+        # Sort reference lines by [N] number (LLM may have emitted them out of order).
+        # Intentionally drops blank lines between entries; the "Trim" step below
+        # removes all content after the last citation line anyway.
         ref_lines = ref_section.split("\n")
         citation_lines = [(i, line) for i, line in enumerate(ref_lines) if _CITATION_LINE_RE.match(line)]
         if citation_lines:
@@ -924,11 +926,16 @@ def expand_reference_urls(report_text: str, registry: SourceRegistry) -> str:
 
     # Find every URL in the references section and replace with canonical
     def _replace_url(m: re.Match) -> str:
-        url = m.group(0).rstrip(".,;)")
+        raw = m.group(0)
+        url = raw.rstrip(".,;)")
+        trailing = raw[len(url) :]
         canonical = registry.resolve_url(url)
         if canonical and canonical != url:
-            return canonical
-        return m.group(0)
+            # Reattach structural punctuation (e.g. ")" in markdown links),
+            # but drop truncation markers ("...", "…")
+            keep = "" if re.fullmatch(r"[.…]+", trailing) else trailing
+            return canonical + keep
+        return raw
 
     ref_section = _GENERIC_URL_RE.sub(_replace_url, ref_section)
 

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -890,3 +890,35 @@ def sanitize_report(report_text: str) -> ReportSanitizationResult:
         truncated_urls_removed=truncated_urls_removed,
         unsafe_urls_removed=unsafe_urls_removed,
     )
+
+
+def expand_reference_urls(report_text: str, registry: SourceRegistry) -> str:
+    """Expand URLs in the references section to their full canonical form.
+
+    Finds every URL in the LLM's references section, fuzzy-matches it
+    against the registry via ``resolve_url()``, and replaces truncated or
+    garbled URLs with the full canonical version.  The LLM's formatting
+    and structure are preserved exactly — only the URLs change.
+    """
+    if not registry.all_sources():
+        return report_text
+
+    ref_match = _REFERENCE_SECTION_RE.search(report_text)
+    if not ref_match:
+        return report_text
+
+    body = report_text[: ref_match.start()]
+    ref_section = report_text[ref_match.start() :]
+
+    # Find every URL in the references section and replace with canonical
+    def _replace_url(m: re.Match) -> str:
+        url = m.group(0).rstrip(".,;)")
+        trailing = m.group(0)[len(url) :]
+        canonical = registry.resolve_url(url)
+        if canonical and canonical != url:
+            return canonical + trailing
+        return m.group(0)
+
+    ref_section = _GENERIC_URL_RE.sub(_replace_url, ref_section)
+
+    return body + ref_section

--- a/tests/aiq_agent/agents/shallow_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/shallow_researcher/test_agent.py
@@ -51,9 +51,11 @@ class TestShallowResearcherAgent:
         """
         with (
             patch.object(SourceRegistry, "all_sources", return_value=[SourceEntry(url="https://example.com")]),
+            patch("aiq_agent.agents.shallow_researcher.agent.expand_reference_urls") as mock_expand,
             patch("aiq_agent.agents.shallow_researcher.agent.verify_citations") as mock_verify,
             patch("aiq_agent.agents.shallow_researcher.agent.sanitize_report") as mock_sanitize,
         ):
+            mock_expand.side_effect = lambda content, reg: content
             mock_verify.side_effect = lambda content, reg: MagicMock(verified_report=content, removed_citations=[])
             mock_sanitize.side_effect = lambda content: MagicMock(sanitized_report=content)
             yield

--- a/tests/aiq_agent/common/test_citation_verification.py
+++ b/tests/aiq_agent/common/test_citation_verification.py
@@ -734,6 +734,24 @@ class TestSanitizeReport:
         assert ref_lines[1].startswith("[2]")
         assert ref_lines[2].startswith("[3]")
 
+    def test_already_sorted_citations_unchanged(self):
+        """Already-sorted citations are not modified."""
+        report = "A [1]. B [2].\n\n## Sources\n[1] First: https://a.com/page\n[2] Second: https://b.com/page"
+        result = sanitize_report(report)
+        assert "[1] First: https://a.com/page" in result.sanitized_report
+        assert "[2] Second: https://b.com/page" in result.sanitized_report
+
+    def test_sorting_preserves_header(self):
+        """Reference section header is preserved before sorted entries."""
+        report = "A [1]. B [2].\n\n## Sources\n[2] Second: https://b.com/page\n[1] First: https://a.com/page"
+        result = sanitize_report(report)
+        assert "## Sources" in result.sanitized_report
+        # Header appears before first citation line in the references section
+        header_pos = result.sanitized_report.index("## Sources")
+        ref_after_header = result.sanitized_report[header_pos:]
+        first_cite_pos = ref_after_header.index("[1]")
+        assert first_cite_pos > 0
+
 
 # ---------------------------------------------------------------------------
 # expand_reference_urls tests

--- a/tests/aiq_agent/common/test_citation_verification.py
+++ b/tests/aiq_agent/common/test_citation_verification.py
@@ -789,6 +789,15 @@ class TestExpandReferenceUrls:
         assert "https://nvidia.com/benefits/full" in result
         assert "**References:**" in result
 
+    def test_ellipsis_truncated_url_expanded_without_trailing_dots(self):
+        """Truncated URL ending in ... has dots stripped after expansion."""
+        registry = SourceRegistry()
+        registry.add(SourceEntry(url="https://example.com/very/long/path/article"))
+        report = "Finding [1].\n\n## Sources\n[1] Article: https://example.com/very/long..."
+        result = expand_reference_urls(report, registry)
+        assert "https://example.com/very/long/path/article" in result
+        assert "..." not in result
+
 
 # ---------------------------------------------------------------------------
 # EmptySourceRegistryError

--- a/tests/aiq_agent/common/test_citation_verification.py
+++ b/tests/aiq_agent/common/test_citation_verification.py
@@ -718,6 +718,22 @@ class TestSanitizeReport:
         assert result.body_urls_replaced == 1
         assert result.body_urls_removed == 1
 
+    def test_out_of_order_citations_sorted(self):
+        """Citations emitted out of order by LLM are sorted sequentially."""
+        report = (
+            "A [1]. B [2]. C [3].\n\n"
+            "## Sources\n"
+            "[3] Third: https://c.com/page\n"
+            "[1] First: https://a.com/page\n"
+            "[2] Second: https://b.com/page"
+        )
+        result = sanitize_report(report)
+        lines = result.sanitized_report.split("\n")
+        ref_lines = [ln for ln in lines if ln.strip().startswith("[")]
+        assert ref_lines[0].startswith("[1]")
+        assert ref_lines[1].startswith("[2]")
+        assert ref_lines[2].startswith("[3]")
+
 
 # ---------------------------------------------------------------------------
 # expand_reference_urls tests
@@ -785,8 +801,8 @@ class TestExpandReferenceUrls:
         registry.add(SourceEntry(url="https://nvidia.com/benefits/full"))
         report = "Benefits info.\n\n**References:**\n- [NVIDIA Benefits](https://nvidia.com/benefits)"
         result = expand_reference_urls(report, registry)
-        # Structure preserved, URL expanded inside the markdown link
-        assert "https://nvidia.com/benefits/full" in result
+        # Structure preserved, URL expanded inside the markdown link with closing )
+        assert "[NVIDIA Benefits](https://nvidia.com/benefits/full)" in result
         assert "**References:**" in result
 
     def test_ellipsis_truncated_url_expanded_without_trailing_dots(self):

--- a/tests/aiq_agent/common/test_citation_verification.py
+++ b/tests/aiq_agent/common/test_citation_verification.py
@@ -23,6 +23,7 @@ from aiq_agent.common.citation_verification import SourceEntry
 from aiq_agent.common.citation_verification import SourceRegistry
 from aiq_agent.common.citation_verification import _normalize_url
 from aiq_agent.common.citation_verification import _parse_citation_key
+from aiq_agent.common.citation_verification import expand_reference_urls
 from aiq_agent.common.citation_verification import extract_sources_from_tool_result
 from aiq_agent.common.citation_verification import register_source_parser
 from aiq_agent.common.citation_verification import sanitize_report
@@ -716,6 +717,77 @@ class TestSanitizeReport:
         assert "https://unknown.com" not in result.sanitized_report
         assert result.body_urls_replaced == 1
         assert result.body_urls_removed == 1
+
+
+# ---------------------------------------------------------------------------
+# expand_reference_urls tests
+# ---------------------------------------------------------------------------
+
+
+class TestExpandReferenceUrls:
+    """Tests for expanding truncated/garbled URLs in references."""
+
+    def test_truncated_url_expanded(self):
+        """Truncated URL in references is expanded to full canonical form."""
+        registry = SourceRegistry()
+        registry.add(SourceEntry(url="https://nvidia.com/benefits/full-guide-2026"))
+        report = "Finding [1].\n\n## Sources\n[1] Benefits: https://nvidia.com/benefits"
+        result = expand_reference_urls(report, registry)
+        assert "https://nvidia.com/benefits/full-guide-2026" in result
+        # Truncated URL should be gone
+        assert result.count("https://nvidia.com/benefits") == 1
+
+    def test_full_url_unchanged(self):
+        """URLs that already match the registry are not modified."""
+        registry = SourceRegistry()
+        registry.add(SourceEntry(url="https://example.com/article"))
+        report = "Finding [1].\n\n## Sources\n[1] Article: https://example.com/article"
+        result = expand_reference_urls(report, registry)
+        assert "https://example.com/article" in result
+
+    def test_no_references_section_unchanged(self):
+        """Report without references section is returned unchanged."""
+        registry = SourceRegistry()
+        registry.add(SourceEntry(url="https://example.com"))
+        report = "Just a plain report."
+        assert expand_reference_urls(report, registry) == report
+
+    def test_empty_registry_unchanged(self):
+        """Empty registry returns report unchanged."""
+        registry = SourceRegistry()
+        report = "Finding.\n\n## Sources\n[1] https://example.com"
+        assert expand_reference_urls(report, registry) == report
+
+    def test_body_not_modified(self):
+        """URLs in the body are not touched — only references section."""
+        registry = SourceRegistry()
+        registry.add(SourceEntry(url="https://example.com/full-path"))
+        report = "See https://example.com for details.\n\n## Sources\n[1] Page: https://example.com"
+        result = expand_reference_urls(report, registry)
+        # Body URL stays truncated
+        assert "See https://example.com for details." in result
+        # References URL is expanded
+        assert "[1] Page: https://example.com/full-path" in result
+
+    def test_multiple_urls_expanded(self):
+        """Multiple truncated URLs are all expanded."""
+        registry = SourceRegistry()
+        registry.add(SourceEntry(url="https://a.com/long/path/1"))
+        registry.add(SourceEntry(url="https://b.com/long/path/2"))
+        report = "Findings.\n\n## Sources\n[1] A: https://a.com/long\n[2] B: https://b.com/long"
+        result = expand_reference_urls(report, registry)
+        assert "https://a.com/long/path/1" in result
+        assert "https://b.com/long/path/2" in result
+
+    def test_preserves_llm_formatting(self):
+        """LLM's formatting (markdown links, bullets, etc.) is preserved."""
+        registry = SourceRegistry()
+        registry.add(SourceEntry(url="https://nvidia.com/benefits/full"))
+        report = "Benefits info.\n\n**References:**\n- [NVIDIA Benefits](https://nvidia.com/benefits)"
+        result = expand_reference_urls(report, registry)
+        # Structure preserved, URL expanded inside the markdown link
+        assert "https://nvidia.com/benefits/full" in result
+        assert "**References:**" in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Introduced `expand_reference_urls` function to expand truncated or garbled URLs in the references section of reports to their full canonical form.
- Updated `DeepResearcherAgent` and `ShallowResearcherAgent` to utilize the new URL expansion before verifying citations.
- Added comprehensive unit tests for `expand_reference_urls` to ensure correct functionality and preservation of report formatting.

These changes improve the accuracy of citation tracking and enhance the overall reliability of the research agents.