### PR TITLE
fix: inject fresh idToken on WebSocket upgrade for reliable auth

### DIFF
--- a/frontends/ui/server.js
+++ b/frontends/ui/server.js
@@ -24,6 +24,7 @@
 const http = require('http')
 const httpProxy = require('http-proxy')
 const { parse } = require('url')
+const { decode: decodeJwt } = require('next-auth/jwt')
 
 const dev = process.env.NODE_ENV !== 'production'
 const hostname = process.env.HOSTNAME || '0.0.0.0'
@@ -42,6 +43,58 @@ const getBackendWsUrl = () => {
 const BACKEND_HTTP_URL = getBackendUrl()
 const BACKEND_WS_URL = getBackendWsUrl()
 const NEXT_INTERNAL_URL = process.env.NEXT_INTERNAL_URL || 'http://localhost:3001'
+const NEXTAUTH_SECRET = process.env.NEXTAUTH_SECRET
+
+/**
+ * Parse cookies from a raw Cookie header string.
+ */
+const parseCookies = (cookieHeader) => {
+  const cookies = {}
+  if (!cookieHeader) return cookies
+  for (const part of cookieHeader.split(';')) {
+    const idx = part.indexOf('=')
+    if (idx > 0) {
+      cookies[part.slice(0, idx).trim()] = part.slice(idx + 1).trim()
+    }
+  }
+  return cookies
+}
+
+/**
+ * Extract idToken from the NextAuth session JWT cookie.
+ *
+ * proxy.ts (Next.js middleware) sets the idToken cookie on HTTP responses,
+ * but WebSocket upgrades bypass Next.js entirely — the gateway handles them
+ * directly. If the browser hasn't received a recent HTTP response that set
+ * the cookie (first load, expired token, stale cache), the WebSocket
+ * connects without auth and downstream services that need the caller's
+ * identity (e.g. ECI search) fail.
+ *
+ * This function decodes the NextAuth session JWT (which the browser always
+ * sends) and extracts the idToken so the gateway can inject it into the
+ * proxied WebSocket request.
+ */
+const extractIdTokenFromSession = async (cookieHeader) => {
+  if (!NEXTAUTH_SECRET) return null
+  const cookies = parseCookies(cookieHeader)
+
+  // NextAuth 4 uses prefixed names when NEXTAUTH_URL is HTTPS
+  const sessionToken =
+    cookies['__Secure-next-auth.session-token'] ||
+    cookies['next-auth.session-token']
+  if (!sessionToken) return null
+
+  try {
+    const decoded = await decodeJwt({
+      token: sessionToken,
+      secret: NEXTAUTH_SECRET,
+    })
+    return decoded?.idToken || null
+  } catch (err) {
+    console.error('[WS Auth] Failed to decode NextAuth session:', err.message)
+    return null
+  }
+}
 
 // In production, we run Next.js in the same process
 let nextApp = null
@@ -144,7 +197,7 @@ const startServer = async () => {
   })
 
   // WebSocket upgrade handler
