### PR TITLE
Add register_token_fetcher plugin hook for auth extensibility

### DIFF
--- a/src/aiq_agent/auth/utils.py
+++ b/src/aiq_agent/auth/utils.py
@@ -22,10 +22,34 @@ Token source: Context cookies (idToken) - set by the frontend auth layer.
 import base64
 import json
 import logging
+from collections.abc import Callable
 
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
+
+_token_fetchers: list[tuple[int, Callable[[], str | None]]] = []
+
+
+def register_token_fetcher(fetcher: Callable[[], str | None], priority: int = 0) -> None:
+    """Register an additional token source.
+
+    Registered fetchers are tried in priority order (highest first) before
+    the default Context cookie lookup. The first fetcher that returns a
+    non-None token wins.
+
+    Args:
+        fetcher: Callable that returns a token string or None.
+        priority: Higher priority fetchers are tried first. Default: 0.
+    """
+    _token_fetchers.append((priority, fetcher))
+    _token_fetchers.sort(key=lambda x: x[0], reverse=True)
+    logger.debug("Registered token fetcher (priority=%d), total fetchers: %d", priority, len(_token_fetchers))
+
+
+def clear_token_fetchers() -> None:
+    """Remove all registered token fetchers. Useful for testing."""
+    _token_fetchers.clear()
 
 
 class UserInfo(BaseModel):
@@ -68,11 +92,23 @@ def get_auth_token() -> str | None:
     """
     Get authentication token from the request context.
 
-    Reads the idToken cookie set by the frontend auth layer.
+    Tries registered token fetchers in priority order (highest first),
+    then falls back to the idToken cookie set by the frontend auth layer.
 
     Returns:
         ID token string or None if not available.
     """
+    # Try registered fetchers first (highest priority first)
+    for _priority, fetcher in _token_fetchers:
+        try:
+            token = fetcher()
+            if token:
+                logger.debug("Token provided by registered fetcher")
+                return token
+        except Exception as e:
+            logger.debug("Registered token fetcher failed: %s", e)
+
+    # Default: Context cookies
     from nat.builder.context import Context
 
     try:

--- a/src/aiq_agent/auth/utils.py
+++ b/src/aiq_agent/auth/utils.py
@@ -22,6 +22,7 @@ Token source: Context cookies (idToken) - set by the frontend auth layer.
 import base64
 import json
 import logging
+import threading
 from collections.abc import Callable
 
 from pydantic import BaseModel
@@ -29,6 +30,7 @@ from pydantic import BaseModel
 logger = logging.getLogger(__name__)
 
 _token_fetchers: list[tuple[int, Callable[[], str | None]]] = []
+_fetcher_lock = threading.Lock()
 
 
 def register_token_fetcher(fetcher: Callable[[], str | None], priority: int = 0) -> None:
@@ -38,18 +40,29 @@ def register_token_fetcher(fetcher: Callable[[], str | None], priority: int = 0)
     the default Context cookie lookup. The first fetcher that returns a
     non-None token wins.
 
+    Duplicate fetchers (same callable identity) are silently ignored.
+
     Args:
         fetcher: Callable that returns a token string or None.
         priority: Higher priority fetchers are tried first. Default: 0.
     """
-    _token_fetchers.append((priority, fetcher))
-    _token_fetchers.sort(key=lambda x: x[0], reverse=True)
+    with _fetcher_lock:
+        if any(f is fetcher for _, f in _token_fetchers):
+            logger.debug("Token fetcher already registered, skipping duplicate")
+            return
+        _token_fetchers.append((priority, fetcher))
+        _token_fetchers.sort(key=lambda x: x[0], reverse=True)
     logger.debug("Registered token fetcher (priority=%d), total fetchers: %d", priority, len(_token_fetchers))
 
 
 def clear_token_fetchers() -> None:
-    """Remove all registered token fetchers. Useful for testing."""
-    _token_fetchers.clear()
+    """Remove all registered token fetchers.
+
+    Warning: This is intended for test isolation only. Calling in production
+    will silently remove all registered auth sources.
+    """
+    with _fetcher_lock:
+        _token_fetchers.clear()
 
 
 class UserInfo(BaseModel):
@@ -98,8 +111,10 @@ def get_auth_token() -> str | None:
     Returns:
         ID token string or None if not available.
     """
-    # Try registered fetchers first (highest priority first)
-    for _priority, fetcher in _token_fetchers:
+    # Try registered fetchers first (highest priority first).
+    # Iterate a snapshot so concurrent register_token_fetcher() calls
+    # don't mutate the list mid-iteration.
+    for _priority, fetcher in list(_token_fetchers):
         try:
             token = fetcher()
             if token:

