### PR TITLE
fix: add LangGraph checkpoint tables to init-db.sql

### DIFF
--- a/deploy/compose/init-db.sql
+++ b/deploy/compose/init-db.sql
@@ -2,15 +2,23 @@
 -- AI-Q Blueprint - Database Initialization (idempotent — safe to re-run)
 -- =============================================================================
 --
--- What this script handles:
---   - Creating databases (aiq_checkpoints)
---   - Granting permissions
---   - Creating NAT JobStore table (job_info)
---   - Creating performance indices
+-- Run by the backend init container on every pod start. All statements are
+-- idempotent (IF NOT EXISTS) so re-runs are safe.
 --
--- What the app handles automatically:
---   - job_events table (event_store.py creates via SQLAlchemy)
---   - summaries table (summary_store.py creates if not exists)
+-- Databases:
+--   - aiq_jobs         (job metadata, events, document summaries)
+--   - aiq_checkpoints  (LangGraph conversation state)
+--
+-- Tables in aiq_jobs:
+--   - job_info      — NAT JobStore metadata (status, timestamps, expiry)
+--   - job_events    — SSE streaming events and job event persistence
+--   - summaries     — Document summaries (collection + filename keyed)
+--
+-- Tables in aiq_checkpoints:
+--   - checkpoints           — LangGraph conversation checkpoints
+--   - checkpoint_blobs      — LangGraph binary state data
+--   - checkpoint_writes     — LangGraph pending writes
+--   - checkpoint_migrations — LangGraph schema version tracking
 --
 -- =============================================================================
 

--- a/deploy/compose/init-db.sql
+++ b/deploy/compose/init-db.sql
@@ -10,7 +10,6 @@
 --
 -- What the app handles automatically:
 --   - job_events table (event_store.py creates via SQLAlchemy)
---   - LangGraph checkpoint tables (AsyncPostgresSaver creates them)
 --   - summaries table (summary_store.py creates if not exists)
 --
 -- =============================================================================
@@ -23,12 +22,11 @@ GRANT ALL PRIVILEGES ON DATABASE aiq_jobs TO aiq;
 GRANT ALL PRIVILEGES ON DATABASE aiq_checkpoints TO aiq;
 
 -- =============================================================================
--- Create job store table in aiq_jobs database
--- Note: job_events table is created by the app (event_store.py)
+-- Create tables in aiq_jobs database
 -- =============================================================================
 \connect aiq_jobs
 
--- Job metadata table (NAT JobStore - not auto-created by NAT)
+-- Job metadata table (NAT JobStore)
 CREATE TABLE IF NOT EXISTS job_info (
     job_id VARCHAR PRIMARY KEY,
     status VARCHAR NOT NULL,
@@ -42,6 +40,73 @@ CREATE TABLE IF NOT EXISTS job_info (
     is_expired BOOLEAN DEFAULT FALSE
 );
 
--- Performance indices
 CREATE INDEX IF NOT EXISTS idx_job_info_status ON job_info(status);
 CREATE INDEX IF NOT EXISTS idx_job_info_created_at ON job_info(created_at);
+
+-- Job events table (SSE streaming, event persistence)
+CREATE TABLE IF NOT EXISTS job_events (
+    id SERIAL PRIMARY KEY,
+    job_id VARCHAR(64) NOT NULL,
+    event_type VARCHAR(64) NOT NULL,
+    event_data TEXT,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_events_job_id ON job_events(job_id);
+CREATE INDEX IF NOT EXISTS idx_job_events_job_id_id ON job_events(job_id, id);
+
+-- Document summaries table
+CREATE TABLE IF NOT EXISTS summaries (
+    collection VARCHAR(256) NOT NULL,
+    filename VARCHAR(512) NOT NULL,
+    summary TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (collection, filename)
+);
+
+CREATE INDEX IF NOT EXISTS idx_summaries_collection ON summaries(collection);
+
+-- =============================================================================
+-- Create LangGraph checkpoint tables in aiq_checkpoints database
+-- These must exist before backends connect. Previously left to the app,
+-- but if postgres restarts without a backend restart, the tables are lost
+-- and running backends crash with "relation checkpoints does not exist".
+-- =============================================================================
+\connect aiq_checkpoints
+
+CREATE TABLE IF NOT EXISTS checkpoint_migrations (
+    v INTEGER PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS checkpoints (
+    thread_id TEXT NOT NULL,
+    checkpoint_ns TEXT NOT NULL DEFAULT '',
+    checkpoint_id TEXT NOT NULL,
+    parent_checkpoint_id TEXT,
+    type TEXT,
+    checkpoint JSONB NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}',
+    PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id)
+);
+
+CREATE TABLE IF NOT EXISTS checkpoint_blobs (
+    thread_id TEXT NOT NULL,
+    checkpoint_ns TEXT NOT NULL DEFAULT '',
+    channel TEXT NOT NULL,
+    version TEXT NOT NULL,
+    type TEXT NOT NULL,
+    blob BYTEA,
+    PRIMARY KEY (thread_id, checkpoint_ns, channel, version)
+);
+
+CREATE TABLE IF NOT EXISTS checkpoint_writes (
+    thread_id TEXT NOT NULL,
+    checkpoint_ns TEXT NOT NULL DEFAULT '',
+    checkpoint_id TEXT NOT NULL,
+    task_id TEXT NOT NULL,
+    idx INTEGER NOT NULL,
+    channel TEXT NOT NULL,
+    type TEXT,
+    blob BYTEA NOT NULL,
+    PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id, task_id, idx)
+);

