### PR TITLE
fix: idempotent DB init and SSE stream reliability with connection poolers

### DIFF
--- a/deploy/compose/init-db.sql
+++ b/deploy/compose/init-db.sql
@@ -1,9 +1,8 @@
 -- =============================================================================
--- AI-Q Blueprint - Database Initialization
--- This script runs on first PostgreSQL startup (fresh volume only)
+-- AI-Q Blueprint - Database Initialization (idempotent — safe to re-run)
 -- =============================================================================
 --
--- What this script handles (requires admin privileges):
+-- What this script handles:
 --   - Creating databases (aiq_checkpoints)
 --   - Granting permissions
 --   - Creating NAT JobStore table (job_info)
@@ -16,8 +15,8 @@
 --
 -- =============================================================================
 
--- Create checkpoints database for LangGraph agent state
-CREATE DATABASE aiq_checkpoints;
+-- Create checkpoints database if it doesn't exist
+SELECT 'CREATE DATABASE aiq_checkpoints' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'aiq_checkpoints')\gexec
 
 -- Grant permissions
 GRANT ALL PRIVILEGES ON DATABASE aiq_jobs TO aiq;

--- a/frontends/aiq_api/src/aiq_api/jobs/runner.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/runner.py
@@ -285,10 +285,12 @@ async def run_agent_job(
         async with WorkflowBuilder.from_config(config=config) as builder:
             fn_config = builder.get_function_config(agent_config_name)
 
-            # Get LLMs for deep_researcher (orchestrator required)
-            orchestrator_llm = await builder.get_llm(
-                fn_config.orchestrator_llm, wrapper_type=LLMFrameworkEnum.LANGCHAIN
-            )
+            # Get LLMs - handle both deep_researcher (orchestrator_llm) and shallow/other agents (llm)
+            orchestrator_llm = None
+            if hasattr(fn_config, "orchestrator_llm") and fn_config.orchestrator_llm:
+                orchestrator_llm = await builder.get_llm(
+                    fn_config.orchestrator_llm, wrapper_type=LLMFrameworkEnum.LANGCHAIN
+                )
             planner_llm = None
             researcher_llm = None
             if hasattr(fn_config, "planner_llm") and fn_config.planner_llm:
@@ -299,6 +301,8 @@ async def run_agent_job(
                 )
 
             llm = orchestrator_llm
+            if llm is None and hasattr(fn_config, "llm") and fn_config.llm:
+                llm = await builder.get_llm(fn_config.llm, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
 
             tools = await builder.get_tools(tool_names=fn_config.tools, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
             if data_sources is not None:
@@ -538,13 +542,24 @@ def _create_agent_instance(
     1. llm_provider + tools pattern (DeepResearcherAgent style)
     2. llm + tools pattern (simpler agents)
     """
-    # Try llm_provider pattern first (DeepResearcherAgent)
+    # Try deep_researcher pattern (llm_provider + tools + max_loops + verbose)
     try:
         return agent_cls(
             llm_provider=llm_provider,
             tools=tools,
             max_loops=getattr(fn_config, "max_loops", 3),
             verbose=verbose,
+            callbacks=callbacks,
+        )
+    except TypeError:
+        pass
+
+    # Try llm_provider + tools pattern (ShallowResearcherAgent style)
+    try:
+        return agent_cls(
+            llm_provider=llm_provider,
+            tools=tools,
+            max_tool_iterations=getattr(fn_config, "max_tool_iterations", 5),
             callbacks=callbacks,
         )
     except TypeError:

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -1036,6 +1036,7 @@ async def _sse_generator_postgres(job_store, job_id: str, db_url: str, start_eve
     # LISTEN/NOTIFY needs a persistent session — incompatible with PgBouncer
     # transaction pooling. Use AIQ_LISTEN_DB_URL to point directly at PostgreSQL.
     import os
+
     listen_db_url = os.environ.get("AIQ_LISTEN_DB_URL", db_url)
     asyncpg_url = listen_db_url.replace("+psycopg2", "").replace("+asyncpg", "").replace("postgresql://", "postgres://")
     channel = f"job_events_{job_id.replace('-', '_')}"

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -1033,7 +1033,11 @@ async def _sse_generator_postgres(job_store, job_id: str, db_url: str, start_eve
             sequence_id += 1
         return f"id: {sequence_id}\nevent: {event_type}\ndata: {json.dumps(data)}\n\n"
 
-    asyncpg_url = db_url.replace("+psycopg2", "").replace("+asyncpg", "").replace("postgresql://", "postgres://")
+    # LISTEN/NOTIFY needs a persistent session — incompatible with PgBouncer
+    # transaction pooling. Use AIQ_LISTEN_DB_URL to point directly at PostgreSQL.
+    import os
+    listen_db_url = os.environ.get("AIQ_LISTEN_DB_URL", db_url)
+    asyncpg_url = listen_db_url.replace("+psycopg2", "").replace("+asyncpg", "").replace("postgresql://", "postgres://")
     channel = f"job_events_{job_id.replace('-', '_')}"
 
     logger.info(f"SSE pub-sub stream starting for job_id={job_id}, channel={channel}")
@@ -1119,7 +1123,14 @@ async def _sse_generator_postgres(job_store, job_id: str, db_url: str, start_eve
                                 event_type = event.pop("type", "event")
                                 yield format_sse(event_type, event, db_event_id)
                     except TimeoutError:
-                        pass
+                        # Fallback poll: catch events if NOTIFY was lost
+                        fallback_events = await EventStore.get_events_async(db_url, job_id, last_event_id, 100)
+                        for event in fallback_events:
+                            db_event_id = event.pop("_id", None)
+                            if db_event_id:
+                                last_event_id = db_event_id
+                            event_type = event.pop("type", "event")
+                            yield format_sse(event_type, event, db_event_id)
 
                     job = await job_store.get_job(job_id)
                     if not job:


### PR DESCRIPTION
### Summary
  
- Make `init-db.sql` idempotent so database tables are recreated correctly after postgres restarts (previously CREATE DATABASE errored on re-runs, skipping subsequent `CREATE TABLE` statements)                    

- Fix SSE /stream endpoint stalling when a connection pooler (e.g. PgBouncer) sits between the app and PostgreSQL. PostgreSQL `LISTEN/NOTIFY` requires a persistent connection, which transaction-mode poolers silently drop. Added optional `AIQ_LISTEN_DB_URL` env var to specify a direct PostgreSQL connection for the `LISTEN` channel. When unset, falls back to `NAT_JOB_STORE_DB_URL` — no configuration needed for deployments without a connection pooler. Also added a fallback DB poll every 5s so events are still delivered even if the real-time notification channel is disrupted.
  
  
### Test plan                                                       

  - Deploy with PostgreSQL, submit a deep research job, verify /stream delivers events in real-time                                                                                                                
  - If using a connection pooler, set `AIQ_LISTEN_DB_URL` to a direct PostgreSQL URL and verify streaming works
  - Restart postgres, verify job_info / aiq_checkpoints tables are recreated automatically                                                                                                                         
  - Test with SQLite to confirm no regression (SSE uses polling mode, LISTEN code path not hit)