--- a/tests/aiq_agent/auth/__init__.py
+++ b/tests/aiq_agent/auth/__init__.py
@@ -12,27 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""Shared authentication utilities for AI-Q blueprint.
-
-This module provides token retrieval and user info utilities that can be used
-by any tool or agent.
-"""
-
-from .utils import UserInfo
-from .utils import clear_token_fetchers
-from .utils import decode_jwt_payload
-from .utils import get_auth_token
-from .utils import get_current_user_info
-from .utils import get_user_info_from_token
-from .utils import register_token_fetcher
-
-__all__ = [
-    "UserInfo",
-    "clear_token_fetchers",
-    "decode_jwt_payload",
-    "get_auth_token",
-    "get_current_user_info",
-    "get_user_info_from_token",
-    "register_token_fetcher",
-]

--- a/tests/aiq_agent/auth/test_auth_utils.py
+++ b/tests/aiq_agent/auth/test_auth_utils.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for auth utilities: token fetcher registry and user info extraction.
+
+Module under test: src/aiq_agent/auth/utils.py
+"""
+
+import base64
+import json
+
+import pytest
+
+from aiq_agent.auth import clear_token_fetchers
+from aiq_agent.auth import get_auth_token
+from aiq_agent.auth import get_current_user_info
+from aiq_agent.auth import register_token_fetcher
+
+
+def _make_jwt(payload: dict) -> str:
+    """Build a minimal unsigned JWT (header.payload.signature) for testing."""
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "none"}).encode()).rstrip(b"=").decode()
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+    return f"{header}.{body}.sig"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_fetchers():
+    """Ensure each test starts and ends with a clean fetcher registry."""
+    clear_token_fetchers()
+    yield
+    clear_token_fetchers()
+
+
+def test_get_auth_token_default_returns_none():
+    """With no fetchers registered and no Context, get_auth_token returns None."""
+    assert get_auth_token() is None
+
+
+def test_register_token_fetcher_basic():
+    """A registered fetcher that returns a token is used by get_auth_token."""
+    register_token_fetcher(lambda: "my-token")
+    assert get_auth_token() == "my-token"
+
+
+def test_register_token_fetcher_priority():
+    """Higher-priority fetcher wins over lower-priority one."""
+    register_token_fetcher(lambda: "low", priority=1)
+    register_token_fetcher(lambda: "high", priority=10)
+    assert get_auth_token() == "high"
+
+
+def test_register_token_fetcher_skips_none():
+    """A fetcher returning None is skipped; the next fetcher is tried."""
+    register_token_fetcher(lambda: None, priority=10)
+    register_token_fetcher(lambda: "fallback", priority=5)
+    assert get_auth_token() == "fallback"
+
+
+def test_register_token_fetcher_skips_exceptions():
+    """A fetcher that raises is skipped; the next fetcher is tried."""
+
+    def bad_fetcher():
+        raise RuntimeError("boom")
+
+    register_token_fetcher(bad_fetcher, priority=10)
+    register_token_fetcher(lambda: "ok", priority=5)
+    assert get_auth_token() == "ok"
+
+
+def test_clear_token_fetchers():
+    """After clearing, no registered fetchers remain and default behavior is restored."""
+    register_token_fetcher(lambda: "token")
+    assert get_auth_token() == "token"
+
+    clear_token_fetchers()
+    assert get_auth_token() is None
+
+
+def test_get_current_user_info_uses_registered_fetcher():
+    """get_current_user_info delegates to get_auth_token, which uses registered fetchers."""
+    jwt = _make_jwt({"email": "alice@nvidia.com", "name": "Alice"})
+    register_token_fetcher(lambda: jwt)
+
+    user_info = get_current_user_info()
+    assert user_info is not None
+    assert user_info.email == "alice@nvidia.com"
+    assert user_info.name == "Alice"

--- a/tests/aiq_agent/auth/test_auth_utils.py
+++ b/tests/aiq_agent/auth/test_auth_utils.py
@@ -98,3 +98,19 @@ def test_get_current_user_info_uses_registered_fetcher():
     assert user_info is not None
     assert user_info.email == "alice@nvidia.com"
     assert user_info.name == "Alice"
+
+
+def test_register_token_fetcher_deduplication():
+    """Registering the same fetcher twice is a no-op (identity check)."""
+    call_count = 0
+
+    def my_fetcher():
+        nonlocal call_count
+        call_count += 1
+        return "token"
+
+    register_token_fetcher(my_fetcher, priority=5)
+    register_token_fetcher(my_fetcher, priority=10)  # duplicate — ignored
+
+    assert get_auth_token() == "token"
+    assert call_count == 1  # called only once, not twice


### PR DESCRIPTION
## Summary

- Add `register_token_fetcher(fetcher, priority)` to `aiq_agent.auth` — allows external plugins to register additional token sources without monkey-patching
- Registered fetchers are tried in priority order (highest first) before the default AIQContext cookie lookup
- `get_current_user_info()` benefits automatically since it delegates to `get_auth_token()`
- Add `clear_token_fetchers()` for test isolation

## Motivation

The current `get_auth_token()` only reads from AIQContext cookies set by the Next.js frontend. Enterprise deployments using custom SSO providers (Okta, Auth0, Azure AD, custom OIDC), CLI-based workflows, or API gateway token injection have no clean way to provide tokens — they must monkey-patch `get_auth_token()` at import time.

With this hook, auth extensions become:
```python
from aiq_agent.auth import register_token_fetcher

def my_sso_token_fetcher() -> str | None:
    # Check env var, cached token, custom header, etc.
    return os.getenv("MY_SSO_TOKEN")

register_token_fetcher(my_sso_token_fetcher, priority=10)
```

The fetcher chain is:
1. Registered fetchers (highest priority first)
2. Default AIQContext cookie lookup (existing behavior, unchanged)

First non-None token wins. Exceptions in fetchers are caught and logged, falling through to the next source.

## Test plan

- [x] `test_get_auth_token_default_returns_none` — no context, no fetchers → None
- [x] `test_register_token_fetcher_basic` — registered fetcher returns token
- [x] `test_register_token_fetcher_priority` — highest priority wins
- [x] `test_register_token_fetcher_skips_none` — None return falls through
- [x] `test_register_token_fetcher_skips_exceptions` — exceptions fall through
- [x] `test_clear_token_fetchers` — clear restores default behavior
- [x] `test_get_current_user_info_uses_registered_fetcher` — end-to-end with JWT

🤖 Generated with [Claude Code](https://claude.com/claude-code)