--- a/deploy/compose/init-db.sql
+++ b/deploy/compose/init-db.sql
@@ -57,7 +57,7 @@ CREATE TABLE IF NOT EXISTS job_events (
     job_id VARCHAR(64) NOT NULL,
     event_type VARCHAR(64) NOT NULL,
     event_data TEXT,
-    created_at TIMESTAMP DEFAULT NOW()
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
 CREATE INDEX IF NOT EXISTS idx_job_events_job_id ON job_events(job_id);
@@ -68,7 +68,7 @@ CREATE TABLE IF NOT EXISTS summaries (
     collection VARCHAR(256) NOT NULL,
     filename VARCHAR(512) NOT NULL,
     summary TEXT NOT NULL,
-    created_at TIMESTAMP DEFAULT NOW(),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     PRIMARY KEY (collection, filename)
 );
 

--- a/deploy/helm/deployment-k8s/values.yaml
+++ b/deploy/helm/deployment-k8s/values.yaml
@@ -148,34 +148,8 @@ aiq:
         POSTGRES_PASSWORD: DB_USER_PASSWORD
       env:
         POSTGRES_DB: aiq_jobs
-      configMaps:
-      - name: aiq-postgres-init
-        data:
-          init.sql: "-- =============================================================================\n\
-            -- AI-Q - Database Initialization\n-- This script runs on first PostgreSQL\
-            \ startup (fresh volume only)\n-- =============================================================================\n\
-            --\n-- What this script handles (requires admin privileges):\n--   - Creating\
-            \ databases (aiq_checkpoints)\n--   - Granting permissions\n--   - Creating\
-            \ NAT JobStore table (job_info)\n--   - Creating performance indices\n\
-            --\n-- What the app handles automatically:\n--   - job_events table (event_store.py\
-            \ creates via SQLAlchemy)\n--   - LangGraph checkpoint tables (AsyncPostgresSaver\
-            \ creates them)\n--   - summaries table (summary_store.py creates if not\
-            \ exists)\n--\n-- =============================================================================\n\
-            \n-- Create checkpoints database for LangGraph agent state\nCREATE DATABASE\
-            \ aiq_checkpoints;\n\n-- Grant permissions\nGRANT ALL PRIVILEGES ON DATABASE\
-            \ aiq_jobs TO :\"db_user\";\nGRANT ALL PRIVILEGES ON DATABASE aiq_checkpoints\
-            \ TO :\"db_user\";\n\n-- =============================================================================\n\
-            -- Create job store table in aiq_jobs database\n-- Note: job_events table\
-            \ is created by the app (event_store.py)\n-- =============================================================================\n\
-            \\connect aiq_jobs\n\n-- Job metadata table (NAT JobStore - not auto-created\
-            \ by NAT)\nCREATE TABLE IF NOT EXISTS job_info (\n    job_id VARCHAR PRIMARY\
-            \ KEY,\n    status VARCHAR NOT NULL,\n    config_file VARCHAR,\n    error\
-            \ VARCHAR,\n    output_path VARCHAR,\n    created_at TIMESTAMP WITH TIME\
-            \ ZONE,\n    updated_at TIMESTAMP WITH TIME ZONE,\n    expiry_seconds\
-            \ INTEGER,\n    output VARCHAR,\n    is_expired BOOLEAN DEFAULT FALSE\n\
-            );\n\n-- Performance indices\nCREATE INDEX IF NOT EXISTS idx_job_info_status\
-            \ ON job_info(status);\nCREATE INDEX IF NOT EXISTS idx_job_info_created_at\
-            \ ON job_info(created_at);\n"
+      # ConfigMap for init.sql is managed by postgres-init-configmap.yaml template
+      # which reads from files/init-db.sql (source of truth: deploy/compose/init-db.sql)
       persistence:
       - name: aiq-postgres-data
         accessModes:

--- a/deploy/helm/helm-charts-k8s/aiq/files/init-db.sql
+++ b/deploy/helm/helm-charts-k8s/aiq/files/init-db.sql
@@ -58,7 +58,7 @@ CREATE TABLE IF NOT EXISTS job_events (
     job_id VARCHAR(64) NOT NULL,
     event_type VARCHAR(64) NOT NULL,
     event_data TEXT,
-    created_at TIMESTAMP DEFAULT NOW()
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
 CREATE INDEX IF NOT EXISTS idx_job_events_job_id ON job_events(job_id);
@@ -69,7 +69,7 @@ CREATE TABLE IF NOT EXISTS summaries (
     collection VARCHAR(256) NOT NULL,
     filename VARCHAR(512) NOT NULL,
     summary TEXT NOT NULL,
-    created_at TIMESTAMP DEFAULT NOW(),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     PRIMARY KEY (collection, filename)
 );
 

--- a/deploy/helm/helm-charts-k8s/aiq/files/init-db.sql
+++ b/deploy/helm/helm-charts-k8s/aiq/files/init-db.sql
@@ -1,0 +1,121 @@
+-- =============================================================================
+-- AI-Q Blueprint - Database Initialization (idempotent — safe to re-run)
+-- KEEP IN SYNC with deploy/compose/init-db.sql (the source of truth)
+-- =============================================================================
+--
+-- Run by the backend init container on every pod start. All statements are
+-- idempotent (IF NOT EXISTS) so re-runs are safe.
+--
+-- Databases:
+--   - aiq_jobs         (job metadata, events, document summaries)
+--   - aiq_checkpoints  (LangGraph conversation state)
+--
+-- Tables in aiq_jobs:
+--   - job_info      — NAT JobStore metadata (status, timestamps, expiry)
+--   - job_events    — SSE streaming events and job event persistence
+--   - summaries     — Document summaries (collection + filename keyed)
+--
+-- Tables in aiq_checkpoints:
+--   - checkpoints           — LangGraph conversation checkpoints
+--   - checkpoint_blobs      — LangGraph binary state data
+--   - checkpoint_writes     — LangGraph pending writes
+--   - checkpoint_migrations — LangGraph schema version tracking
+--
+-- =============================================================================
+
+-- Create checkpoints database if it doesn't exist
+SELECT 'CREATE DATABASE aiq_checkpoints' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'aiq_checkpoints')\gexec
+
+-- Grant permissions
+GRANT ALL PRIVILEGES ON DATABASE aiq_jobs TO aiq;
+GRANT ALL PRIVILEGES ON DATABASE aiq_checkpoints TO aiq;
+
+-- =============================================================================
+-- Create tables in aiq_jobs database
+-- =============================================================================
+\connect aiq_jobs
+
+-- Job metadata table (NAT JobStore)
+CREATE TABLE IF NOT EXISTS job_info (
+    job_id VARCHAR PRIMARY KEY,
+    status VARCHAR NOT NULL,
+    config_file VARCHAR,
+    error VARCHAR,
+    output_path VARCHAR,
+    created_at TIMESTAMP WITH TIME ZONE,
+    updated_at TIMESTAMP WITH TIME ZONE,
+    expiry_seconds INTEGER,
+    output VARCHAR,
+    is_expired BOOLEAN DEFAULT FALSE
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_info_status ON job_info(status);
+CREATE INDEX IF NOT EXISTS idx_job_info_created_at ON job_info(created_at);
+
+-- Job events table (SSE streaming, event persistence)
+CREATE TABLE IF NOT EXISTS job_events (
+    id SERIAL PRIMARY KEY,
+    job_id VARCHAR(64) NOT NULL,
+    event_type VARCHAR(64) NOT NULL,
+    event_data TEXT,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_events_job_id ON job_events(job_id);
+CREATE INDEX IF NOT EXISTS idx_job_events_job_id_id ON job_events(job_id, id);
+
+-- Document summaries table
+CREATE TABLE IF NOT EXISTS summaries (
+    collection VARCHAR(256) NOT NULL,
+    filename VARCHAR(512) NOT NULL,
+    summary TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (collection, filename)
+);
+
+CREATE INDEX IF NOT EXISTS idx_summaries_collection ON summaries(collection);
+
+-- =============================================================================
+-- Create LangGraph checkpoint tables in aiq_checkpoints database
+-- These must exist before backends connect. Previously left to the app,
+-- but if postgres restarts without a backend restart, the tables are lost
+-- and running backends crash with "relation checkpoints does not exist".
+-- =============================================================================
+\connect aiq_checkpoints
+
+CREATE TABLE IF NOT EXISTS checkpoint_migrations (
+    v INTEGER PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS checkpoints (
+    thread_id TEXT NOT NULL,
+    checkpoint_ns TEXT NOT NULL DEFAULT '',
+    checkpoint_id TEXT NOT NULL,
+    parent_checkpoint_id TEXT,
+    type TEXT,
+    checkpoint JSONB NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}',
+    PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id)
+);
+
+CREATE TABLE IF NOT EXISTS checkpoint_blobs (
+    thread_id TEXT NOT NULL,
+    checkpoint_ns TEXT NOT NULL DEFAULT '',
+    channel TEXT NOT NULL,
+    version TEXT NOT NULL,
+    type TEXT NOT NULL,
+    blob BYTEA,
+    PRIMARY KEY (thread_id, checkpoint_ns, channel, version)
+);
+
+CREATE TABLE IF NOT EXISTS checkpoint_writes (
+    thread_id TEXT NOT NULL,
+    checkpoint_ns TEXT NOT NULL DEFAULT '',
+    checkpoint_id TEXT NOT NULL,
+    task_id TEXT NOT NULL,
+    idx INTEGER NOT NULL,
+    channel TEXT NOT NULL,
+    type TEXT,
+    blob BYTEA NOT NULL,
+    PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id, task_id, idx)
+);

--- a/deploy/helm/helm-charts-k8s/aiq/templates/postgres-init-configmap.yaml
+++ b/deploy/helm/helm-charts-k8s/aiq/templates/postgres-init-configmap.yaml
@@ -1,0 +1,14 @@
+{{- $postgres := index .Values.apps "postgres" }}
+{{- if and $postgres $postgres.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-postgres-init
+  namespace: {{ include "aiq.namespace" . }}
+  labels:
+    app: {{ .Release.Name }}-postgres
+    component: postgres
+data:
+  init.sql: |
+{{ .Files.Get "files/init-db.sql" | indent 4 }}
+{{- end }}


### PR DESCRIPTION
Previously the checkpoint tables (checkpoints, checkpoint_blobs, checkpoint_writes, checkpoint_migrations) were created by the app at runtime via AsyncPostgresSaver. If postgres restarts without a backend restart, the tables are lost and running backends crash with "relation checkpoints does not exist".

Now created idempotently in init-db.sql alongside the job store tables. The backend init container runs this on every pod start, ensuring tables exist before any backend connects.