-  server.on('upgrade', (req, socket, head) => {
+  server.on('upgrade', async (req, socket, head) => {
     socket.setKeepAlive?.(true, 15000)
     socket.setTimeout?.(0)
 
@@ -161,6 +214,16 @@ const startServer = async () => {
     if (pathname === '/websocket' || pathname.startsWith('/websocket')) {
       req.url = '/websocket' + (parsedUrl.search || '')
 
+      // Ensure idToken cookie is present for backend auth.
+      // proxy.ts only runs on HTTP requests and can miss the WebSocket
+      // upgrade, leaving the backend without the caller's Starfleet token.
+      const cookies = parseCookies(req.headers.cookie)
+      if (!cookies.idToken) {
+        const idToken = await extractIdTokenFromSession(req.headers.cookie)
+        if (idToken) {
+          req.headers.cookie = `${req.headers.cookie || ''}; idToken=${idToken}`
+        }
+      }
 
       backendProxy.ws(
         req,

--- a/frontends/ui/server.js
+++ b/frontends/ui/server.js
@@ -214,15 +214,21 @@ const startServer = async () => {
     if (pathname === '/websocket' || pathname.startsWith('/websocket')) {
       req.url = '/websocket' + (parsedUrl.search || '')
 
-      // Ensure idToken cookie is present for backend auth.
-      // proxy.ts only runs on HTTP requests and can miss the WebSocket
-      // upgrade, leaving the backend without the caller's Starfleet token.
-      const cookies = parseCookies(req.headers.cookie)
-      if (!cookies.idToken) {
-        const idToken = await extractIdTokenFromSession(req.headers.cookie)
-        if (idToken) {
-          req.headers.cookie = `${req.headers.cookie || ''}; idToken=${idToken}`
-        }
+      // Ensure the backend receives a fresh idToken for auth.
+      // proxy.ts (Next.js middleware) sets the idToken cookie on HTTP
+      // responses, but WebSocket upgrades bypass Next.js. The browser may
+      // send a stale or missing idToken cookie while the NextAuth session
+      // JWT (refreshed every ~30 min by the JWT callback) has the latest
+      // token. Always prefer the session JWT so the backend gets the
+      // freshest credential.
+      const idToken = await extractIdTokenFromSession(req.headers.cookie)
+      if (idToken) {
+        // Strip any existing idToken cookie and inject the fresh one
+        const cookieParts = (req.headers.cookie || '')
+          .split(';')
+          .filter((c) => !c.trim().startsWith('idToken='))
+        cookieParts.push(`idToken=${idToken}`)
+        req.headers.cookie = cookieParts.join('; ')
       }
 
       backendProxy.ws(

--- a/frontends/ui/server.js
+++ b/frontends/ui/server.js
@@ -89,7 +89,10 @@ const extractIdTokenFromSession = async (cookieHeader) => {
       token: sessionToken,
       secret: NEXTAUTH_SECRET,
     })
-    return decoded?.idToken || null
+    if (!decoded || decoded.error) return null
+    const expiresAt = decoded.expiresAt
+    if (!expiresAt || Date.now() >= expiresAt * 1000) return null
+    return decoded.idToken || null
   } catch (err) {
     console.error('[WS Auth] Failed to decode NextAuth session:', err.message)
     return null


### PR DESCRIPTION
## Summary

- WebSocket upgrades bypass Next.js middleware (`proxy.ts`), so the `idToken` cookie may be missing or stale when the gateway proxies to the backend
- Downstream services that need the caller's identity (e.g. ECI enterprise search) fail with "No authentication token available" for some users — clearing browser cache is the only workaround
- Fix: decode the NextAuth session JWT (which always has the latest refreshed token) during WebSocket upgrade in the gateway and inject the fresh `idToken` cookie on the proxied request

## Root Cause

`proxy.ts` sets the `idToken` cookie on HTTP responses, but the gateway `server.js` handles WebSocket upgrades directly without going through Next.js. When the browser hasn't received a recent HTTP response (first load race, expired token, stale cache), the WebSocket connects without auth. Even when the cookie exists, it may be stale (from before a token refresh) while the NextAuth session JWT has the latest credential.

## What Changed

`frontends/ui/server.js`:
- Added `extractIdTokenFromSession()` — decodes the NextAuth session JWT using `next-auth/jwt` and extracts the `idToken`
- On every WebSocket upgrade to `/websocket`, the gateway now decodes the session JWT and injects the fresh `idToken` cookie, replacing any stale value
- Falls back gracefully if `NEXTAUTH_SECRET` is not set or decoding fails

## Test plan

- [ ] Sign in via Starfleet SSO, immediately send a chat query that triggers ECI search — should succeed without "No authentication token" error
- [ ] Wait for token refresh (~30 min), then send another ECI query via WebSocket — should still succeed with the refreshed token
- [ ] Clear browser cache and repeat — should work on first load
- [ ] Verify non-auth deployments (`REQUIRE_AUTH=false`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)