### PR TITLE
Enhance title extraction logic in citation verification to prioritize titles closest to URLs

### DIFF
--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -450,19 +450,33 @@ _TITLE_NEAR_URL_PATTERNS = [
 def _extract_title_for_url(content: str, url: str) -> str | None:
     """Try to extract a title associated with a URL from the surrounding content.
 
-    Looks in the text block containing the URL for common title patterns.
+    Finds the title pattern **closest to** (and preceding) the URL within its
+    text block.  This prevents a single block containing multiple search
+    results from assigning the first result's title to every URL.
     """
     # Find the block of text containing this URL (split by --- or double newlines)
     blocks = re.split(r"\n\n---\n\n|\n\n\n", content)
     for block in blocks:
         if url not in block:
             continue
+        url_pos = block.index(url)
+        best_title: str | None = None
+        best_distance = float("inf")
         for pattern in _TITLE_NEAR_URL_PATTERNS:
-            title_match = pattern.search(block)
-            if title_match:
+            for title_match in pattern.finditer(block):
                 title = title_match.group(1).strip()
-                if title and title != url:
-                    return title
+                if not title or title == url:
+                    continue
+                # Prefer titles that appear before (and closest to) the URL
+                distance = url_pos - title_match.end()
+                if distance < 0:
+                    # Title appears after the URL — use large penalty
+                    distance = abs(distance) + 10000
+                if distance < best_distance:
+                    best_distance = distance
+                    best_title = title
+        if best_title:
+            return best_title
     return None
 
 

--- a/tests/aiq_agent/common/test_citation_verification.py
+++ b/tests/aiq_agent/common/test_citation_verification.py
@@ -373,6 +373,29 @@ class TestGenericUrlExtractor:
         entries = extract_sources_from_tool_result("any_tool", content)
         assert len(entries) == 1
 
+    def test_multiple_urls_in_same_block_get_correct_titles(self):
+        """Each URL should get the title closest to it, not the first title in the block."""
+        content = (
+            "1. **Spider 2.0: Enterprise Text-to-SQL** (2024)\n"
+            "   - Link: https://arxiv.org/abs/2411.07763\n"
+            "\n"
+            "2. **Spider: A Large-Scale Dataset** (2018)\n"
+            "   - Link: https://arxiv.org/abs/2308.15363"
+        )
+        entries = extract_sources_from_tool_result("paper_search_tool", content)
+        assert len(entries) == 2
+        # Each URL should have its own title, not both sharing the first title
+        titles = {e.url: e.title for e in entries}
+        assert titles["https://arxiv.org/abs/2411.07763"] == "Spider 2.0: Enterprise Text-to-SQL"
+        assert titles["https://arxiv.org/abs/2308.15363"] == "Spider: A Large-Scale Dataset"
+
+    def test_title_extraction_prefers_preceding_title(self):
+        """Title that appears before the URL is preferred over one after."""
+        content = "<title>Correct Title</title>\nhttps://example.com/page\n<title>Wrong Title</title>"
+        entries = extract_sources_from_tool_result("web_search", content)
+        assert len(entries) == 1
+        assert entries[0].title == "Correct Title"
+
 
 class TestKnowledgeLayerParser:
     """Tests for knowledge layer output parser."""


### PR DESCRIPTION
- Enhance title extraction logic in citation verification to prioritize titles closest to URLs
- Add tests to ensure correct title assignment for multiple URLs within the same text block and preference for preceding titles.