### PR TITLE
Fix silent auth transport failures in WebSocket and SSE

### DIFF
--- a/frontends/ui/src/app/api/jobs/async/[...path]/route.ts
+++ b/frontends/ui/src/app/api/jobs/async/[...path]/route.ts
@@ -55,13 +55,16 @@ const getAuthHeaders = async (req: Request, pathSegments: string[]): Promise<Rec
     return {}
   }
 
-  // Only allow query token for stream paths (EventSource can't set headers)
+  // Only allow query token for stream paths (EventSource can't set headers).
+  // Note: tokens in URLs may appear in server access logs. This is a
+  // server-side route handler — the token is extracted here and forwarded
+  // only via headers, never passed on as a URL to the backend.
   const allowQueryToken = pathSegments.includes('stream')
   const rawQueryToken = new URL(req.url).searchParams.get('token')?.trim()
   const queryToken = allowQueryToken && rawQueryToken ? rawQueryToken : undefined
 
-  if (queryToken && process.env.NODE_ENV === 'development') {
-    console.warn('[Deep Research API] Using ?token= query fallback for stream auth')
+  if (queryToken) {
+    console.warn('[Deep Research API] SSE stream using ?token= query fallback (idToken cookie missing)')
   }
 
   const authToken = req.headers.get('Authorization') || (queryToken ? `Bearer ${queryToken}` : null)

--- a/frontends/ui/src/app/api/jobs/async/[...path]/route.ts
+++ b/frontends/ui/src/app/api/jobs/async/[...path]/route.ts
@@ -43,18 +43,31 @@ const buildBackendUrl = (path: string[]): string => {
 }
 
 /**
- * Get auth headers from request, including idToken cookie
- * Returns empty object when REQUIRE_AUTH=false to prevent user identification
+ * Get auth headers from request, including idToken cookie.
+ * Returns empty object when REQUIRE_AUTH=false to prevent user identification.
+ *
+ * For SSE stream paths, accepts a ?token= query parameter as a fallback
+ * because EventSource cannot set custom headers or cookies.
  */
-const getAuthHeaders = async (req: Request): Promise<Record<string, string>> => {
+const getAuthHeaders = async (req: Request, pathSegments: string[]): Promise<Record<string, string>> => {
   // Skip auth when REQUIRE_AUTH=false - don't forward any auth info to backend
   if (!isAuthRequired()) {
     return {}
   }
 
-  const authToken = req.headers.get('Authorization')
+  // Only allow query token for stream paths (EventSource can't set headers)
+  const allowQueryToken = pathSegments.includes('stream')
+  const rawQueryToken = new URL(req.url).searchParams.get('token')?.trim()
+  const queryToken = allowQueryToken && rawQueryToken ? rawQueryToken : undefined
+
+  if (queryToken && process.env.NODE_ENV === 'development') {
+    console.warn('[Deep Research API] Using ?token= query fallback for stream auth')
+  }
+
+  const authToken = req.headers.get('Authorization') || (queryToken ? `Bearer ${queryToken}` : null)
   const cookieStore = await cookies()
-  const idToken = cookieStore.get('idToken')?.value
+  const cookieIdToken = cookieStore.get('idToken')?.value
+  const idToken = cookieIdToken || queryToken
 
   return {
     ...(authToken ? { Authorization: authToken } : {}),
@@ -78,7 +91,7 @@ export async function GET(
     console.log('[Deep Research API] GET:', backendUrl, isStreamRequest ? '(SSE)' : '')
 
     // Get auth headers (includes idToken cookie)
-    const authHeaders = await getAuthHeaders(req)
+    const authHeaders = await getAuthHeaders(req, path)
     console.log('[Deep Research API] idToken cookie present:', !!authHeaders.Cookie)
 
     // Forward the request to the backend
@@ -88,6 +101,7 @@ export async function GET(
         ...authHeaders,
         Accept: isStreamRequest ? 'text/event-stream' : 'application/json',
       },
+      ...(isStreamRequest ? { signal: req.signal } : {}),
     })
 
     // Handle error responses
@@ -185,7 +199,7 @@ export async function POST(
     }
 
     // Get auth headers (includes idToken cookie)
-    const authHeaders = await getAuthHeaders(req)
+    const authHeaders = await getAuthHeaders(req, path)
     console.log('[Deep Research API] POST idToken cookie present:', !!authHeaders.Cookie)
 
     // Forward the request to the backend

--- a/frontends/ui/src/features/chat/hooks/use-deep-research.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-deep-research.spec.ts
@@ -906,7 +906,7 @@ describe('useDeepResearch', () => {
       consoleErrorSpy.mockRestore()
     })
 
-    test('onError does nothing when backend is reachable (transient SSE error)', async () => {
+    test('onError surfaces error when backend is reachable (no longer silently swallowed)', async () => {
       await setupConnectedHook()
 
       mockCheckBackendHealthCached.mockResolvedValue(true)
@@ -923,9 +923,14 @@ describe('useDeepResearch', () => {
         await mockClient?.callbacks.onError?.(new Error('Transient error'))
       })
 
-      expect(mockAddErrorCard).not.toHaveBeenCalled()
-      expect(mockCompleteDeepResearch).not.toHaveBeenCalled()
-      expect(mockSetStreaming).not.toHaveBeenCalled()
+      // Errors are now surfaced instead of silently swallowed when backend is healthy
+      expect(mockAddErrorCard).toHaveBeenCalledWith(
+        'connection.failed',
+        'Transient error',
+        expect.any(String)
+      )
+      expect(mockCompleteDeepResearch).toHaveBeenCalled()
+      expect(mockSetStreaming).toHaveBeenCalledWith(false)
 
       consoleWarnSpy.mockRestore()
     })

--- a/frontends/ui/src/features/chat/hooks/use-deep-research.ts
+++ b/frontends/ui/src/features/chat/hooks/use-deep-research.ts
@@ -24,6 +24,7 @@ import { useChatStore } from '../store'
 import { useAuth } from '@/adapters/auth'
 import { useLayoutStore } from '@/features/layout/store'
 import { checkBackendHealthCached } from '@/shared/hooks/use-backend-health'
+import { isLikelyAuthRelatedTransportError, isDeepResearchReplayCompleteMode } from '../lib/transport-auth-signals'
 
 /** Timeout in milliseconds before showing a warning (60 seconds) */
 const TIMEOUT_WARNING_MS = 60000
@@ -75,7 +76,7 @@ export const useDeepResearch = (): UseDeepResearchReturn => {
 
   // Auth token for authenticated requests
   // Note: idToken is used for backend auth, not accessToken
-  const { idToken } = useAuth()
+  const { idToken, authRequired, error: authError } = useAuth()
 
   // Chat store state and actions
   const {
@@ -135,6 +136,28 @@ export const useDeepResearch = (): UseDeepResearchReturn => {
     lastEventTimeRef.current = Date.now()
     setIsTimedOut(false)
   }, [])
+
+  /**
+   * Classify a deep research stream failure as auth-related or generic.
+   * Used when the backend is healthy but the SSE stream errored,
+   * which typically means the auth cookie or token drifted.
+   */
+  const getDeepResearchStreamFailure = useCallback(
+    (message: string, details?: string): { code: string; message: string; details?: string } => {
+      if (!authRequired) {
+        return { code: 'connection.failed', message, details }
+      }
+      if (authError === 'RefreshAccessTokenError' || isLikelyAuthRelatedTransportError(message)) {
+        return {
+          code: 'auth.session_expired',
+          message: 'Your session has expired. Please sign in again to continue.',
+          details,
+        }
+      }
+      return { code: 'connection.failed', message, details }
+    },
+    [authRequired, authError]
+  )
 
   /**
    * Create and connect to the SSE stream
@@ -242,7 +265,7 @@ export const useDeepResearch = (): UseDeepResearchReturn => {
           },
 
           onStreamMode: (mode) => {
-            if (mode === 'live' && buf.active) {
+            if (isDeepResearchReplayCompleteMode(mode) && buf.active) {
               flushBuffer()
               setCurrentStatus('researching')
             }
@@ -468,7 +491,15 @@ export const useDeepResearch = (): UseDeepResearchReturn => {
             const { isDeepResearchStreaming, deepResearchStatus } = useChatStore.getState()
             if (isDeepResearchStreaming && deepResearchStatus !== 'interrupted' && deepResearchStatus !== 'failure') {
               const backendUp = await checkBackendHealthCached()
-              if (backendUp) return
+
+              if (backendUp) {
+                // Backend is healthy but stream failed -- classify the error
+                const errorInfo = getDeepResearchStreamFailure(error.message, error.stack)
+                const state = useChatStore.getState()
+                state.addErrorCard(errorInfo.code as Parameters<typeof state.addErrorCard>[0], errorInfo.message, errorInfo.details)
+                return
+              }
+
               console.error('Deep research SSE failed (backend unreachable):', error)
               setCurrentStatus('error')
 
@@ -513,6 +544,7 @@ export const useDeepResearch = (): UseDeepResearchReturn => {
       completeDeepResearchLLMStep, addDeepResearchAgentWithId, completeDeepResearchAgent,
       addDeepResearchToolCall, completeDeepResearchToolCall, addDeepResearchFile,
       patchConversationMessage, addDeepResearchBanner, setStreaming, setStreamLoaded,
+      getDeepResearchStreamFailure,
     ]
   )
 

--- a/frontends/ui/src/features/chat/hooks/use-deep-research.ts
+++ b/frontends/ui/src/features/chat/hooks/use-deep-research.ts
@@ -492,15 +492,16 @@ export const useDeepResearch = (): UseDeepResearchReturn => {
             if (isDeepResearchStreaming && deepResearchStatus !== 'interrupted' && deepResearchStatus !== 'failure') {
               const backendUp = await checkBackendHealthCached()
 
-              if (backendUp) {
-                // Backend is healthy but stream failed -- classify the error
-                const errorInfo = getDeepResearchStreamFailure(error.message, error.stack)
-                const state = useChatStore.getState()
-                state.addErrorCard(errorInfo.code as Parameters<typeof state.addErrorCard>[0], errorInfo.message, errorInfo.details)
-                return
-              }
+              const errorInfo = backendUp
+                ? getDeepResearchStreamFailure(error.message, error.stack)
+                : { code: 'agent.deep_research_failed' as const, message: error.message, details: error.stack }
 
-              console.error('Deep research SSE failed (backend unreachable):', error)
+              console.error(
+                backendUp
+                  ? 'Deep research SSE failed while backend remained reachable:'
+                  : 'Deep research SSE failed (backend unreachable):',
+                error
+              )
               setCurrentStatus('error')
 
               const state = useChatStore.getState()
@@ -517,7 +518,7 @@ export const useDeepResearch = (): UseDeepResearchReturn => {
                 })
               }
 
-              state.addErrorCard('agent.deep_research_failed', error.message, error.stack)
+              state.addErrorCard(errorInfo.code as Parameters<typeof state.addErrorCard>[0], errorInfo.message, errorInfo.details)
               addDeepResearchBanner('failure', jobId, ownerConvId || undefined)
               stopAllDeepResearchSpinners()
               clientRef.current?.disconnect()

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -36,6 +36,7 @@ import { useConnectionRecovery } from './use-connection-recovery'
 import { useLayoutStore } from '@/features/layout/store'
 import { useDocumentsStore } from '@/features/documents/store'
 import { useAuth } from '@/adapters/auth'
+import { isLikelyAuthRelatedTransportError } from '../lib/transport-auth-signals'
 import type {
   Conversation,
   PromptType,
@@ -152,7 +153,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
   // Ref to track the current status for detecting status changes
   const currentStatusRef = useRef<StatusType | null>(null)
 
-  const { user } = useAuth()
+  const { user, authRequired, error: authError } = useAuth()
 
   // Chat store
   const {
@@ -201,6 +202,28 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
     const userId = user?.id ?? null
     setCurrentUser(userId)
   }, [user?.id, setCurrentUser])
+
+  /**
+   * Classify a transport failure as auth-related or generic connection error.
+   * Used when the backend is healthy but the WebSocket/SSE connection failed,
+   * which typically means the auth cookie or token drifted.
+   */
+  const getTransportFailure = useCallback(
+    (message: string, details?: string): { code: ErrorCode; message: string; details?: string } => {
+      if (!authRequired) {
+        return { code: 'connection.failed', message, details }
+      }
+      if (authError === 'RefreshAccessTokenError' || isLikelyAuthRelatedTransportError(message)) {
+        return {
+          code: 'auth.session_expired' as ErrorCode,
+          message: 'Your session has expired. Please sign in again to continue.',
+          details,
+        }
+      }
+      return { code: 'connection.failed', message, details }
+    },
+    [authRequired, authError]
+  )
 
   /**
    * Create WebSocket callbacks that route messages to the store
@@ -452,17 +475,12 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         // Connection errors (all retries exhausted) -- gate with health check
         if (errorContent.code === 'CONNECTION_FAILED') {
           const backendUp = await checkBackendHealthCached()
-          if (backendUp) {
-            // Backend is healthy -- this was a transient WebSocket issue.
-            // Don't alarm the user; the connection will re-establish on next send.
-            return
-          }
-          // Backend is truly down -- show error
-          addErrorCard(
-            'connection.failed',
-            errorContent.message,
-            errorContent.details,
-          )
+
+          const errorInfo = backendUp
+            ? getTransportFailure(errorContent.message, errorContent.details)
+            : { code: 'connection.failed' as const, message: errorContent.message, details: errorContent.details }
+
+          addErrorCard(errorInfo.code, errorInfo.message, errorInfo.details)
           setCurrentStatus(null)
           setStreaming(false)
           setLoading(false)
@@ -546,6 +564,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
     addDeepResearchBanner,
     addPlanMessage,
     updateConversationTitle,
+    getTransportFailure,
   ])
 
   /**

--- a/frontends/ui/src/features/chat/lib/transport-auth-signals.spec.ts
+++ b/frontends/ui/src/features/chat/lib/transport-auth-signals.spec.ts
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test } from 'vitest'
+
+import {
+  isLikelyAuthRelatedTransportError,
+  isDeepResearchReplayCompleteMode,
+} from './transport-auth-signals'
+
+describe('isLikelyAuthRelatedTransportError', () => {
+  test.each([
+    ['HTTP 401 response', 'Upstream returned 401 Unauthorized'],
+    ['unauthorized keyword', 'Request was unauthorized'],
+    ['token expired', 'token has expired'],
+    ['token invalid', 'token is invalid'],
+    ['token missing', 'token missing from request'],
+    ['session expired', 'session expired'],
+    ['session invalid', 'session invalid or revoked'],
+    ['authentication keyword', 'authentication failed'],
+    ['mixed case', 'Token Expired due to timeout'],
+    ['401 in longer message', 'WebSocket closed: 401 Unauthorized - check credentials'],
+  ])('returns true for auth-shaped error: %s', (_label, text) => {
+    expect(isLikelyAuthRelatedTransportError(text)).toBe(true)
+  })
+
+  test.each([
+    ['network error', 'Network connection timed out'],
+    ['generic server error', 'Internal server error 500'],
+    ['DNS failure', 'ENOTFOUND backend.example.com'],
+    ['connection refused', 'Connection refused'],
+    ['SSE retry', 'SSE connection failed after retries'],
+    ['empty string', ''],
+    ['random text', 'Something went wrong, please try again'],
+    ['403 forbidden (RBAC, not auth)', 'HTTP 403 Forbidden'],
+    ['permission denied', 'You do not have permission to access this resource'],
+  ])('returns false for non-auth error: %s', (_label, text) => {
+    expect(isLikelyAuthRelatedTransportError(text)).toBe(false)
+  })
+})
+
+describe('isDeepResearchReplayCompleteMode', () => {
+  test('returns true for live mode', () => {
+    expect(isDeepResearchReplayCompleteMode('live')).toBe(true)
+  })
+
+  test('returns true for pubsub mode', () => {
+    expect(isDeepResearchReplayCompleteMode('pubsub')).toBe(true)
+  })
+
+  test('returns false for polling mode', () => {
+    expect(isDeepResearchReplayCompleteMode('polling')).toBe(false)
+  })
+
+  test('returns false for unknown mode', () => {
+    expect(isDeepResearchReplayCompleteMode('unknown')).toBe(false)
+  })
+
+  test('returns false for empty string', () => {
+    expect(isDeepResearchReplayCompleteMode('')).toBe(false)
+  })
+})

--- a/frontends/ui/src/features/chat/lib/transport-auth-signals.ts
+++ b/frontends/ui/src/features/chat/lib/transport-auth-signals.ts
@@ -13,8 +13,6 @@
 const AUTH_ERROR_PATTERNS = [
   /\b401\b/i,
   /\bunauthorized\b/i,
-  /\bforbidden\b/i,
-  /\b403\b/i,
   /\btoken.*(expired|invalid|missing)\b/i,
   /\bsession.*(expired|invalid)\b/i,
   /\bauthenticat/i,

--- a/frontends/ui/src/features/chat/lib/transport-auth-signals.ts
+++ b/frontends/ui/src/features/chat/lib/transport-auth-signals.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Heuristics for detecting auth-related transport failures.
+ *
+ * WebSocket and SSE transports surface opaque errors when the backend
+ * rejects a request due to missing or invalid auth. These helpers let
+ * the UI hooks distinguish "backend is down" from "auth drifted" so
+ * users see an actionable "session expired" message instead of silence.
+ */
+
+const AUTH_ERROR_PATTERNS = [
+  /\b401\b/i,
+  /\bunauthorized\b/i,
+  /\bforbidden\b/i,
+  /\b403\b/i,
+  /\btoken.*(expired|invalid|missing)\b/i,
+  /\bsession.*(expired|invalid)\b/i,
+  /\bauthenticat/i,
+]
+
+/**
+ * Returns true if the error text looks like it was caused by an
+ * authentication or authorization failure rather than a network issue.
+ */
+export const isLikelyAuthRelatedTransportError = (text: string): boolean => {
+  return AUTH_ERROR_PATTERNS.some((pattern) => pattern.test(text))
+}
+
+/**
+ * Returns true if the given stream.mode value indicates that SSE replay
+ * catch-up is complete and the stream has switched to live events.
+ */
+export const isDeepResearchReplayCompleteMode = (mode: string): boolean => {
+  return mode === 'live' || mode === 'pubsub'
+}

--- a/frontends/ui/src/proxy.spec.ts
+++ b/frontends/ui/src/proxy.spec.ts
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mockGetToken = vi.fn()
+const mockCookiesSet = vi.fn()
+const mockCookiesDelete = vi.fn()
+
+vi.mock('next-auth/jwt', () => ({
+  getToken: (...args: unknown[]) => mockGetToken(...args),
+}))
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    next: () => ({
+      cookies: {
+        set: mockCookiesSet,
+        delete: mockCookiesDelete,
+      },
+    }),
+  },
+}))
+
+vi.mock('@/adapters/auth/config', () => ({
+  SESSION_MAX_AGE_SECONDS: 86400,
+  isAuthRequired: () => true,
+  shouldUseSecureCookies: () => true,
+}))
+
+import proxy from './proxy'
+
+describe('proxy auth cookie management', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-02T12:00:00Z'))
+    process.env.REQUIRE_AUTH = 'true'
+    process.env.NEXTAUTH_SECRET = 'test-secret' // pragma: allowlist secret
+  })
+
+  test('sets idToken cookie with maxAge tracking real token TTL', async () => {
+    const nowSec = Math.floor(Date.now() / 1000)
+    mockGetToken.mockResolvedValue({
+      idToken: 'valid-token-123',
+      expiresAt: nowSec + 3600, // expires in 1 hour
+    })
+
+    await proxy({
+      nextUrl: { pathname: '/' },
+    } as never)
+
+    expect(mockCookiesSet).toHaveBeenCalledWith(
+      'idToken',
+      'valid-token-123',
+      expect.objectContaining({
+        httpOnly: true,
+        sameSite: 'lax',
+        secure: true,
+        maxAge: 3600, // matches real TTL, not fixed 24h
+      })
+    )
+    expect(mockCookiesDelete).not.toHaveBeenCalledWith('idToken')
+  })
+
+  test('keeps cookie during refresh buffer window (not cleared early)', async () => {
+    const nowSec = Math.floor(Date.now() / 1000)
+    // Token expires in 60 seconds — within any reasonable refresh buffer,
+    // but NOT actually expired. Cookie should still be set.
+    mockGetToken.mockResolvedValue({
+      idToken: 'almost-expired-token',
+      expiresAt: nowSec + 60,
+    })
+
+    await proxy({
+      nextUrl: { pathname: '/' },
+    } as never)
+
+    expect(mockCookiesSet).toHaveBeenCalledWith(
+      'idToken',
+      'almost-expired-token',
+      expect.objectContaining({
+        maxAge: 60,
+      })
+    )
+    expect(mockCookiesDelete).not.toHaveBeenCalledWith('idToken')
+  })
+
+  test('clears cookie when token is actually expired', async () => {
+    const nowSec = Math.floor(Date.now() / 1000)
+    mockGetToken.mockResolvedValue({
+      idToken: 'expired-token',
+      expiresAt: nowSec - 10, // expired 10 seconds ago
+    })
+
+    await proxy({
+      nextUrl: { pathname: '/' },
+    } as never)
+
+    expect(mockCookiesDelete).toHaveBeenCalledWith('idToken')
+    expect(mockCookiesSet).not.toHaveBeenCalled()
+  })
+
+  test('clears cookie when refresh has already failed', async () => {
+    mockGetToken.mockResolvedValue({
+      error: 'RefreshAccessTokenError',
+      idToken: 'stale-token',
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    })
+
+    await proxy({
+      nextUrl: { pathname: '/' },
+    } as never)
+
+    expect(mockCookiesDelete).toHaveBeenCalledWith('idToken')
+    expect(mockCookiesSet).not.toHaveBeenCalled()
+  })
+
+  test('clears cookie when no token in session', async () => {
+    mockGetToken.mockResolvedValue({
+      // no idToken field
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    })
+
+    await proxy({
+      nextUrl: { pathname: '/' },
+    } as never)
+
+    expect(mockCookiesDelete).toHaveBeenCalledWith('idToken')
+    expect(mockCookiesSet).not.toHaveBeenCalled()
+  })
+
+  test('clears cookie when getToken returns null', async () => {
+    mockGetToken.mockResolvedValue(null)
+
+    await proxy({
+      nextUrl: { pathname: '/' },
+    } as never)
+
+    expect(mockCookiesDelete).toHaveBeenCalledWith('idToken')
+    expect(mockCookiesSet).not.toHaveBeenCalled()
+  })
+
+  test('clamps maxAge to SESSION_MAX_AGE_SECONDS', async () => {
+    const nowSec = Math.floor(Date.now() / 1000)
+    mockGetToken.mockResolvedValue({
+      idToken: 'long-lived-token',
+      expiresAt: nowSec + 200000, // way beyond 24h
+    })
+
+    await proxy({
+      nextUrl: { pathname: '/' },
+    } as never)
+
+    expect(mockCookiesSet).toHaveBeenCalledWith(
+      'idToken',
+      'long-lived-token',
+      expect.objectContaining({
+        maxAge: 86400, // clamped to SESSION_MAX_AGE_SECONDS
+      })
+    )
+  })
+})

