### PR TITLE
Add documentation for observability and port forwarding

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -58,10 +58,18 @@ DASK_DISTRIBUTED__LOGGING__DISTRIBUTED=warning
 # AIQ_SUMMARY_DB=
 
 # -----------------------------------------------------------------------------
+# Observability / Tracing (optional)
+# See docs/source/deployment/observability.md for setup guides.
+# -----------------------------------------------------------------------------
+# LANGCHAIN_TRACING_V2=true
+# LANGCHAIN_API_KEY=
+# LANGCHAIN_PROJECT=aiq-research
+# WANDB_API_KEY=
+
+# -----------------------------------------------------------------------------
 # Evaluation (optional)
 # -----------------------------------------------------------------------------
 # JINA_API_KEY=
-# WANDB_API_KEY=
 
 # -----------------------------------------------------------------------------
 # Frontend File Upload Configuration

--- a/docs/source/deployment/index.md
+++ b/docs/source/deployment/index.md
@@ -29,6 +29,8 @@ All containerized deployments run the same three services:
 
 - **[Docker Build System](./docker-build.md)** -- Multi-stage Dockerfile architecture, build targets (dev vs. release), base images, and startup scripts (`entrypoint.py` and `start_web.py`).
 
+- **[Observability](./observability.md)** -- Tracing and monitoring with Phoenix, LangSmith, Weave, and OpenTelemetry.
+
 - **[Production Considerations](./production.md)** -- Guidance on managed databases, horizontal scaling, security hardening, monitoring, and resource requirements.
 
 ## Quick Start

--- a/docs/source/deployment/observability.md
+++ b/docs/source/deployment/observability.md
@@ -24,7 +24,7 @@ The AI-Q blueprint supports multiple observability backends for tracing agent ex
 1. Install Phoenix:
 
    ```bash
-   pip install arize-phoenix
+   uv pip install arize-phoenix
    ```
 
 2. Start the Phoenix server:
@@ -208,6 +208,8 @@ general:
 
 | Field | Description |
 |-------|-------------|
+| `endpoint` | The OTEL collector URL to send spans to (e.g., `http://your-otel-collector:4318/v1/traces`). |
+| `project` | Logical project name attached to all exported spans. |
 | `redaction_enabled` | Enable or disable redaction processing. |
 | `redaction_attributes` | Span attributes to redact (defaults to `input.value`, `output.value`, `nat.metadata`). |
 | `force_redaction` | Always redact, regardless of header conditions. |
@@ -220,11 +222,17 @@ general:
 The exporter supports standard OTEL batch settings:
 
 ```yaml
-batch_size: 512
-flush_interval: 5000
-max_queue_size: 2048
-drop_on_overflow: false
-shutdown_timeout: 30000
+general:
+  telemetry:
+    tracing:
+      otel:
+        _type: otelcollector_redaction
+        endpoint: http://your-otel-collector:4318/v1/traces
+        batch_size: 512
+        flush_interval: 5000
+        max_queue_size: 2048
+        drop_on_overflow: false
+        shutdown_timeout: 30000
 ```
 
 ## Verbose Logging

--- a/docs/source/deployment/observability.md
+++ b/docs/source/deployment/observability.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # Observability
 
