### PR TITLE
Propagate auth token to Dask workers for async jobs

### DIFF
--- a/frontends/aiq_api/src/aiq_api/jobs/_auth_context.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/_auth_context.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-task auth token context for async jobs.
+
+Uses a ContextVar so concurrent jobs in the same Dask worker process
+each see their own token without cross-task leakage.
+
+The token fetcher is registered once at import time. It returns the
+token from the current task's context, or None if no token is set.
+"""
+
+from contextvars import ContextVar
+
+from aiq_agent.auth import register_token_fetcher
+
+job_auth_token: ContextVar[str | None] = ContextVar("job_auth_token", default=None)
+
+
+def _job_token_fetcher() -> str | None:
+    """Return the auth token for the current async task, if any."""
+    return job_auth_token.get()
+
+
+# Register once — the ContextVar ensures per-task isolation
+register_token_fetcher(_job_token_fetcher, priority=5)

--- a/frontends/aiq_api/src/aiq_api/jobs/runner.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/runner.py
@@ -207,6 +207,7 @@ async def run_agent_job(
     parent_conversation_id: str | None = None,
     available_documents: list[dict] | None = None,
     data_sources: list[str] | None = None,
+    auth_token: str | None = None,
 ):
     """
     Dask task to run any registered agent with cancellation support and telemetry.