--- a/frontends/ui/src/proxy.ts
+++ b/frontends/ui/src/proxy.ts
@@ -26,20 +26,29 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import {
-  TOKEN_REFRESH_BUFFER_SECONDS,
   SESSION_MAX_AGE_SECONDS,
   isAuthRequired,
   shouldUseSecureCookies,
 } from '@/adapters/auth/config'
 
 /**
- * Check if a token is expired or about to expire (within buffer period).
- * Returns true if the token should be considered invalid.
+ * Check if a token is actually expired (real expiry, not refresh buffer).
+ * The refresh buffer is for proactive token refresh in the NextAuth JWT
+ * callback — the cookie should remain valid until the token truly expires
+ * so that WebSocket and SSE transports can still authenticate.
  */
-const isTokenExpiredOrExpiring = (expiresAt: number | undefined): boolean => {
+const isTokenExpired = (expiresAt: number | undefined): boolean => {
   if (!expiresAt) return true
-  const expiresAtWithBuffer = expiresAt - TOKEN_REFRESH_BUFFER_SECONDS
-  return Date.now() >= expiresAtWithBuffer * 1000
+  return Date.now() >= expiresAt * 1000
+}
+
+/**
+ * Compute the cookie maxAge so it expires with the token rather than
+ * lasting a fixed 24 hours. Clamped to [1, SESSION_MAX_AGE_SECONDS].
+ */
+const idTokenCookieMaxAgeSeconds = (expiresAt: number): number => {
+  const nowSec = Math.floor(Date.now() / 1000)
+  return Math.min(SESSION_MAX_AGE_SECONDS, Math.max(1, expiresAt - nowSec))
 }
 
 export default async function proxy(req: NextRequest) {
@@ -83,20 +92,20 @@ export default async function proxy(req: NextRequest) {
 
       const expiresAt = token.expiresAt as number | undefined
 
-      // Set idToken cookie only if we have a valid, non-expired token
-      // If token is expired or expiring, don't set the cookie - this forces
-      // the client-side session check to trigger a refresh via useSession()
-      if (token.idToken && !isTokenExpiredOrExpiring(expiresAt)) {
+      // Set idToken cookie only if we have a valid, non-expired token.
+      // Unlike the refresh buffer (which proactively refreshes tokens),
+      // the cookie stays valid until real expiry so WebSocket/SSE
+      // transports don't lose auth while NextAuth refreshes in the background.
+      if (token.idToken && !isTokenExpired(expiresAt)) {
         response.cookies.set('idToken', token.idToken as string, {
           httpOnly: true,
           sameSite: 'lax',
           path: '/',
           secure: shouldUseSecureCookies(),
-          maxAge: SESSION_MAX_AGE_SECONDS,
+          maxAge: idTokenCookieMaxAgeSeconds(expiresAt!),
         })
-      } else if (isTokenExpiredOrExpiring(expiresAt)) {
-        // Token is expired or about to expire - clear the cookie
-        // This signals to the client that re-authentication or refresh is needed
+      } else if (isTokenExpired(expiresAt)) {
+        // Token is actually expired - clear the cookie
         response.cookies.delete('idToken')
       } else {
         // No idToken in session - clear the cookie

--- a/frontends/ui/src/proxy.ts
+++ b/frontends/ui/src/proxy.ts
@@ -104,11 +104,8 @@ export default async function proxy(req: NextRequest) {
           secure: shouldUseSecureCookies(),
           maxAge: idTokenCookieMaxAgeSeconds(expiresAt!),
         })
-      } else if (isTokenExpired(expiresAt)) {
-        // Token is actually expired - clear the cookie
-        response.cookies.delete('idToken')
       } else {
-        // No idToken in session - clear the cookie
+        // Token expired or absent - clear the cookie
         response.cookies.delete('idToken')
       }
     } else {


### PR DESCRIPTION
## Summary

Fixes a silent failure mode where users could submit a prompt and see no response, no error, and no visible feedback when authentication drifts between the browser session and backend transport.

## Problem

When auth is enabled, the `idToken` cookie is cleared during the refresh buffer window (`TOKEN_REFRESH_BUFFER_SECONDS` before actual expiry). But NextAuth still reports the session as authenticated. This creates a drift state where:

- The UI shows the user as logged in
- WebSocket and SSE transports depend on the `idToken` cookie for backend auth
- Transport silently fails because the cookie was already cleared
- The error handler in `use-deep-research.ts` checks if `/health` returns 200, and if so, **silently returns** — swallowing the auth failure entirely

The user sees: submit a query → nothing happens → no error card, no feedback.

## What Changed

1. **`proxy.ts`** — Keep the backend `idToken` cookie until actual token expiry, not the refresh buffer. NextAuth still refreshes proactively; this just prevents clearing transport auth early. Cookie `maxAge` now tracks real JWT TTL instead of a hardcoded 24h.

2. **`route.ts` (jobs async)** — Support `?token=` query parameter fallback for SSE stream paths. `EventSource` cannot set `Authorization` headers, so when the cookie is missing or stale, the frontend can pass the token as a query param. Only honored on `/stream` paths to prevent URL-based auth on REST endpoints.

3. **`use-websocket-chat.ts`** — When a `CONNECTION_FAILED` error occurs and the backend is healthy, classify the failure instead of silently returning. If the error looks auth-related (401, unauthorized, token expired) or NextAuth already reported a refresh failure, surface `auth.session_expired`. Otherwise surface `connection.failed`.

4. **`use-deep-research.ts`** — Same pattern for SSE transport errors. Replace the `if (backendUp) return` silent swallow with proper error classification and user-facing error cards. Also accept `pubsub` (not just `live`) as a replay-complete stream mode signal.

5. **`transport-auth-signals.ts`** (new) — Shared utility for detecting auth-shaped transport errors via pattern matching (401, 403, unauthorized, token expired, etc.) and replay mode detection.

## Test plan

- [ ] Deploy with `REQUIRE_AUTH=true` and an OAuth provider
- [ ] Submit a prompt — verify normal flow works
- [ ] Wait for token to enter refresh buffer — verify prompt still works (cookie not cleared early)
- [ ] Force token expiry — verify `auth.session_expired` error card appears (not silent)
- [ ] Start deep research, force token expiry mid-stream — verify error card appears
- [ ] With `REQUIRE_AUTH=false` — verify no auth-related error cards appear on transport failures
- [ ] SSE reconnect with `?token=` param — verify it authenticates when cookie is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)