### PR TITLE
fix: surface unavailable tool details in user-facing error messages

### DIFF
--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -205,11 +205,9 @@ class ChatResearcherAgent:
             except EmptySourceRegistryError as exc:
                 logger.warning("Shallow research produced no verifiable sources")
                 if exc.unavailable_tools:
-                    err_msg = (
-                        "Cannot start shallow research: No tools are available. "
-                        "At least one tool must be configured and available. "
-                        f"Unavailable tools: {', '.join(exc.unavailable_tools)}."
-                    )
+                    from aiq_agent.common.tool_validation import format_tool_unavailability_error
+
+                    err_msg = format_tool_unavailability_error("shallow research", exc.unavailable_tools)
                 else:
                     err_msg = (
                         "The search tools did not return any results for this question. "
@@ -294,11 +292,9 @@ class ChatResearcherAgent:
             except EmptySourceRegistryError as exc:
                 logger.warning("Deep research produced no verifiable sources")
                 if exc.unavailable_tools:
-                    err_msg = (
-                        "Cannot start deep research: No tools are available. "
-                        "At least one tool must be configured and available. "
-                        f"Unavailable tools: {', '.join(exc.unavailable_tools)}."
-                    )
+                    from aiq_agent.common.tool_validation import format_tool_unavailability_error
+
+                    err_msg = format_tool_unavailability_error("deep research", exc.unavailable_tools)
                 else:
                     err_msg = (
                         "The search tools did not return any results for this question. "

--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -202,13 +202,20 @@ class ChatResearcherAgent:
                     available_documents=state.available_documents,
                 )
                 result = await self.shallow_research_fn(shallow_state)
-            except EmptySourceRegistryError:
+            except EmptySourceRegistryError as exc:
                 logger.warning("Shallow research produced no verifiable sources")
-                err_msg = (
-                    "The search tools did not return any results for this question. "
-                    "This may be due to a temporary issue or the question may need to be rephrased. "
-                    "Please try again."
-                )
+                if exc.unavailable_tools:
+                    err_msg = (
+                        "Cannot start shallow research: No tools are available. "
+                        "At least one tool must be configured and available. "
+                        f"Unavailable tools: {', '.join(exc.unavailable_tools)}."
+                    )
+                else:
+                    err_msg = (
+                        "The search tools did not return any results for this question. "
+                        "This may be due to a temporary issue or the question may need to be rephrased. "
+                        "Please try again."
+                    )
                 # confidence="high" reflects certainty that an error occurred and that the error
                 # message is the correct response — not uncertainty about the answer quality.
                 # escalate_to_deep=False because retrying deep research will not resolve a
@@ -284,13 +291,20 @@ class ChatResearcherAgent:
             )
             try:
                 result = await self.deep_research_fn(deep_state)
-            except EmptySourceRegistryError:
+            except EmptySourceRegistryError as exc:
                 logger.warning("Deep research produced no verifiable sources")
-                err_msg = (
-                    "The search tools did not return any results for this question. "
-                    "This may be due to a temporary issue or the question may need to be rephrased. "
-                    "Please try again."
-                )
+                if exc.unavailable_tools:
+                    err_msg = (
+                        "Cannot start deep research: No tools are available. "
+                        "At least one tool must be configured and available. "
+                        f"Unavailable tools: {', '.join(exc.unavailable_tools)}."
+                    )
+                else:
+                    err_msg = (
+                        "The search tools did not return any results for this question. "
+                        "This may be due to a temporary issue or the question may need to be rephrased. "
+                        "Please try again."
+                    )
                 return {"messages": [AIMessage(content=err_msg)]}
             except Exception as e:
                 if _AuthError and isinstance(e, _AuthError):

--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -205,9 +205,13 @@ class ChatResearcherAgent:
             except EmptySourceRegistryError as exc:
                 logger.warning("Shallow research produced no verifiable sources")
                 if exc.unavailable_tools:
