### PR TITLE
refactor(prompts): restructure all prompts for KV cache prefix reuse

### DIFF
--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -280,6 +280,7 @@ class ChatResearcherAgent:
                 data_sources=state.data_sources,
                 clarifier_result=state.clarifier_result,
                 available_documents=state.available_documents,
+                user_info=state.user_info,
             )
             try:
                 result = await self.deep_research_fn(deep_state)

--- a/src/aiq_agent/agents/chat_researcher/prompts/intent_classification.j2
+++ b/src/aiq_agent/agents/chat_researcher/prompts/intent_classification.j2
@@ -1,18 +1,5 @@
 You are the orchestration layer of an AI Research Assistant built by NVIDIA. Your goal is to analyze the user's query, determine its intent, and provide either a direct response (Meta) or a research plan (Shallow/Deep).
 
-### CONTEXT
-Current Date and Time: {{ current_datetime }}
-{% if user_info and user_info.name %}
-User: **{{ user_info.name }}** ({{ user_info.email or "email not provided" }})
-{% endif %}
-
-Available Tools:
-{% if tools is defined and tools|length > 0 %}
-{% for tool in tools %}- {{ tool.name }}: {{ tool.description }}{% endfor %}
-{% else %}
-No research tools available.
-{% endif %}
-
 ### STEP 1: INTENT CLASSIFICATION
 Classify the query as "meta" or "research".
 - **meta**: System identity, abilities, greetings, time/date, tool questions, out-of-scope requests (code/files), emotional check-ins, jokes, casual chat, small talk, or any request that does not need external sources (e.g. "tell me a joke", "how are you").
@@ -42,6 +29,21 @@ You must respond ONLY with a JSON object using this schema:
   "research_depth": "shallow" | "deep" | null,
   "depth_reasoning": "One sentence explanation for depth if research, otherwise null"
 }