@@ -234,7 +235,19 @@ async def run_agent_job(
         parent_workflow_trace_id: Parent trace ID (int or hex string) for trace continuity.
         parent_conversation_id: Conversation ID for session grouping in Phoenix.
         available_documents: Optional list of document dicts with file_name and summary.
+        data_sources: Optional list of allowed data sources to enforce in the worker.
+        auth_token: Optional auth token propagated from the HTTP request for
+            data sources that require authentication (requires_auth: true).
     """
+
+    # Propagate auth token into the current async task's context so tools
+    # can retrieve it via get_auth_token(). Uses a ContextVar so concurrent
+    # jobs in the same Dask worker process don't leak tokens across tasks.
+    _auth_token_reset = None
+    if auth_token:
+        from ._auth_context import job_auth_token
+
+        _auth_token_reset = job_auth_token.set(auth_token)
 
     from aiq_agent.common import LLMProvider
     from aiq_agent.common import LLMRole
@@ -537,6 +550,11 @@ async def run_agent_job(
             event_store.flush()
         if cancellation_monitor:
             cancellation_monitor.stop()
+        # Clean up job-scoped auth token
+        if _auth_token_reset is not None:
+            from ._auth_context import job_auth_token
+
+            job_auth_token.reset(_auth_token_reset)
 
 
 def _create_agent_instance(

--- a/frontends/aiq_api/src/aiq_api/jobs/submit.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/submit.py
@@ -171,6 +171,12 @@ async def submit_agent_job(
     if not scheduler_address:
         raise RuntimeError("Async job submission requires NAT_DASK_SCHEDULER_ADDRESS to be set")
 
+    # Auto-capture auth token if not explicitly provided
+    if auth_token is None:
+        from aiq_agent.auth import get_auth_token
+
+        auth_token = get_auth_token()
+
     job_store = JobStore(scheduler_address=scheduler_address, db_url=db_url)
     resolved_job_id = job_store.ensure_job_id(job_id)
 

--- a/frontends/aiq_api/src/aiq_api/jobs/submit.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/submit.py
@@ -91,6 +91,7 @@ async def submit_agent_job(
     expiry_seconds: int = 86400,
     available_documents: list[dict] | None = None,
     data_sources: list[str] | None = None,
+    auth_token: str | None = None,
 ) -> str:
     """
     Submit an agent job to the Dask cluster.
@@ -106,6 +107,8 @@ async def submit_agent_job(
         expiry_seconds: Job expiry time in seconds (default 24h).
         available_documents: Optional list of document dicts with file_name and summary.
         data_sources: Optional list of allowed data sources to enforce in the worker.
+        auth_token: Optional auth token to propagate to the Dask worker for
+            data sources that require authentication.
 
     Returns:
         The job ID.
@@ -188,6 +191,7 @@ async def submit_agent_job(
             *_get_parent_trace_context(),
             available_documents,
             data_sources,
+            auth_token,
         ],
     )
 

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -289,6 +289,11 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         resolved_job_id = job_store.ensure_job_id(req.job_id)
         expiry = req.expiry_seconds if req.expiry_seconds is not None else default_expiry_seconds
 
+        # Propagate auth token to Dask worker for requires_auth data sources
+        from aiq_agent.auth import get_auth_token
+
+        auth_token = get_auth_token()
+
         job_args = [
             not use_threads,  # configure_logging
             log_level,
@@ -307,6 +312,7 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
             None,  # parent_conversation_id
             None,  # available_documents
             None,  # data_sources
+            auth_token,  # auth_token
         ]
 
         job_id, _ = await job_store.submit_job(

--- a/src/aiq_agent/auth/__init__.py
+++ b/src/aiq_agent/auth/__init__.py
@@ -26,6 +26,7 @@ from .utils import get_auth_token
 from .utils import get_current_user_info
 from .utils import get_user_info_from_token
 from .utils import register_token_fetcher
+from .utils import unregister_token_fetcher
 
 __all__ = [
     "UserInfo",
@@ -35,4 +36,5 @@ __all__ = [
     "get_current_user_info",
     "get_user_info_from_token",
     "register_token_fetcher",
+    "unregister_token_fetcher",
 ]

--- a/src/aiq_agent/auth/utils.py
+++ b/src/aiq_agent/auth/utils.py
@@ -55,6 +55,24 @@ def register_token_fetcher(fetcher: Callable[[], str | None], priority: int = 0)
     logger.debug("Registered token fetcher (priority=%d), total fetchers: %d", priority, len(_token_fetchers))
 
 
+def unregister_token_fetcher(fetcher: Callable[[], str | None]) -> None:
+    """Remove a previously registered token fetcher.
+
+    Matches by callable identity (``is`` check). No-op if the fetcher
+    is not currently registered.
+
+    Args:
+        fetcher: The same callable object that was passed to
+            :func:`register_token_fetcher`.
+    """
+    with _fetcher_lock:
+        before = len(_token_fetchers)
+        _token_fetchers[:] = [(p, f) for p, f in _token_fetchers if f is not fetcher]
+        removed = before - len(_token_fetchers)
+    if removed:
+        logger.debug("Unregistered token fetcher, total fetchers: %d", len(_token_fetchers))
+
+
 def clear_token_fetchers() -> None:
     """Remove all registered token fetchers.
 

--- a/tests/aiq_agent/jobs/test_runner.py
+++ b/tests/aiq_agent/jobs/test_runner.py
@@ -427,7 +427,8 @@ class TestSubmitDeepResearchJob:
         assert result == "test-job-id"
         mock_job_store.submit_job.assert_called_once()
         job_args = mock_job_store.submit_job.call_args.kwargs["job_args"]
-        assert job_args[-1] == ["web_search"]
+        # data_sources is second-to-last (auth_token is last)
+        assert job_args[-2] == ["web_search"]
 
     @pytest.mark.asyncio
     async def test_submit_with_custom_job_id(self):


### PR DESCRIPTION
Data sources with requires_auth: true need an auth token in the Dask worker process. The WebSocket path has request context (cookies), but async jobs run in separate Dask workers where no request context exists.

Fix: capture the auth token at job submission time via get_auth_token() and pass it as a job arg. The worker registers it as a token fetcher so tools can authenticate via the standard get_auth_token() API.

Changes:
- routes/jobs.py: call get_auth_token(), append to job_args
- runner.py: accept auth_token param, register as fetcher (priority=5)
- submit.py: accept and forward auth_token param