### PR TITLE
Add register_token_fetcher plugin hook for auth extensibility

### DIFF
--- a/src/aiq_agent/auth/utils.py
+++ b/src/aiq_agent/auth/utils.py
@@ -22,10 +22,34 @@ Token source: Context cookies (idToken) - set by the frontend auth layer.
 import base64
 import json
 import logging
+from collections.abc import Callable
 
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
+
+_token_fetchers: list[tuple[int, Callable[[], str | None]]] = []
+
+
+def register_token_fetcher(fetcher: Callable[[], str | None], priority: int = 0) -> None:
+    """Register an additional token source.
+
+    Registered fetchers are tried in priority order (highest first) before
+    the default Context cookie lookup. The first fetcher that returns a
+    non-None token wins.
+
+    Args:
+        fetcher: Callable that returns a token string or None.
+        priority: Higher priority fetchers are tried first. Default: 0.
+    """
+    _token_fetchers.append((priority, fetcher))
+    _token_fetchers.sort(key=lambda x: x[0], reverse=True)
+    logger.debug("Registered token fetcher (priority=%d), total fetchers: %d", priority, len(_token_fetchers))
+
+
+def clear_token_fetchers() -> None:
+    """Remove all registered token fetchers. Useful for testing."""
+    _token_fetchers.clear()
 
 
 class UserInfo(BaseModel):
@@ -68,11 +92,23 @@ def get_auth_token() -> str | None:
     """
     Get authentication token from the request context.
 
-    Reads the idToken cookie set by the frontend auth layer.
+    Tries registered token fetchers in priority order (highest first),
+    then falls back to the idToken cookie set by the frontend auth layer.
 
     Returns:
         ID token string or None if not available.
     """
+    # Try registered fetchers first (highest priority first)
+    for _priority, fetcher in _token_fetchers:
+        try:
+            token = fetcher()
+            if token:
+                logger.debug("Token provided by registered fetcher")
+                return token
+        except Exception as e:
+            logger.debug("Registered token fetcher failed: %s", e)
+
+    # Default: Context cookies
     from nat.builder.context import Context
 
     try:

--- a/tests/aiq_agent/auth/__init__.py
+++ b/tests/aiq_agent/auth/__init__.py
@@ -12,27 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""Shared authentication utilities for AI-Q blueprint.
-
-This module provides token retrieval and user info utilities that can be used
-by any tool or agent.
-"""
-
-from .utils import UserInfo
-from .utils import clear_token_fetchers
-from .utils import decode_jwt_payload
-from .utils import get_auth_token
-from .utils import get_current_user_info
-from .utils import get_user_info_from_token
-from .utils import register_token_fetcher
-
-__all__ = [
-    "UserInfo",
-    "clear_token_fetchers",
-    "decode_jwt_payload",
-    "get_auth_token",
-    "get_current_user_info",
-    "get_user_info_from_token",
-    "register_token_fetcher",
-]

--- a/tests/aiq_agent/auth/test_auth_utils.py
+++ b/tests/aiq_agent/auth/test_auth_utils.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for auth utilities: token fetcher registry and user info extraction.
+
+Module under test: src/aiq_agent/auth/utils.py
+"""
+
+import base64
+import json
+
+import pytest
+
+from aiq_agent.auth import clear_token_fetchers
+from aiq_agent.auth import get_auth_token
+from aiq_agent.auth import get_current_user_info
+from aiq_agent.auth import register_token_fetcher
+
+
+def _make_jwt(payload: dict) -> str:
+    """Build a minimal unsigned JWT (header.payload.signature) for testing."""
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "none"}).encode()).rstrip(b"=").decode()
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+    return f"{header}.{body}.sig"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_fetchers():
+    """Ensure each test starts and ends with a clean fetcher registry."""
+    clear_token_fetchers()
+    yield
+    clear_token_fetchers()
+
+
+def test_get_auth_token_default_returns_none():
+    """With no fetchers registered and no Context, get_auth_token returns None."""
+    assert get_auth_token() is None
+
+
+def test_register_token_fetcher_basic():
+    """A registered fetcher that returns a token is used by get_auth_token."""
+    register_token_fetcher(lambda: "my-token")
+    assert get_auth_token() == "my-token"
+
+
+def test_register_token_fetcher_priority():
+    """Higher-priority fetcher wins over lower-priority one."""
+    register_token_fetcher(lambda: "low", priority=1)
+    register_token_fetcher(lambda: "high", priority=10)
+    assert get_auth_token() == "high"
+
+
+def test_register_token_fetcher_skips_none():
+    """A fetcher returning None is skipped; the next fetcher is tried."""
+    register_token_fetcher(lambda: None, priority=10)
+    register_token_fetcher(lambda: "fallback", priority=5)
+    assert get_auth_token() == "fallback"
+
+
+def test_register_token_fetcher_skips_exceptions():
+    """A fetcher that raises is skipped; the next fetcher is tried."""
+
+    def bad_fetcher():
+        raise RuntimeError("boom")
+
+    register_token_fetcher(bad_fetcher, priority=10)
+    register_token_fetcher(lambda: "ok", priority=5)
+    assert get_auth_token() == "ok"
+
+
+def test_clear_token_fetchers():
+    """After clearing, no registered fetchers remain and default behavior is restored."""
+    register_token_fetcher(lambda: "token")
+    assert get_auth_token() == "token"
+
+    clear_token_fetchers()
+    assert get_auth_token() is None
+
+
+def test_get_current_user_info_uses_registered_fetcher():
+    """get_current_user_info delegates to get_auth_token, which uses registered fetchers."""
+    jwt = _make_jwt({"email": "alice@nvidia.com", "name": "Alice"})
+    register_token_fetcher(lambda: jwt)
+
+    user_info = get_current_user_info()
+    assert user_info is not None
+    assert user_info.email == "alice@nvidia.com"
+    assert user_info.name == "Alice"


### PR DESCRIPTION
## Summary

- Add `register_token_fetcher(fetcher, priority)` to `aiq_agent.auth` — allows external plugins to register additional token sources without monkey-patching
- Registered fetchers are tried in priority order (highest first) before the default AIQContext cookie lookup
- `get_current_user_info()` benefits automatically since it delegates to `get_auth_token()`
- Add `clear_token_fetchers()` for test isolation

## Motivation

Internal extensions (e.g., Starfleet auth) currently monkey-patch `get_auth_token()` and `get_current_user_info()` at import time to add multi-source token retrieval (env vars, cached tokens from CLI login). This is fragile — any change to the auth module's function signatures or imports silently breaks the patches.

With this hook, internal extensions become:
```python
from aiq_agent.auth import register_token_fetcher
register_token_fetcher(get_starfleet_token, priority=10)
```

Instead of 40+ lines of `setattr` and `__all__` manipulation.

## Test plan

- [x] `test_get_auth_token_default_returns_none` — no context, no fetchers → None
- [x] `test_register_token_fetcher_basic` — registered fetcher returns token
- [x] `test_register_token_fetcher_priority` — highest priority wins
- [x] `test_register_token_fetcher_skips_none` — None return falls through
- [x] `test_register_token_fetcher_skips_exceptions` — exceptions fall through
- [x] `test_clear_token_fetchers` — clear restores default behavior
- [x] `test_get_current_user_info_uses_registered_fetcher` — end-to-end with JWT

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>