+
+{#- === KV CACHE BOUNDARY — dynamic content below === -#}
+
+### CONTEXT
+Current Date and Time: {{ current_datetime }}
+{% if user_info and user_info.name %}
+User: **{{ user_info.name }}** ({{ user_info.email or "email not provided" }})
+{% endif %}
+
+Available Tools:
+{% if tools is defined and tools|length > 0 %}
+{% for tool in tools %}- {{ tool.name }}: {{ tool.description }}{% endfor %}
+{% else %}
+No research tools available.
+{% endif %}
 
 ### USER QUERY
 "{{ query }}"

--- a/src/aiq_agent/agents/clarifier/prompts/plan_generation.j2
+++ b/src/aiq_agent/agents/clarifier/prompts/plan_generation.j2
@@ -11,18 +11,6 @@ IMPORTANT RULES:
 - Do NOT include numbering in section names (e.g., use "Introduction" not "1. Introduction" or "Section 1: Introduction")
 - Keep section names concise (3-6 words each)
 
-{% if clarifier_context %}
-CLARIFICATION CONTEXT:
-{{ clarifier_context }}
-{% endif %}
-
-{% if feedback_history %}
-PREVIOUS FEEDBACK (incorporate this into your revised plan):
-{% for feedback in feedback_history %}
-- {{ feedback }}
-{% endfor %}
-{% endif %}
-
 OUTPUT FORMAT:
 ```json
 {
@@ -38,3 +26,17 @@ OUTPUT FORMAT:
 ```
 
 Create a focused plan that addresses the user's research needs.
+
+{#- === KV CACHE BOUNDARY — dynamic content below === -#}
+
+{% if clarifier_context %}
+CLARIFICATION CONTEXT:
+{{ clarifier_context }}
+{% endif %}
+
+{% if feedback_history %}
+PREVIOUS FEEDBACK (incorporate this into your revised plan):
+{% for feedback in feedback_history %}
+- {{ feedback }}
+{% endfor %}
+{% endif %}

--- a/src/aiq_agent/agents/clarifier/prompts/research_clarification.j2
+++ b/src/aiq_agent/agents/clarifier/prompts/research_clarification.j2
@@ -1,11 +1,5 @@
 You are a **research clarification assistant** that operates as part of a deep research agent system.
 
-{% if available_documents and available_documents | length > 0 %}## Uploaded documents (IMPORTANT)
-The user has uploaded the following file(s); they are ingested and will be included in research:{% for doc in available_documents %}
-- **{{ doc.file_name }}**: {{ doc.summary or "No summary" }}{% endfor %}
-
-If the user's request refers to "the paper", "my file", "the document", or a filename (e.g. {{ available_documents[0].file_name }}), treat it as referring to these uploaded files. Do NOT ask which paper or which file—proceed with the understanding that the uploaded file(s) are the subject. Only ask for clarification on other missing dimensions (e.g. comparison criteria), not the document identity.{% endif %}
-
 You do NOT:
 - Perform research
 - Answer research questions
@@ -56,14 +50,14 @@ A request is clear enough to proceed WITHOUT clarification if ANY of the followi
 - Critical context is missing that would change the research approach entirely
 
 Examples that do NOT need clarification:
-- "How does machine learning work?" → Clear topic, seeking explanation
-- "What caused the 2008 financial crisis?" → Clear topic, historical/causal question
-- "What are the benefits of meditation?" → Clear topic, informational
+- "How does machine learning work?" -> Clear topic, seeking explanation
+- "What caused the 2008 financial crisis?" -> Clear topic, historical/causal question
+- "What are the benefits of meditation?" -> Clear topic, informational
 
 Examples that MAY need clarification:
-- "Research AI" → Too vague, what aspect?
-- "Compare databases" → Which databases? What criteria?
-- "Help me with my project" → What project? What kind of help?
+- "Research AI" -> Too vague, what aspect?
+- "Compare databases" -> Which databases? What criteria?
+- "Help me with my project" -> What project? What kind of help?
 
 ---
 
@@ -75,11 +69,6 @@ Examples that MAY need clarification:
   - Re-evaluate the request using the new information
   - Ask a follow-up ONLY if it addresses a DIFFERENT unresolved dimension
 - Never ask about the same dimension twice
-
-{% if clarifier_result is defined and clarifier_result %}
-## Clarification Context So Far
-{{ clarifier_result }}
-{% endif %}
 
 ---
 
@@ -151,3 +140,18 @@ User: "What caused World War I?"
 - Never use technical/business templates for non-technical topics
 - Never answer the research question
 - Your goal is minimal friction - only clarify when truly necessary
+
+{#- === KV CACHE BOUNDARY — dynamic content below === -#}
+
+{% if available_documents and available_documents | length > 0 %}
+## Uploaded documents (IMPORTANT)
+The user has uploaded the following file(s); they are ingested and will be included in research:{% for doc in available_documents %}
+- **{{ doc.file_name }}**: {{ doc.summary or "No summary" }}{% endfor %}
+
+If the user's request refers to "the paper", "my file", "the document", or a filename (e.g. {{ available_documents[0].file_name }}), treat it as referring to these uploaded files. Do NOT ask which paper or which file — proceed with the understanding that the uploaded file(s) are the subject. Only ask for clarification on other missing dimensions (e.g. comparison criteria), not the document identity.
+{% endif %}
+
+{% if clarifier_result is defined and clarifier_result %}
+## Clarification Context So Far
+{{ clarifier_result }}
+{% endif %}

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -210,6 +210,8 @@ class DeepResearcherAgent:
                 ),
                 "system_prompt": render_prompt_template(
                     self._prompts["planner"],
+                    current_datetime=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                    user_info=state.user_info,
                     tools=self.tools_info,
                     available_documents=available_docs,
                 ),
@@ -226,6 +228,7 @@ class DeepResearcherAgent:
                 "system_prompt": render_prompt_template(
                     self._prompts["researcher"],
                     current_datetime=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                    user_info=state.user_info,
                     tools=self.tools_info,
                     available_documents=available_docs,
                 ),
@@ -250,6 +253,7 @@ class DeepResearcherAgent:
         orchestrator_instructions = render_prompt_template(
             self._prompts["orchestrator"],
             current_datetime=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            user_info=state.user_info,
             clarifier_result=state.clarifier_result,
             available_documents=available_docs,
             tools=self.tools_info,

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -169,7 +169,7 @@ class DeepResearcherAgent:
             ToolNameSanitizationMiddleware(valid_tool_names=[t.name for t in self.all_tools]),
             ToolRetryMiddleware(max_retries=3, backoff_factor=2.0, initial_delay=1.0),
             self.source_registry_middleware,
-            ToolResultPruningMiddleware(keep_last_n=3, max_chars=500),
+            ToolResultPruningMiddleware(keep_last_n=10, max_chars=2000),
             ModelRetryMiddleware(max_retries=10, backoff_factor=2.0, initial_delay=1.0),
         ]
 

--- a/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
@@ -10,8 +10,18 @@ Step 1. **Task Decomposition and Progress Tracking**: Use `write_todos` to track
 Step 2. **Planning**: Delegate research planning to the planner-agent using the task() tool to generate task analysis, TOC, constraints, and queries.
 Step 3. **Research**: Read the generated plan using read_file /shared/plan.json, then delegate up to 6 researcher-agent calls for the queries from the plan using the task() tool. ALWAYS use the researcher-agent for research; never conduct search yourself and never re-delegate to the planner-agent.
 Step 4. **Verify after each researcher**: Use `think` tool to check and note down if findings satisfy constraints.
-Step 5. **Synthesize**: Use ls /shared/, read_file and grep to discover all research notes and sub-agent findings. Then call `get_verified_sources` to get the authoritative list of all URLs captured from search tools — use ONLY these URLs in your report. Use the `think` tool to record your synthesis observations.
-Step 6. **Write report**: Write a comprehensive, in-depth, long-form report following the TOC and satisfying constraints.
+Step 5. **Synthesize** (CRITICAL — follow this exact sequence):
+   a. Call `ls /shared/` to discover all research note files.
+   b. Call `read_file` on EACH file. Read ALL files before proceeding — do not start writing until you have read every researcher output.
+   c. After reading all files, call `think` to create a consolidated outline:
+      - List every concrete fact, name, date, number, project, ticket, and URL found across ALL files
+      - Group findings by topic/section
+      - Note which findings appear in multiple sources (high confidence)
+      - Note genuine gaps (topics with zero findings)
+   d. Call `get_verified_sources` to get the authoritative URL list — use ONLY these URLs in your report.
+   e. Write a consolidated findings summary using `write_file /shared/consolidated_findings.md`. Include every key fact, figure, name, date, URL, and quote from all researcher files. This file serves as your reference during report writing — if older tool results are pruned from context, you can re-read this file.
+   **WARNING**: If you skip reading any /shared/ file, your report will be incomplete. If you skip writing consolidated_findings.md, you risk losing earlier findings during report writing.
+Step 6. **Write report**: Write a comprehensive, in-depth, long-form report following the TOC and satisfying constraints. If you need to recall researcher findings during writing, re-read `/shared/consolidated_findings.md`.
 Step 7. **Final verification**: Use `think` tool to review constraints, note any gaps, proceed with best-effort report. Make sure that:
    - All TOC sections from planner are covered
    - Every claim has a citation

--- a/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
@@ -1,29 +1,9 @@
 You are a Deep Research agent that coordinates the production of a publication-ready, well-cited research report on the provided topic.
 
-Current date and time: {{ current_datetime }}
-
-{% if clarifier_result %}
-## Clarification Context
-The user provided the following clarifications about their research needs:
-{{ clarifier_result }}
-{% endif -%}{%- set ns = namespace(has_web_search=false, has_knowledge_search=false, has_paper_search=false) -%}
-{% for tool in tools -%}
-{% if ('web' in tool.name.lower() or 'tavily' in tool.name.lower()) and ('knowledge' not in tool.name.lower()) %}{% set ns.has_web_search = true %}{% endif -%}
-{% if 'knowledge' in tool.name.lower() %}{% set ns.has_knowledge_search = true %}{% endif -%}
-{% if 'paper' in tool.name.lower() %}{% set ns.has_paper_search = true %}{% endif -%}
-{% endfor -%}{%- if ns.has_knowledge_search or available_documents %}
-## User Uploaded Documents
-The user has uploaded the following documents to the knowledge base:
-{% for doc in (available_documents or []) %}
-- **{{ doc.file_name }}**: {{ doc.summary or "No summary available" }}
-{% endfor %}
-When delegating to researcher-agent, prioritize queries about these internal documents. Include document context in your task delegations when relevant.
-{% endif -%}
-
 ## Available Subagents
 
 1. **planner-agent**: Content-driven research planning - generates task analysis, TOC (Table of Contents), constraints (acceptance criteria), and queries
-2. **researcher-agent**: Gathers and synthesizes information using advanced_web_search_tool, paper_search_tool and/or knowledge_search,
+2. **researcher-agent**: Gathers and synthesizes information using available search tools
 
 ## Workflow
 Step 1. **Task Decomposition and Progress Tracking**: Use `write_todos` to track research tasks, updating as planning completes and work progresses. Follow instructions in `## Progress Tracking` section.
@@ -62,7 +42,7 @@ When calling task() for planner-agent, use this format:
 Create a research plan for the following user request:
 <paste user's complete request here verbatim>
 
-The planner will use search tools (knowledge_search, advanced_web_search_tool, paper_search_tool) to discover internal vs external and what information exists, then return the final plan. Expect multiple tool calls from the planner before it returns the plan.
+The planner will use search tools to discover internal vs external and what information exists, then return the final plan. Expect multiple tool calls from the planner before it returns the plan.
 ```
 
 ## Research Loop
@@ -77,7 +57,7 @@ Use `think` tool to verify constraints after each researcher call and before fin
 
 ## Critical Rules
 - You MUST ALWAYS produce a complete report. NEVER ask the user for permission, clarification, or additional input.
-- If advanced_web_search_tool or other search tools fail or return insufficient data:
+- If search tools fail or return insufficient data:
   1. Use available information to provide best-effort analysis
   2. Clearly acknowledge limitations in the report (e.g., "Based on available sources...")
   3. Make reasonable inferences where appropriate
@@ -164,3 +144,27 @@ Before outputting the final report to the user:
 4. Verify sources section is present (citations are auto-verified by the system)
 
 Write final report using write_file to /report.md. Return ONLY the final report without anything else now.
+
+{#- === KV CACHE BOUNDARY — dynamic content below === -#}
+
+## Context
+Current date and time: {{ current_datetime }}
+
+{% if clarifier_result %}
+## Clarification Context
+The user provided the following clarifications about their research needs:
+{{ clarifier_result }}
+{% endif %}
+
+{% if available_documents %}
+## User Uploaded Documents
+The user has uploaded the following documents to the knowledge base:
+{% for doc in (available_documents or []) %}
+- **{{ doc.file_name }}**: {{ doc.summary or "No summary available" }}
+{% endfor %}
+When delegating to researcher-agent, prioritize queries about these internal documents. Include document context in your task delegations when relevant.
+{% endif %}
+
+## Available Tools
+{% for tool in tools %}- **{{ tool.name }}**: {{ tool.description }}
+{% endfor %}

--- a/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
@@ -149,6 +149,10 @@ Write final report using write_file to /report.md. Return ONLY the final report 
 
 ## Context
 Current date and time: {{ current_datetime }}
+{% if user_info and user_info.name %}
+Authenticated user: **{{ user_info.name }}** ({{ user_info.email or "email not provided" }})
+When the user says "me", "myself", or "my work", they mean this person.
+{% endif %}
 
 {% if clarifier_result %}
 ## Clarification Context

--- a/src/aiq_agent/agents/deep_researcher/prompts/planner.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/planner.j2
@@ -127,6 +127,13 @@ Remember: Your goal is to produce an evidence-grounded plan with clear acceptanc
 
 {#- === KV CACHE BOUNDARY — dynamic content below === -#}
 
+## Context
+Current date and time: {{ current_datetime }}
+{% if user_info and user_info.name %}
+Authenticated user: **{{ user_info.name }}** ({{ user_info.email or "email not provided" }})
+When the query references "me", "myself", or "my work", search for this person.
+{% endif %}
+
 ## Available Search Tools
 You have access to the following tools. You can ONLY use the tools provided. Do not assume access to tools not listed.
 

--- a/src/aiq_agent/agents/deep_researcher/prompts/planner.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/planner.j2
@@ -2,19 +2,6 @@ You are the Research Planner Subagent. For the given task, generate a comprehens
 Research plan comprises a task analysis, report title, Table of Contents (TOC), constraints, and queries.
 Return the final plan to the orchestrator in your final message.
 
-{% set ns = namespace(has_web_search=false, has_knowledge_search=false, has_paper_search=false) -%}
-{% for tool in tools -%}{%- if ('web' in tool.name.lower() or 'tavily' in tool.name.lower()) and ('knowledge' not in tool.name.lower()) %}{% set ns.has_web_search = true %}{% endif -%}
-{%- if 'knowledge' in tool.name.lower() or 'document' in tool.name.lower() or 'internal' in tool.name.lower() %}{% set ns.has_knowledge_search = true %}{% endif -%}{%- if 'paper' in tool.name.lower() %}{% set ns.has_paper_search = true %}{% endif %}{% endfor -%}
-{%- if ns.has_web_search or ns.has_paper_search or ns.has_knowledge_search %}## Search Tools and Prioritization
-You have access to the following tools. You can ONLY use the tools provided. Do not assume access to tools not listed
-
-{%- if ns.has_knowledge_search %}
-- **knowledge_search** (Uploaded files): Highest priority. Use first for information from the user's documents. Queries about the uploaded file(s) must use **knowledge_search**.{% if (available_documents and available_documents | length > 0) %}
-The user has uploaded the following documents that may be relevant to this research:{% for doc in available_documents %}
-- **{{ doc.file_name }}**: {{ doc.summary or "No summary available" }}{% endfor %}{% endif %}{% endif -%}
-{%- if ns.has_paper_search %}- **paper_search_tool**: For academic, scholarly, or research-oriented topics. **Do not use** for topics already identified as internal.
-{% endif -%}{%- if ns.has_web_search %}- **advanced_web_search_tool**: For general news, tutorials, implementation details, and comparisons. **Do not use** for topics already identified as internal—use knowledge_search only for those.{% endif %}{% endif %}
-
 ## Other Tools
 - `think`: record your thoughts for downstream steps
 - `ls`: to see if /shared/plan.json exists
@@ -31,9 +18,9 @@ Before generating the research plan, deeply analyze the user's request:
 5. **Language**: What language is the user's request in?
 
 ## Workflow
-- **Task Decomposition**: Use a todo list with write_todos to break down the research into focused tasks and update this todo list based on progress.{%- if ns.has_knowledge_search %}
-- **Internal vs external (you must use tools)**: Call knowledge_search first to see if the topic or named entities are covered in the uploaded documents. If they are, treat them as internal and do not add advanced_web_search_tool/paper_search_tool queries for those. If not found internally, treat as external and use advanced_web_search_tool/paper_search_tool.{% endif -%}{%- if ns.has_web_search or ns.has_paper_search %}
-- **Discover what exists (you must use tools)**: Call advanced_web_search_tool and paper_search_tool to discover what information exists for the task. Use the results to shape your TOC, constraints, and query list—do not guess.{% endif %}
+- **Task Decomposition**: Use a todo list with write_todos to break down the research into focused tasks and update this todo list based on progress.
+- **Internal vs external (you must use tools)**: If a knowledge_search or document tool is available, call it first to see if the topic or named entities are covered in the uploaded documents. If they are, treat them as internal and do not add web/paper queries for those. If not found internally, treat as external and use web/paper search.
+- **Discover what exists (you must use tools)**: Call available search tools to discover what information exists for the task. Use the results to shape your TOC, constraints, and query list — do not guess.
 - **Think**: After each search, use `think` to reason through:
    - What did I learn?
    - Internal or external for each sub-topic?
@@ -53,18 +40,18 @@ The final TOC must be hierarchical with 2 levels (sections and subsections). Gui
 ## Constraints
 Generate that the final report must satisfy. Constraints are acceptance criteria derived from:
 - Deep understanding of the user's request
-- advanced_web_search_tool / paper_search_tool / knowledge_search findings
+- Search tool findings
 - Your reasoning about what is relevant vs tangential, what adds value, and what degrades quality
 
 ### Constraint Principles
 1. **Maximize Specificity**: Include all user-stated details. If user mentions specific entities, dates, or attributes, create constraints for them.
 2. **Implicit Requirements**: For dimensions the user did not specify, but are important for the report, create constraints for them.
-3. **Ground Constraints in Evidence**: Deduce constraints from your search tool findings (advanced_web_search_tool, paper_search_tool, knowledge_search). If searches reveal important dimensions or considerations, create constraints for them.
+3. **Ground Constraints in Evidence**: Deduce constraints from your search tool findings. If searches reveal important dimensions or considerations, create constraints for them.
 4. **Structured Elements**: If comparisons, structured data, or technical details would enhance the report, add constraints for appropriate elements (tables, equations, code blocks).
 5. **Language**: If user input is non-English, add a constraint for response language.
 
 ## Queries
-After you have finished your own search tool calls and refined the plan, list the final queries in the JSON below. A **researcher agent** will later execute these queries (advanced_web_search_tool, paper_search_tool, knowledge_search) and synthesize findings. Base this list on what you discovered during your planning searches—do not invent queries you did not ground in your tool use.
+After you have finished your own search tool calls and refined the plan, list the final queries in the JSON below. A **researcher agent** will later execute these queries and synthesize findings. Base this list on what you discovered during your planning searches — do not invent queries you did not ground in your tool use.
 The researcher has no additional context, so each query must be **self-contained and specific**.
 Generate as many queries as you need to enable comprehensive coverage of all TOC sections.
 
@@ -72,8 +59,7 @@ Query Guidelines:
 - Be specific and searchable - include key terms needed to find relevant sources
 - Each query should focus on one clear information need and map to specific TOC sections
 - No duplicate or overlapping queries - each should cover distinct ground
-
-- For topics you identified as internal: in the query rationale, state "Internal: use knowledge_search only" so the researcher does not use advanced_web_search_tool or paper_search_tool for that query
+- For topics you identified as internal: in the query rationale, state "Internal: use knowledge_search only" so the researcher does not use web/paper search for that query
 
 ## Finalize
 - When you have comprehensive coverage, output the final plan JSON directly.
@@ -82,7 +68,7 @@ Query Guidelines:
 
 ## Verify
 Before returning the final research plan, verify:
-- Have you made sufficient search tool calls yourself (e.g. knowledge_search, advanced_web_search_tool, paper_search_tool)? If not, continue searching—do not output the plan yet.
+- Have you made sufficient search tool calls yourself? If not, continue searching — do not output the plan yet.
 - The TOC directly and completely addresses the user's question
 - Constraints are specific, actionable, and grounded in your research findings
 - Every section has supporting queries
@@ -116,14 +102,14 @@ Output a JSON with this structure:
     {
       "category": "content|source|structure|depth|format|exclusion",
       "constraint": "Specific, actionable constraint text",
-      "rationale": "Why this constraint exists (e.g., 'User explicitly requested', 'Discovered from advanced_web_search_tool/paper_search_tool/knowledge_search')",
+      "rationale": "Why this constraint exists",
       "verification": "How to check if satisfied"
     }
   ],
   "queries": [
     {
       "query": "[Specific, self-contained search query]",
-      "tool": "[one of advanced_web_search_tool/paper_search_tool/knowledge_search]",
+      "tool": "[tool name from the Available Search Tools section below]",
       "target_sections": ["[Section Title]"],
       "rationale": "[Why this query is needed]"
     }
@@ -138,3 +124,18 @@ Remember: Your goal is to produce an evidence-grounded plan with clear acceptanc
 - You MUST be confident about your planning outputs grounded with discovered information through search tools.
 - You MUST write the plan to using write_file tool to /shared/plan.json
 - You MUST return the final plan to the orchestrator in your final message.
+
+{#- === KV CACHE BOUNDARY — dynamic content below === -#}
+
+## Available Search Tools
+You have access to the following tools. You can ONLY use the tools provided. Do not assume access to tools not listed.
+
+{% for tool in tools %}- **{{ tool.name }}**: {{ tool.description }}
+{% endfor %}
+
+{% if available_documents and available_documents | length > 0 %}
+## User Uploaded Documents
+The following documents are available via knowledge_search:
+{% for doc in available_documents %}- **{{ doc.file_name }}**: {{ doc.summary or "No summary available" }}
+{% endfor %}
+{% endif %}

--- a/src/aiq_agent/agents/deep_researcher/prompts/researcher.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/researcher.j2
@@ -1,28 +1,6 @@
 Gather and synthesize comprehensive information on the provided query carefully addressing all the aspects/constraints of the request.
 Aim to provide substantial depth and breadth, while prioritizing factual reliability.
 
-Current date : {{ current_datetime }}
-{% set ns = namespace(has_web_search=false, has_internal_search=false, has_paper_search=false) -%}
-{% for tool in tools -%}
-{% if ('web' in tool.name.lower() or 'tavily' in tool.name.lower()) and ('knowledge' not in tool.name.lower()) %}{% set ns.has_web_search = true %}{% endif -%}
-{% if 'knowledge' in tool.name.lower() or 'document' in tool.name.lower() or 'internal' in tool.name.lower() %}{% set ns.has_internal_search = true %}{% endif -%}
-{% if 'paper' in tool.name.lower() %}{% set ns.has_paper_search = true %}{% endif %}
-{% endfor -%}
-{%- if ns.has_web_search or ns.has_paper_search or ns.has_internal_search -%}## Tool Availability and Prioritization
-**You can ONLY use the tools provided below. Do not assume you have access to any other tools.**{%- if (available_documents and available_documents | length > 0) or ns.has_internal_search %}
-- **knowledge_search**: Highest priority. Use for user documents{% if available_documents and available_documents | length > 0 %} (e.g., {{ available_documents | map(attribute='file_name') | join(', ') }}){% endif %}. Use the **knowledge_search** tool for these.{% endif %}{%- if ns.has_paper_search %}
-- **paper_search_tool** (Academic Papers): Use first for queries requiring:
-  - Scientific claims, research findings, or empirical evidence
-  - Technical concepts, algorithms, or methodologies
-  - Medical, health, or clinical information
-  - Historical data with scholarly analysis
-  - Peer-reviewed and citation-backed information{% endif -%}{%- if ns.has_web_search %}
-- **advanced_web_search_tool** (Web Sources): Use for:
-  - Recent news, events, or developments not yet in academic literature
-  - Practical how-to guides, tutorials, or implementation details
-  - Product information, company announcements, or industry updates
-  - Current statistics or real-time data{% endif %}
-{% endif %}
 ## Research Protocol
 1. **Read the question carefully** - What specific information does the user need?
 2. **Start with broader searches** - Use broad, comprehensive queries first
@@ -86,3 +64,20 @@ Do NOT add URLs from memory — only use URLs that appeared in tool call respons
 
 Write this output using write_file to /shared/[query_topic_x].txt and return.
 Paths are VIRTUAL.
+
+{#- === KV CACHE BOUNDARY — dynamic content below === -#}
+
+## Context
+Current date: {{ current_datetime }}
+
+## Tool Availability and Prioritization
+**You can ONLY use the tools provided below. Do not assume you have access to any other tools.**
+{% for tool in tools %}- **{{ tool.name }}**: {{ tool.description }}
+{% endfor %}
+
+{% if available_documents and available_documents | length > 0 %}
+## User Uploaded Documents
+The following documents are available via knowledge_search:
+{% for doc in available_documents %}- **{{ doc.file_name }}**: {{ doc.summary or "No summary available" }}
+{% endfor %}
+{% endif %}

--- a/src/aiq_agent/agents/deep_researcher/prompts/researcher.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/researcher.j2
@@ -69,6 +69,10 @@ Paths are VIRTUAL.
 
 ## Context
 Current date: {{ current_datetime }}
+{% if user_info and user_info.name %}
+Authenticated user: **{{ user_info.name }}** ({{ user_info.email or "email not provided" }})
+When the query references "me", "myself", or "my work", search for this person.
+{% endif %}
 
 ## Tool Availability and Prioritization
 **You can ONLY use the tools provided below. Do not assume you have access to any other tools.**

--- a/src/aiq_agent/agents/shallow_researcher/prompts/researcher.j2
+++ b/src/aiq_agent/agents/shallow_researcher/prompts/researcher.j2
@@ -5,7 +5,7 @@ Prioritize sources based on the query intent:
 
 1. **User Documents (Highest Priority)**: If a knowledge_search or document tool is available, use it first for "my files," "the uploaded doc," or personal/provided data.
 2. **Academic Research**: If a paper search tool is available, use for scientific or technical validation.
-3. **Web Search**: Use for general facts, news, or when other sources are silent.
+3. **Web Search**: If a web search tool is available, use it for general facts, news, or when other sources are silent.
 
 ## Query Rewriting (before calling search tools)
 Before calling any search tool, rewrite the user's question into a **search-friendly query** that includes **all context the user implied**. Add whatever is needed for the index to return relevant results — do not pass the raw user message if it relies on implicit context.
@@ -16,6 +16,7 @@ Before calling any search tool, rewrite the user's question into a **search-frie
 Pass the **rewritten query** to the search tool. This greatly improves result relevance.
 
 ## Research Rules
+- **Only use tools listed** in the Available Tools section below. Do not assume access to tools not listed. If no web search tool is listed, you have NO web access.
 - **Loop Prevention**: Max 2 calls per tool. If results are empty, change your search string once or move to synthesis.
 
 ## Citation Rules

--- a/src/aiq_agent/agents/shallow_researcher/prompts/researcher.j2
+++ b/src/aiq_agent/agents/shallow_researcher/prompts/researcher.j2
@@ -1,79 +1,23 @@
-{#- 1. CONTEXT & ROLE -#}
-Current date and time: {{ current_datetime }}
-{% if user_info %}
-User Context:
-- Name: {{ user_info.name or "Unknown" }}
-- Email: {{ user_info.email or "Unknown" }}
-{% endif %}
+You are a Shallow Research Agent. Your role is to provide rapid, citation-backed answers using available tools.
 
-You are {{ (user_info.name if user_info else None) or "the user" }}'s Shallow Research Agent. Your role is to provide rapid, citation-backed answers using available tools.
-
-{#- 2. CAPABILITY DETECTION -#}
-{% set ns = namespace(has_internal=false, has_paper=false, has_web=false, internal_tool='') %}
-{% for tool in tools %}
-  {% set t_name = tool.name.lower() %}
-  {% if 'knowledge' in t_name or 'document' in t_name or 'internal' in t_name %}
-    {% set ns.has_internal = true %}{% set ns.internal_tool = tool.name %}
-  {% elif 'paper' in t_name or 'academic' in t_name or 'arxiv' in t_name %}
-    {% set ns.has_paper = true %}
-  {% elif 'web' in t_name or 'tavily' in t_name %}
-    {% set ns.has_web = true %}
-  {% endif %}
-{% endfor %}
-
-## Available Tools
-{% if tools %}
-{% for tool in tools %}- **{{ tool.name }}**: {{ tool.description }}
-{% endfor %}
-{% else %}
-**No research tools available.**
-{% endif %}
-
-{#- 3. REFINED SOURCE HIERARCHY -#}
 ## CRITICAL: Source Hierarchy
 Prioritize sources based on the query intent:
 
-{% if ns.has_internal %}
-1. **User Documents (Highest Priority)**: Use `{{ ns.internal_tool }}` for "my files," "the uploaded doc," or personal/provided data.
-{% endif %}
-{% if ns.has_paper %}
-2. **Academic Research**: Use for scientific or technical validation.
-{% endif %}
-{% if ns.has_web %}
-3. **Web Search**: Use for general facts, news, or when internal sources are silent.
-{% endif %}
+1. **User Documents (Highest Priority)**: If a knowledge_search or document tool is available, use it first for "my files," "the uploaded doc," or personal/provided data.
+2. **Academic Research**: If a paper search tool is available, use for scientific or technical validation.
+3. **Web Search**: Use for general facts, news, or when other sources are silent.
 
+## Query Rewriting (before calling search tools)
+Before calling any search tool, rewrite the user's question into a **search-friendly query** that includes **all context the user implied**. Add whatever is needed for the index to return relevant results — do not pass the raw user message if it relies on implicit context.
 
-{% if available_documents %}
-
-## Uploaded Documents (IMPORTANT)
-
-The user has uploaded the following documents to the knowledge base:
-{% for doc in available_documents %}
-- **{{ doc.file_name }}**: {{ doc.summary or "No summary available" }}
-{% endfor %}
-
-**CRITICAL**: When the user asks to summarize, describe, explain, or query their uploaded documents, you MUST use the **knowledge_search** tool — NOT web search. Only **knowledge_search** has access to these uploaded documents.
-{% endif %}
-
-{#- 4. OPERATIONAL RULES -#}
-{% if ns.has_web %}
-## Query rewriting (before calling search tools)
-Before calling any search tool (web search, etc.), rewrite the user's question into a **search-friendly query** that includes **all context the user implied**. Add whatever is needed for the index to return relevant results—do not pass the raw user message if it relies on implicit context.
-
-- **Add missing context**: Time (current date/year from **Current date and time: {{ current_datetime }}** above), scope, topic, or other details the user assumed but the search index does not have.
+- **Add missing context**: Time (current date/year from the Context section below), scope, topic, or other details the user assumed but the search index does not have.
 - **Examples**: Add current year for "upcoming" or "next" questions; expand vague shorthand with the obvious topic or scope.
 
 Pass the **rewritten query** to the search tool. This greatly improves result relevance.
-{% endif %}
 
 ## Research Rules
 - **Loop Prevention**: Max 2 calls per tool. If results are empty, change your search string once or move to synthesis.
-{% if not ns.has_web %}
-- **Constraints**: **NO WEB ACCESS.**
-{% endif %}
 
-{#- 5. CITATION & FORMATTING -#}
 ## Citation Rules
 Cite sources inline with [1], [2], etc. Include a `**References:**` section at the end.
 - **Format**: `- [N] Title - URL` or `- [N] filename.pdf, p.X` for internal documents
@@ -85,3 +29,29 @@ Cite sources inline with [1], [2], etc. Include a `**References:**` section at t
 
 **References:**
 - [1] Q4_Review.pdf, p. 2 (Internal)"
+
+{#- === KV CACHE BOUNDARY — dynamic content below === -#}
+
+## Context
+Current date and time: {{ current_datetime }}
+{% if user_info %}
+User: {{ user_info.name or "Unknown" }} ({{ user_info.email or "Unknown" }})
+{% endif %}
+
+## Available Tools
+{% if tools %}
+{% for tool in tools %}- **{{ tool.name }}**: {{ tool.description }}
+{% endfor %}
+{% else %}
+**No research tools available.**
+{% endif %}
+
+{% if available_documents %}
+## Uploaded Documents (IMPORTANT)
+The user has uploaded the following documents to the knowledge base:
+{% for doc in available_documents %}
+- **{{ doc.file_name }}**: {{ doc.summary or "No summary available" }}
+{% endfor %}
+
+**CRITICAL**: When the user asks to summarize, describe, explain, or query their uploaded documents, you MUST use the **knowledge_search** tool — NOT web search. Only **knowledge_search** has access to these uploaded documents.
+{% endif %}


### PR DESCRIPTION
## Summary

- Reorder all 7 agent prompt templates so **static instructions come first** and **dynamic/per-request content comes last**, enabling LLM prefix KV cache reuse across requests
- Remove Jinja2 capability detection (`{% set ns = namespace(...) %}`) from all prompts — replaced with generic static prose that the model infers from the tool list
- Add `{#- KV CACHE BOUNDARY -#}` comment in each template marking the static/dynamic split point
- **Fix: propagate `user_info` (name, email) to deep research agents** — previously dropped at the handoff from ChatResearcherState to DeepResearchAgentState, causing "tell me about myself" queries to lose the user's identity
- **Fix: add `current_datetime` to planner** — was missing, so the planner couldn't scope time-sensitive queries
- **Fix: increase `ToolResultPruningMiddleware` retention** from `keep_last_n=3, max_chars=500` to `keep_last_n=10, max_chars=2000` — the old settings truncated earlier researcher findings to 500 chars during synthesis, destroying concrete details before report writing
- **Fix: rewrite orchestrator Step 5** with explicit read-ALL-files-first sequence and a persistent scratchpad (`/shared/consolidated_findings.md`) that survives context pruning

### Prompts restructured (7 files)

| Prompt | Agent | Cacheable prefix |
|--------|-------|-----------------|
| `intent_classification.j2` | Intent Classifier | ~75% |
| `researcher.j2` | Shallow Researcher | ~67% |
| `orchestrator.j2` | Deep Orchestrator | ~85% |
| `planner.j2` | Deep Planner | ~80% |
| `researcher.j2` | Deep Researcher | ~75% |
| `research_clarification.j2` | Clarifier | ~83% |
| `plan_generation.j2` | Clarifier (plan) | ~90% |

### KV cache layout

```
[TOP — STATIC]    Role definition, rules, constraints, examples, output format
                   (identical across all requests for a given deployment)

--- KV cache boundary ---

[BOTTOM — DYNAMIC] Current datetime, user info, tools list, available documents,
                    query, clarifier context, etc.
                    (changes per request or per session)
```

### Context management fix (ToolResultPruningMiddleware)

The orchestrator was losing researcher findings because `ToolResultPruningMiddleware(keep_last_n=3, max_chars=500)` truncated all but the last 3 tool results. With 6 researchers writing to `/shared/`, the orchestrator only saw the last 3 files intact during synthesis:

```
Researcher-1 writes /shared/topic_1.txt  ← truncated to 500 chars by synthesis time
Researcher-2 writes /shared/topic_2.txt  ← truncated to 500 chars
...
Researcher-6 writes /shared/topic_6.txt  ← intact (last 3)
Orchestrator reads files → older findings destroyed → vague report
```

Fix: `keep_last_n=10, max_chars=2000` + explicit read-all-files-first workflow + persistent `/shared/consolidated_findings.md` scratchpad.

### user_info propagation fix

`user_info` (authenticated user's name and email) was available in `ChatResearcherState` but dropped at the handoff to `DeepResearchAgentState`. "Tell me about myself" queries went to deep research without knowing who "myself" is. Now all three deep prompts (orchestrator, planner, researcher) receive and render user identity.

## Test plan

- [x] All 7 prompts render correctly with representative inputs (with and without optional context)
- [x] All 348 existing tests pass (`pytest tests/aiq_agent/agents/ -v`)
- [x] Pre-commit hooks pass (ruff, secrets detection, trailing whitespace)
- [x] user_info renders correctly in deep orchestrator, planner, and researcher (with and without)
- [x] ToolResultPruningMiddleware config change verified in middleware tests
- [ ] Manual verification: run "tell me about myself" query — report should include authenticated user's name, org, projects
- [ ] Manual verification: run external query — verify no regression in report quality
- [ ] Production validation: verify KV cache hit rate via OTEL tracing (if NIM endpoints report cache hits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)