-                    from aiq_agent.common.tool_validation import format_tool_unavailability_error
+                    from aiq_agent.common.tool_validation import format_user_facing_tool_error
 
-                    err_msg = format_tool_unavailability_error("shallow research", exc.unavailable_tools)
+                    err_msg = format_user_facing_tool_error(
+                        "shallow research",
+                        exc.unavailable_tools,
+                        exc.available_count,
+                    )
                 else:
                     err_msg = (
                         "The search tools did not return any results for this question. "
@@ -292,9 +296,13 @@ class ChatResearcherAgent:
             except EmptySourceRegistryError as exc:
                 logger.warning("Deep research produced no verifiable sources")
                 if exc.unavailable_tools:
-                    from aiq_agent.common.tool_validation import format_tool_unavailability_error
+                    from aiq_agent.common.tool_validation import format_user_facing_tool_error
 
-                    err_msg = format_tool_unavailability_error("deep research", exc.unavailable_tools)
+                    err_msg = format_user_facing_tool_error(
+                        "deep research",
+                        exc.unavailable_tools,
+                        exc.available_count,
+                    )
                 else:
                     err_msg = (
                         "The search tools did not return any results for this question. "

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -497,14 +497,15 @@ class DeepResearcherAgent:
             else:
                 from aiq_agent.common.tool_validation import validate_tool_availability
 
-                is_valid, _, unavailable = validate_tool_availability(
+                _, available_count, unavailable = validate_tool_availability(
                     self.tools,
                     research_type="deep research",
                     enable_logging=False,
                 )
                 raise EmptySourceRegistryError(
                     "deep research",
-                    unavailable_tools=unavailable if not is_valid else None,
+                    unavailable_tools=unavailable,
+                    available_count=available_count,
                 )
 
             # Post-process: sanitize report (strip body URLs, shortened URLs, unsafe URLs)

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -497,10 +497,15 @@ class DeepResearcherAgent:
             else:
                 from aiq_agent.common.tool_validation import validate_tool_availability
 
-                _, _, unavailable = validate_tool_availability(
-                    self.tools, research_type="deep research", enable_logging=False,
+                is_valid, _, unavailable = validate_tool_availability(
+                    self.tools,
+                    research_type="deep research",
+                    enable_logging=False,
                 )
-                raise EmptySourceRegistryError("deep research", unavailable_tools=unavailable)
+                raise EmptySourceRegistryError(
+                    "deep research",
+                    unavailable_tools=unavailable if not is_valid else None,
+                )
 
             # Post-process: sanitize report (strip body URLs, shortened URLs, unsafe URLs)
             sanitization = sanitize_report(final_message)

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -495,7 +495,12 @@ class DeepResearcherAgent:
                     )
                 final_message = verification.verified_report
             else:
-                raise EmptySourceRegistryError("deep research")
+                from aiq_agent.common.tool_validation import validate_tool_availability
+
+                _, _, unavailable = validate_tool_availability(
+                    self.tools, research_type="deep research", enable_logging=False,
+                )
+                raise EmptySourceRegistryError("deep research", unavailable_tools=unavailable)
 
             # Post-process: sanitize report (strip body URLs, shortened URLs, unsafe URLs)
             sanitization = sanitize_report(final_message)

--- a/src/aiq_agent/agents/deep_researcher/register.py
+++ b/src/aiq_agent/agents/deep_researcher/register.py
@@ -76,6 +76,18 @@ async def deep_research_agent(config: DeepResearchAgentConfig, builder: Builder)
         excluded = set(config.exclude_tools)
         tools = [t for t in tools if getattr(t, "name", "") not in excluded]
 
+    from aiq_agent.common import validate_tool_availability
+
+    is_valid, available_count, unavailable = validate_tool_availability(
+        tools,
+        research_type="deep research",
+    )
+    if not is_valid:
+        logger.warning(
+            "Startup check: no tools available for deep research. "
+            "All queries will fail until at least one tool is properly configured.",
+        )
+
     llm = await builder.get_llm(config.orchestrator_llm, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
 
     provider = LLMProvider()
@@ -121,14 +133,14 @@ async def deep_research_agent(config: DeepResearchAgentConfig, builder: Builder)
             # At least one tool must be available
             # This prevents the agent from trying to reason about unavailable tools
             # Check selected_tools directly - they already reflect data_sources filtering
-            from aiq_agent.common import format_tool_unavailability_error
+            from aiq_agent.common import format_user_facing_tool_error
             from aiq_agent.common import validate_tool_availability
 
             is_valid, _, unavailable_tools = validate_tool_availability(selected_tools, research_type="deep research")
 
             # Fail if no tools are available
             if not is_valid:
-                error_msg = format_tool_unavailability_error("deep research", unavailable_tools)
+                error_msg = format_user_facing_tool_error("deep research", unavailable_tools)
 
                 # Return error state with error message - this prevents the agent from running
                 from langchain_core.messages import AIMessage

--- a/src/aiq_agent/agents/shallow_researcher/agent.py
+++ b/src/aiq_agent/agents/shallow_researcher/agent.py
@@ -314,10 +314,15 @@ class ShallowResearcherAgent:
                 else:
                     from aiq_agent.common.tool_validation import validate_tool_availability
 
-                    _, _, unavailable = validate_tool_availability(
-                        self.tools, research_type="shallow research", enable_logging=False,
+                    is_valid, _, unavailable = validate_tool_availability(
+                        self.tools,
+                        research_type="shallow research",
+                        enable_logging=False,
                     )
-                    raise EmptySourceRegistryError("shallow research", unavailable_tools=unavailable)
+                    raise EmptySourceRegistryError(
+                        "shallow research",
+                        unavailable_tools=unavailable if not is_valid else None,
+                    )
 
                 # Step 2: sanitize report (strip body URLs, shortened URLs, unsafe URLs)
                 sanitization = sanitize_report(content)

--- a/src/aiq_agent/agents/shallow_researcher/agent.py
+++ b/src/aiq_agent/agents/shallow_researcher/agent.py
@@ -314,14 +314,15 @@ class ShallowResearcherAgent:
                 else:
                     from aiq_agent.common.tool_validation import validate_tool_availability
 
-                    is_valid, _, unavailable = validate_tool_availability(
+                    _, available_count, unavailable = validate_tool_availability(
                         self.tools,
                         research_type="shallow research",
                         enable_logging=False,
                     )
                     raise EmptySourceRegistryError(
                         "shallow research",
-                        unavailable_tools=unavailable if not is_valid else None,
+                        unavailable_tools=unavailable,
+                        available_count=available_count,
                     )
 
                 # Step 2: sanitize report (strip body URLs, shortened URLs, unsafe URLs)

--- a/src/aiq_agent/agents/shallow_researcher/agent.py
+++ b/src/aiq_agent/agents/shallow_researcher/agent.py
@@ -312,7 +312,12 @@ class ShallowResearcherAgent:
                     )
                     content = verification.verified_report
                 else:
-                    raise EmptySourceRegistryError("shallow research")
+                    from aiq_agent.common.tool_validation import validate_tool_availability
+
+                    _, _, unavailable = validate_tool_availability(
+                        self.tools, research_type="shallow research", enable_logging=False,
+                    )
+                    raise EmptySourceRegistryError("shallow research", unavailable_tools=unavailable)
 
                 # Step 2: sanitize report (strip body URLs, shortened URLs, unsafe URLs)
                 sanitization = sanitize_report(content)

--- a/src/aiq_agent/agents/shallow_researcher/register.py
+++ b/src/aiq_agent/agents/shallow_researcher/register.py
@@ -76,6 +76,18 @@ async def shallow_research_agent(config: ShallowResearchAgentConfig, builder: Bu
         excluded = set(config.exclude_tools)
         tools = [t for t in tools if getattr(t, "name", "") not in excluded]
 
+    from aiq_agent.common import validate_tool_availability
+
+    is_valid, available_count, unavailable = validate_tool_availability(
+        tools,
+        research_type="shallow research",
+    )
+    if not is_valid:
+        logger.warning(
+            "Startup check: no tools available for shallow research. "
+            "All queries will fail until at least one tool is properly configured.",
+        )
+
     provider = LLMProvider()
     provider.set_default(llm)
 
@@ -110,7 +122,7 @@ async def shallow_research_agent(config: ShallowResearchAgentConfig, builder: Bu
             # At least one tool must be available
             # This prevents the agent from trying to reason about unavailable tools
             # Check selected_tools directly - they already reflect data_sources filtering
-            from aiq_agent.common import format_tool_unavailability_error
+            from aiq_agent.common import format_user_facing_tool_error
             from aiq_agent.common import validate_tool_availability
 
             is_valid, _, unavailable_tools = validate_tool_availability(
@@ -119,7 +131,7 @@ async def shallow_research_agent(config: ShallowResearchAgentConfig, builder: Bu
 
             # Fail if no tools are available
             if not is_valid:
-                error_msg = format_tool_unavailability_error("shallow research", unavailable_tools)
+                error_msg = format_user_facing_tool_error("shallow research", unavailable_tools)
 
                 # Return error state with error message - this prevents the agent from running
                 from langchain_core.messages import AIMessage

--- a/src/aiq_agent/common/__init__.py
+++ b/src/aiq_agent/common/__init__.py
@@ -57,6 +57,7 @@ from .message_utils import get_latest_user_query
 from .prompt_utils import load_prompt
 from .prompt_utils import render_prompt_template
 from .tool_validation import format_tool_unavailability_error
+from .tool_validation import format_user_facing_tool_error
 from .tool_validation import validate_tool_availability
 
 logger = logging.getLogger(__name__)
@@ -76,6 +77,7 @@ __all__ = [
     "filter_tools_by_sources",
     "format_data_source_tools",
     "format_tool_unavailability_error",
+    "format_user_facing_tool_error",
     "get_all_tool_refs",
     "get_checkpointer",
     "get_or_create_session_registry",

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -77,9 +77,11 @@ class EmptySourceRegistryError(Exception):
         self,
         agent_type: str = "research",
         unavailable_tools: list[str] | None = None,
+        available_count: int = 0,
     ) -> None:
         self.agent_type = agent_type
         self.unavailable_tools = unavailable_tools or []
+        self.available_count = available_count
         super().__init__(
             f"Research failed: no sources were captured during {agent_type}. "
             "All tool calls may have failed or returned no results. "

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -73,8 +73,13 @@ class CitationVerificationResult:
 class EmptySourceRegistryError(Exception):
     """Raised when no sources were captured during research."""
 
-    def __init__(self, agent_type: str = "research") -> None:
+    def __init__(
+        self,
+        agent_type: str = "research",
+        unavailable_tools: list[str] | None = None,
+    ) -> None:
         self.agent_type = agent_type
+        self.unavailable_tools = unavailable_tools or []
         super().__init__(
             f"Research failed: no sources were captured during {agent_type}. "
             "All tool calls may have failed or returned no results. "

--- a/src/aiq_agent/common/tool_validation.py
+++ b/src/aiq_agent/common/tool_validation.py
@@ -16,9 +16,36 @@
 """Tool validation utilities for checking tool availability."""
 
 import logging
+import os
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# Returned to end users in web/production/e2e deployments.  Detailed
+# diagnostics (specific tool names and missing API keys) are only shown when
+# AIQ_DEV_ENV is "cli" — set automatically by scripts/start_cli.sh.
+# See deploy/.env for guidance.
+_GENERIC_TOOL_ERROR = (
+    "Some search capabilities are currently unavailable. Please contact your administrator or try again later."
+)
+
+
+def _extract_unavailable_reason(description: str) -> str:
+    """Extract the reason from a stub tool's description.
+
+    Stub tools typically have descriptions like:
+        ``"Web search tool (unavailable - missing TAVILY_API_KEY)"``
+    This extracts ``"missing TAVILY_API_KEY"`` from the parenthetical.
+    """
+    import re
+
+    match = re.search(r"\(unavailable\s*[-:]\s*(.+?)\)", description, re.IGNORECASE)
+    if match:
+        return match.group(1).strip()
+    match = re.search(r"(missing\s+\S+)", description, re.IGNORECASE)
+    if match:
+        return match.group(1).strip()
+    return "missing or invalid API key"
 
 
 def validate_tool_availability(
@@ -48,16 +75,16 @@ def validate_tool_availability(
 
     for tool in tools:
         tool_name = getattr(tool, "name", "").lower()
-        tool_desc = getattr(tool, "description", "").lower() or ""
+        tool_desc_original = getattr(tool, "description", "") or ""
+        tool_desc = tool_desc_original.lower()
 
-        # Check if tool is unavailable (stub)
         is_unavailable = "unavailable" in tool_desc or "missing" in tool_desc
 
         if is_unavailable:
-            reason = "missing or invalid API key or config error"
+            reason = _extract_unavailable_reason(tool_desc_original)
             if enable_logging:
                 logger.info("Tool %s is unavailable: %s", tool_name, reason)
-            unavailable_tools.append(f"{tool_name} - {reason}")
+            unavailable_tools.append(f"{tool_name} ({reason})")
         else:
             available_tools_count += 1
             if enable_logging:
@@ -96,3 +123,41 @@ def format_tool_unavailability_error(
         f" At least one tool must be configured and available.{unavailable_info}\n"
     )
     return error_msg
+
+
+def format_user_facing_tool_error(
+    research_type: str,
+    unavailable_tools: list[str],
+    available_count: int = 0,
+) -> str:
+    """Format a tool-unavailability error appropriate for the current deployment mode.
+
+    In CLI mode (``AIQ_DEV_ENV=cli``), the full tool details are returned so
+    developers can diagnose quickly in the terminal.  In all other modes
+    (e2e, web, production, unset) a generic message is returned to avoid
+    leaking infrastructure details to end users in the web UI.
+
+    The detailed message is **always** logged at WARNING level regardless of
+    deployment mode so operators can still diagnose from server logs.
+
+    Args:
+        research_type: Type of research (e.g., "shallow research", "deep research")
+        unavailable_tools: List of unavailable tool names with reasons
+        available_count: Number of tools that passed pre-flight checks
+
+    Returns:
+        User-facing error message string
+    """
+    if available_count == 0:
+        detailed = format_tool_unavailability_error(research_type, unavailable_tools)
+    else:
+        tool_list = ", ".join(unavailable_tools)
+        detailed = f"Research did not return any results. Unavailable tools: {tool_list}.\n"
+
+    logger.warning(detailed.strip())
+
+    dev_env = os.environ.get("AIQ_DEV_ENV", "")
+    if dev_env == "cli":
+        return detailed
+
+    return _GENERIC_TOOL_ERROR


### PR DESCRIPTION
## Summary
- When research fails with no sources captured, the error handler now reports which tools were unavailable (stubs) instead of showing a generic "temporary issue" message
- Enriches `EmptySourceRegistryError` with an optional `unavailable_tools` list populated via the existing `validate_tool_availability` check
- Preserves the generic fallback when no tool details are available
- Should help resolve the internal version to outline unset api keys in response since ECI might've been the cause 
## Test plan
- Start CLI with `TAVILY_API_KEY` unset
- Submit a query and confirm the error lists the specific unavailable tools
- Set valid keys and confirm normal research works