### PR TITLE
Fix for reduced-motion breaking panel show/hide bug

### DIFF
--- a/frontends/ui/src/app/globals.css
+++ b/frontends/ui/src/app/globals.css
@@ -64,6 +64,7 @@
 html,
 body {
   height: 100%;
+  min-width: 768px;
   margin: 0;
   padding: 0;
 }

--- a/frontends/ui/src/app/globals.css
+++ b/frontends/ui/src/app/globals.css
@@ -72,9 +72,49 @@ body {
   height: 100%;
 }
 
-/* Smooth scrolling */
-html {
-  scroll-behavior: smooth;
+/* Smooth scrolling — only when user has no motion preference */
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
+}
+
+/* =============================================================================
+   Reduced-motion fallbacks for KUI SidePanel, overlay, and collapsibles.
+
+   KUI's slide animations are gated behind @media (prefers-reduced-motion:
+   no-preference) in kui-generated.css and rely on animation-fill-mode: both
+   to persist the final transform. When animations are disabled (reduce), no
+   fill-mode applies and force-mounted panels stay visible at transform: none.
+   These rules provide the correct end-state transforms directly.
+   ============================================================================= */
+@media (prefers-reduced-motion: reduce) {
+  .nv-side-panel-content.nv-side-panel-content--side-left {
+    transform: translate(-100%);
+  }
+  .nv-side-panel-content.nv-side-panel-content--side-left[data-state="open"] {
+    transform: translate(0);
+  }
+
+  .nv-side-panel-content.nv-side-panel-content--side-right {
+    transform: translate(100%);
+  }
+  .nv-side-panel-content.nv-side-panel-content--side-right[data-state="open"] {
+    transform: translate(0);
+  }
+
+  .nv-side-panel-overlay {
+    opacity: 0;
+    pointer-events: none;
+  }
+  .nv-side-panel-overlay[data-state="open"] {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .nv-collapsible-content[data-state="closed"] {
+    height: 0;
+  }
 }
 
 /* Focus visible styles for accessibility */

--- a/frontends/ui/src/features/layout/components/MainLayout.tsx
+++ b/frontends/ui/src/features/layout/components/MainLayout.tsx
@@ -18,6 +18,7 @@
 
 import { type FC, useCallback } from 'react'
 import { Flex } from '@/adapters/ui'
+import { useReducedMotion } from '@/hooks/use-reduced-motion'
 import { AppBar } from './AppBar'
 import { SessionsPanel } from './SessionsPanel'
 import { ChatArea } from './ChatArea'
@@ -74,6 +75,7 @@ export const MainLayout: FC<MainLayoutProps> = ({
   } = useChatStore()
 
   const { rightPanel, closeRightPanel } = useLayoutStore()
+  const prefersReducedMotion = useReducedMotion()
 
   // Deep research SSE hook - manages connection when deep research starts
   useDeepResearch()
@@ -162,7 +164,7 @@ export const MainLayout: FC<MainLayoutProps> = ({
           className="flex flex-col overflow-hidden"
           style={{
             width: isResearchPanelOpen ? '40%' : '100%',
-            transition: 'width 600ms ease-in-out',
+            transition: prefersReducedMotion ? 'none' : 'width 600ms ease-in-out',
           }}
         >
           {/* Chat Area - Scrollable */}

--- a/frontends/ui/src/features/layout/components/MainLayout.tsx
+++ b/frontends/ui/src/features/layout/components/MainLayout.tsx
@@ -146,7 +146,7 @@ export const MainLayout: FC<MainLayoutProps> = ({
   })
 
   return (
-    <Flex direction="col" className="h-screen w-screen overflow-hidden">
+    <Flex direction="col" className="h-screen min-w-[768px] overflow-x-auto overflow-y-hidden">
       {/* AppBar - Fixed at top */}
       <AppBar
         sessionTitle={currentConversation?.title || 'New Session'}

--- a/frontends/ui/src/features/layout/components/ResearchPanel.tsx
+++ b/frontends/ui/src/features/layout/components/ResearchPanel.tsx
@@ -18,6 +18,7 @@ import { Close, Generate, StopCircle } from '@/adapters/ui/icons'
 import { cancelJob } from '@/adapters/api'
 import { useChatStore, useLoadJobData } from '@/features/chat'
 import { useAuth } from '@/adapters/auth'
+import { useReducedMotion } from '@/hooks/use-reduced-motion'
 import { useLayoutStore } from '../store'
 import { PlanTab } from './PlanTab'
 import { TasksTab } from './TasksTab'
@@ -51,6 +52,8 @@ export const ResearchPanel: FC<ResearchPanelProps> = ({ children, isAuthenticate
   const deepResearchStreamLoaded = useChatStore((state) => state.deepResearchStreamLoaded)
   const { importStreamOnly, isLoading: isStreamLoading } = useLoadJobData()
   const { idToken } = useAuth()
+
+  const prefersReducedMotion = useReducedMotion()
 
   const isOpen = rightPanel === 'research'
   const cancelFallbackRef = useRef<NodeJS.Timeout | null>(null)
@@ -158,7 +161,9 @@ export const ResearchPanel: FC<ResearchPanelProps> = ({ children, isAuthenticate
       style={{
         width: isOpen ? 'calc(60% + 40px)' : '40px',
         minWidth: isOpen ? 'calc(60% + 40px)' : '40px',
-        transition: 'width 600ms ease-in-out, min-width 600ms ease-in-out',
+        transition: prefersReducedMotion
+          ? 'none'
+          : 'width 600ms ease-in-out, min-width 600ms ease-in-out',
       }}
     >
       {/* Toggle Tag Button - protruding from left side, always visible */}
@@ -192,9 +197,11 @@ export const ResearchPanel: FC<ResearchPanelProps> = ({ children, isAuthenticate
           style={{
             visibility: isOpen ? 'visible' : 'hidden',
             opacity: isOpen ? 1 : 0,
-            transition: isOpen
-              ? 'opacity 100ms ease-in-out, visibility 0ms'
-              : 'opacity 100ms ease-in-out 500ms, visibility 0ms 600ms',
+            transition: prefersReducedMotion
+              ? 'none'
+              : isOpen
+                ? 'opacity 100ms ease-in-out, visibility 0ms'
+                : 'opacity 100ms ease-in-out 500ms, visibility 0ms 600ms',
           }}
         >
         {/* Header with tabs and close button */}

--- a/frontends/ui/src/hooks/use-reduced-motion.ts
+++ b/frontends/ui/src/hooks/use-reduced-motion.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState, useEffect } from 'react'
+
+const QUERY = '(prefers-reduced-motion: reduce)'
+
+/**
+ * Reactively tracks the user's `prefers-reduced-motion` OS/browser setting.
+ * Returns `true` when the user prefers reduced motion, `false` otherwise.
+ *
+ * Always initialises as `false` so the server and first client render
+ * produce identical markup (avoids hydration mismatch). The real value
+ * is picked up in a post-mount effect — the brief first paint with
+ * transitions enabled is imperceptible since layout hasn't shifted yet.
+ */
+export function useReducedMotion(): boolean {
+  const [prefersReduced, setPrefersReduced] = useState(false)
+
+  useEffect(() => {
+    const mql = window.matchMedia(QUERY)
+    setPrefersReduced(mql.matches)
+    const handler = (e: MediaQueryListEvent) => setPrefersReduced(e.matches)
+    mql.addEventListener('change', handler)
+    return () => mql.removeEventListener('change', handler)
+  }, [])
+
+  return prefersReduced
+}


### PR DESCRIPTION
## Summary

- **Fix SessionsPanel (and all KUI SidePanels) broken under `prefers-reduced-motion: reduce`**: KUI's slide animations are gated behind `@media (prefers-reduced-motion: no-preference)` with `animation-fill-mode: both` persisting the final transform. When reduced motion is enabled, animations are skipped entirely and force-mounted panels stay visible at `transform: none`. Added CSS fallback rules in `globals.css` that directly apply the correct end-state transforms (`translate(-100%)` / `translate(100%)`) under reduced motion.
- **Respect reduced motion for inline JS transitions**: Created a `useReducedMotion()` hook and applied it to `ResearchPanel` and `MainLayout` so their inline `style` transitions become instant when the user prefers reduced motion. The hook initializes as `false` to avoid SSR hydration mismatches.
- **Add min-width 768px viewport guard**: Instead of a full mobile-responsive layout, enforce a minimum width on `html/body` and the root layout container so the browser shows a horizontal scrollbar when the viewport is narrower than 768px, preventing nav/UI from being cropped.

## Test plan

- [ ] Enable "Reduce Motion" in OS accessibility settings and verify:
  - SessionsPanel opens and closes correctly (no stuck panel)
  - DataSourcesPanel and SettingsPanel open/close correctly
  - ResearchPanel expands/collapses instantly (no animation)
  - Collapsible/accordion sections expand and collapse
- [ ] Disable "Reduce Motion" and verify all panel animations still work normally
- [ ] Resize browser window below 768px and verify horizontal scrollbar appears instead of layout breakage
- [ ] Verify no hydration mismatch warnings in the browser console

Made with [Cursor](https://cursor.com)