-The AI-Q blueprint supports multiple observability backends for tracing agent execution, LLM calls, tool invocations, and token usage. Choose the backend that best fits your workflow.
+The AI-Q blueprint supports multiple observability backends for tracing agent execution, LLM calls, tool invocations, and token usage. Choose the backend that best fits your workflow. For more details on available backends, refer to the [NVIDIA Agent Toolkit observability documentation](https://docs.nvidia.com/nemo/agent-toolkit/latest/run-workflows/observe/observe.html).
 
 | Backend | Best For | Setup |
 |---------|----------|-------|

--- a/docs/source/deployment/observability.md
+++ b/docs/source/deployment/observability.md
@@ -241,7 +241,7 @@ For quick debugging without any external services, enable the built-in verbose c
 
 ```yaml
 workflow:
-  _type: chat_researcher_agent
+  _type: chat_deepresearcher_agent
   verbose: true
 ```
 

--- a/docs/source/deployment/observability.md
+++ b/docs/source/deployment/observability.md
@@ -74,18 +74,7 @@ The AI-Q blueprint supports multiple observability backends for tracing agent ex
 
    The `LANGCHAIN_PROJECT` variable groups traces under a named project. If omitted, traces go to the `default` project.
 
-3. Start the application as usual. All LangChain and LangGraph operations are traced automatically. No YAML config changes are required -- the LangChain SDK detects these environment variables at startup:
-
-   ```yaml
-   # No telemetry.tracing section needed for LangSmith.
-   # The environment variables above are sufficient.
-   general:
-     telemetry:
-       logging:
-         console:
-           _type: console
-           level: INFO
-   ```
+3. Start the application as usual. All LangChain and LangGraph operations are traced automatically. No YAML config changes are required -- the LangChain SDK detects these environment variables at startup.
 
 ### What You Can Inspect
 

--- a/docs/source/deployment/observability.md
+++ b/docs/source/deployment/observability.md
@@ -1,0 +1,253 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Observability
+
+The AI-Q blueprint supports multiple observability backends for tracing agent execution, LLM calls, tool invocations, and token usage. Choose the backend that best fits your workflow.
+
+| Backend | Best For | Setup |
+|---------|----------|-------|
+| [Phoenix](#phoenix) | Local development, trace visualization | Run Phoenix server, add YAML config |
+| [LangSmith](#langsmith) | LLM evaluation, prompt optimization, team collaboration | Set environment variables |
+| [Weights & Biases Weave](#weights--biases-weave) | Experiment tracking, model monitoring | Set environment variables |
+| [OpenTelemetry Collector](#opentelemetry-collector) | Production infrastructure, enterprise redaction | YAML config with OTEL endpoint |
+| [Verbose Logging](#verbose-logging) | Quick debugging, no external services | CLI flag or YAML config |
+
+## Phoenix
+
+[Phoenix](https://docs.arize.com/phoenix) provides a local UI for visualizing traces, inspecting LLM calls, and analyzing token usage and latency. It is the recommended backend for local development.
+
+### Setup
+
+1. Install Phoenix:
+
+   ```bash
+   pip install arize-phoenix
+   ```
+
+2. Start the Phoenix server:
+
+   ```bash
+   python -m phoenix.server.main serve
+   ```
+
+   This launches the Phoenix UI at [http://localhost:6006](http://localhost:6006).
+
+3. Enable Phoenix tracing in your YAML config:
+
+   ```yaml
+   general:
+     telemetry:
+       tracing:
+         phoenix:
+           _type: phoenix
+           endpoint: http://localhost:6006/v1/traces
+           project: dev
+   ```
+
+   The `project` field groups traces under a named project in the Phoenix UI.
+
+### What You Can Inspect
+
+- **Traces** -- Full agent execution trees showing orchestrator routing, tool calls, and LLM interactions.
+- **Token usage** -- Per-call input/output token counts and costs.
+- **Latency** -- Time spent in each step of the agent pipeline.
+- **Tool calls** -- Arguments passed to and results returned from search tools, RAG retrieval, and other data sources.
+
+## LangSmith
+
+[LangSmith](https://smith.langchain.com/) provides cloud-hosted tracing, evaluation datasets, and prompt optimization for LangChain-based applications. It works automatically through the LangChain integration -- no YAML config changes are needed.
+
+### Setup
+
+1. Create an account at [smith.langchain.com](https://smith.langchain.com/) and generate an API key.
+
+2. Set the following environment variables in `deploy/.env`:
+
+   ```bash
+   LANGCHAIN_TRACING_V2=true
+   LANGCHAIN_API_KEY=lsv2-...
+   LANGCHAIN_PROJECT=aiq-research
+   ```
+
+   The `LANGCHAIN_PROJECT` variable groups traces under a named project. If omitted, traces go to the `default` project.
+
+3. Start the application as usual. All LangChain and LangGraph operations are traced automatically. No YAML config changes are required -- the LangChain SDK detects these environment variables at startup:
+
+   ```yaml
+   # No telemetry.tracing section needed for LangSmith.
+   # The environment variables above are sufficient.
+   general:
+     telemetry:
+       logging:
+         console:
+           _type: console
+           level: INFO
+   ```
+
+### What You Can Inspect
+
+- **Trace trees** -- Visualize the full agent execution including orchestrator decisions, tool calls, and LLM interactions.
+- **LLM calls** -- Input prompts, output completions, token counts, and latency for every model call.
+- **Evaluation** -- Build datasets from traced runs and evaluate agent quality over time.
+
+## Weights & Biases Weave
+
+[Weave](https://wandb.ai/site/weave) provides experiment tracking and trace logging integrated with the Weights & Biases platform. NAT includes Weave support via the `weave` extra (`nvidia-nat[weave]`), which is already installed in this project.
+
+### Setup
+
+1. Create a [Weights & Biases](https://wandb.ai/) account if you do not have one.
+
+2. Set the API key in `deploy/.env`:
+
+   ```bash
+   WANDB_API_KEY=your-wandb-api-key
+   ```
+
+   Alternatively, authenticate interactively:
+
+   ```bash
+   wandb login
+   ```
+
+3. Enable Weave tracing in your YAML config:
+
+   ```yaml
+   general:
+     telemetry:
+       tracing:
+         weave:
+           _type: weave
+           project: aiq-research
+   ```
+
+### Configuration Reference
+
+The Weave exporter supports PII redaction and custom trace attributes:
+
+```yaml
+general:
+  telemetry:
+    tracing:
+      weave:
+        _type: weave
+        project: aiq-research
+        verbose: false
+        redact_pii: true
+        redact_pii_fields:
+          - CREDIT_CARD
+          - EMAIL_ADDRESS
+          - PHONE_NUMBER
+        redact_keys:
+          - api_key
+          - authorization
+        attributes:
+          environment: development
+          team: research
+```
+
+| Field | Description |
+|-------|-------------|
+| `project` | The W&B project name. |
+| `verbose` | Enable verbose logging for the Weave exporter. |
+| `redact_pii` | Automatically redact PII from traces using Presidio. |
+| `redact_pii_fields` | Custom PII entity types to redact (e.g., `CREDIT_CARD`, `EMAIL_ADDRESS`). Only used when `redact_pii` is `true`. |
+| `redact_keys` | Additional keys to redact beyond the defaults (`api_key`, `auth_headers`, `authorization`). |
+| `attributes` | Custom attributes to include in all trace spans. |
+
+### What You Can Inspect
+
+- **Trace timelines** -- Agent execution flows with timing breakdowns.
+- **Model calls** -- Inputs, outputs, and metadata for each LLM invocation.
+- **Experiment comparison** -- Compare traces across different configurations or model versions.
+
+## OpenTelemetry Collector
+
+For production environments, the AI-Q blueprint provides a custom OpenTelemetry exporter (`otelcollector_redaction`) that forwards spans to any OTEL-compatible collector (Jaeger, Grafana Tempo, Datadog, etc.) with built-in privacy redaction.
+
+### Setup
+
+Add the exporter to your YAML config:
+
+```yaml
+general:
+  telemetry:
+    tracing:
+      otel:
+        _type: otelcollector_redaction
+        endpoint: http://your-otel-collector:4318/v1/traces
+        project: aiq-research
+        resource_attributes:
+          deployment.environment: production
+          service.version: "1.0.0"
+```
+
+### Privacy Redaction
+
+The `otelcollector_redaction` exporter can automatically redact sensitive data from trace spans before they leave the application. This is useful for enterprise environments where LLM inputs and outputs may contain PII or confidential information.
+
+```yaml
+general:
+  telemetry:
+    tracing:
+      otel:
+        _type: otelcollector_redaction
+        endpoint: http://your-otel-collector:4318/v1/traces
+        project: aiq-research
+        redaction_enabled: true
+        redaction_attributes:
+          - input.value
+          - output.value
+          - nat.metadata
+        force_redaction: false
+        redaction_tag: redacted
+```
+
+| Field | Description |
+|-------|-------------|
+| `redaction_enabled` | Enable or disable redaction processing. |
+| `redaction_attributes` | Span attributes to redact (defaults to `input.value`, `output.value`, `nat.metadata`). |
+| `force_redaction` | Always redact, regardless of header conditions. |
+| `redaction_tag` | Tag added to spans when redaction is applied. |
+| `redaction_headers` | Request headers checked to determine whether to redact. |
+| `resource_attributes` | Custom OTEL resource attributes attached to all spans. |
+
+### Batch Configuration
+
+The exporter supports standard OTEL batch settings:
+
+```yaml
+batch_size: 512
+flush_interval: 5000
+max_queue_size: 2048
+drop_on_overflow: false
+shutdown_timeout: 30000
+```
+
+## Verbose Logging
+
+For quick debugging without any external services, enable the built-in verbose callback logger. This prints detailed agent execution information directly to the console.
+
+### Enable via CLI
+
+```bash
+./scripts/start_cli.sh --verbose
+```
+
+### Enable via YAML Config
+
+```yaml
+workflow:
+  _type: chat_researcher_agent
+  verbose: true
+```
+
+### What Gets Logged
+
+- Chain starts and completions (orchestrator routing, agent handoffs)
+- LLM invocations with model name and token counts
+- Tool calls with arguments and return values
+- Reasoning content for frontier models that support it

--- a/docs/source/deployment/production.md
+++ b/docs/source/deployment/production.md
@@ -118,10 +118,7 @@ Set `LOG_LEVEL=DEBUG` for verbose output during troubleshooting. Use `LOG_LEVEL=
 
 ### Tracing
 
-The backend supports OpenTelemetry-compatible tracing. Configure the following for observability:
-
-- **Phoenix tracing** -- Set up Phoenix for local trace visualization during development and debugging.
-- **LangSmith** -- For LLM-specific tracing, evaluation, and optimization. Configure `LANGCHAIN_TRACING_V2=true` and set `LANGCHAIN_API_KEY`.
+The backend supports OpenTelemetry-compatible tracing. See [Observability](./observability.md) for setup guides covering Phoenix, LangSmith, Weave, and the OTEL Collector with privacy redaction.
 
 ### Metrics to Watch
 

--- a/docs/source/get-started/quick-start.md
+++ b/docs/source/get-started/quick-start.md
@@ -65,6 +65,10 @@ Open [http://localhost:3000](http://localhost:3000) in your browser.
 The web UI requires Node.js 22+ and npm. If these were available during `./scripts/setup.sh`, UI dependencies are already installed. Otherwise, run `cd frontends/ui && npm ci` first.
 ```
 
+```{tip}
+**Running on a remote VM?** If you access the VM via SSH, you need to forward ports 3000 and 8000 to your local machine: `ssh -L 3000:localhost:3000 -L 8000:localhost:8000 user@your-vm-host`. See [Troubleshooting — VM / Remote Development](../resources/troubleshooting.md#vm--remote-development) for details.
+```
+
 ## Step 3: Ask a Question
 
 Try one of these example queries to observe the system in action:

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -86,6 +86,7 @@ Benchmarks <./evaluation/benchmarks/index.md>
 Overview <./deployment/index.md>
 Docker Compose <./deployment/docker-compose.md>
 Docker Build System <./deployment/docker-build.md>
+Observability <./deployment/observability.md>
 Production <./deployment/production.md>
 ```
 

--- a/docs/source/resources/troubleshooting.md
+++ b/docs/source/resources/troubleshooting.md
@@ -53,6 +53,44 @@ Common issues and solutions for the AI-Q blueprint.
 | Port already in use | Another service on port 3000/8000 | Set `PORT=8100` or `FRONTEND_PORT=3100` in `.env` |
 | UI shows "Backend unavailable" | Backend not healthy | `curl http://localhost:8000/health`; check backend container logs |
 
+## VM / Remote Development
+
+If you are running the AI-Q blueprint on a remote VM (cloud instance, WSL, SSH server) and accessing it from your local browser, `localhost:3000` and `localhost:8000` will not resolve because the services are listening on the VM — not your local machine.
+
+### SSH Port Forwarding
+
+Forward the required ports through your SSH connection:
+
+```bash
+# Forward both the frontend and backend ports
+ssh -L 3000:localhost:3000 -L 8000:localhost:8000 user@your-vm-host
+```
+
+Then open [http://localhost:3000](http://localhost:3000) on your local machine as usual.
+
+To forward ports to an already-active SSH session, you can also use `~C` (SSH escape sequence) to open the SSH command line and type:
+
+```text
+-L 3000:localhost:3000
+-L 8000:localhost:8000
+```
+
+### VS Code Remote SSH
+
+If you are using VS Code Remote-SSH, ports are typically forwarded automatically when the server starts listening. If not, open the **Ports** panel (`Ctrl+Shift+P` → "Ports: Focus on Ports View") and add ports `3000` and `8000` manually.
+
+### Common Symptoms
+
+| Symptom | Cause | Fix |
+| ------- | ----- | --- |
+| "This site can't be reached" on `localhost:3000` or `localhost:8000` | Ports not forwarded from VM to local machine | Use SSH port forwarding (see above) |
+| Connection refused after forwarding | Service not running on the VM | SSH into the VM and verify with `curl http://localhost:8000/health` |
+| Port forwarding conflicts | Local port already in use | Use alternate local ports: `ssh -L 3001:localhost:3000 -L 8001:localhost:8000 user@vm` |
+
+```{note}
+Docker Compose deployments on the VM handle container-to-host port mapping automatically. The SSH forwarding described here is for making the VM's ports accessible on your local machine.
+```
+
 ## Debugging Tips
 
 ### Enable Verbose Logging
@@ -67,6 +105,8 @@ workflow:
 Or through CLI: `./scripts/start_cli.sh --verbose`
 
 ### Phoenix Tracing
+
+For full setup instructions covering Phoenix, LangSmith, and other tracing backends, see [Observability](../deployment/observability.md).
 
 Start a Phoenix server and enable tracing in config:
 

--- a/docs/source/resources/troubleshooting.md
+++ b/docs/source/resources/troubleshooting.md
@@ -68,11 +68,10 @@ ssh -L 3000:localhost:3000 -L 8000:localhost:8000 user@your-vm-host
 
 Then open [http://localhost:3000](http://localhost:3000) on your local machine as usual.
 
-To forward ports to an already-active SSH session, you can also use `~C` (SSH escape sequence) to open the SSH command line and type:
+To forward ports to an already-active SSH session, you can also use `~C` (SSH escape sequence) to open the SSH command line and type the following on a single line (press Enter at the end):
 
 ```text
--L 3000:localhost:3000
--L 8000:localhost:8000
+-L 3000:localhost:3000 -L 8000:localhost:8000
 ```
 
 ### VS Code Remote SSH


### PR DESCRIPTION
## What does this PR do?
* Adds documentation for adding observability platforms for AI-Q, including LangSmith, Weights and Biases, and Arize Phoenix
* Adds documentation for port forwarding capabilities