### PR TITLE
fix: reconnect WebSocket on token refresh to prevent stale auth

### DIFF
--- a/frontends/ui/server.js
+++ b/frontends/ui/server.js
@@ -90,8 +90,13 @@ const extractIdTokenFromSession = async (cookieHeader) => {
       secret: NEXTAUTH_SECRET,
     })
     if (!decoded || decoded.error) return null
-    const expiresAt = decoded.expiresAt
-    if (!expiresAt || Date.now() >= expiresAt * 1000) return null
+    // Note: do NOT reject based on expiresAt here. The session JWT is
+    // valid (NextAuth maxAge = 24h) even when the OAuth token inside it
+    // has expired. Sending an expired idToken is better than sending
+    // nothing — the backend can still identify the caller, and the
+    // SessionProvider will refresh the token within seconds of page load.
+    // The WebSocket reconnect (triggered by idToken rotation in the chat
+    // hook) will then pick up the fresh credential.
     return decoded.idToken || null
   } catch (err) {
     console.error('[WS Auth] Failed to decode NextAuth session:', err.message)

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -153,7 +153,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
   // Ref to track the current status for detecting status changes
   const currentStatusRef = useRef<StatusType | null>(null)
 
-  const { user, authRequired, error: authError } = useAuth()
+  const { user, authRequired, error: authError, idToken } = useAuth()
 
   // Chat store
   const {
@@ -593,6 +593,54 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
       }
     }
   }, [currentConversation?.id, autoConnect, createCallbacks])
+
+  /**
+   * Reconnect the WebSocket when the OAuth idToken rotates.
+   *
+   * server.js decodes the NextAuth session JWT on every WebSocket upgrade
+   * and injects the idToken as a cookie. When a page is reopened after
+   * hours, the initial connection may carry a stale token. The
+   * SessionProvider refreshes tokens within seconds of mount — this effect
+   * detects the rotation and forces a reconnect so the new WebSocket gets
+   * the fresh credential. Also covers long-lived connections where the
+   * token refreshes every ~55 min.
+   */
+  const tokenInitRef = useRef(false)
+  const prevIdTokenRef = useRef(idToken)
+  const tokenReconnectPending = useRef(false)
+
+  useEffect(() => {
+    // First render — capture initial token, don't reconnect
+    if (!tokenInitRef.current) {
+      tokenInitRef.current = true
+      prevIdTokenRef.current = idToken
+      return
+    }
+
+    // Detect token rotation
+    if (prevIdTokenRef.current !== idToken) {
+      prevIdTokenRef.current = idToken
+      tokenReconnectPending.current = true
+    }
+
+    // Nothing pending
+    if (!tokenReconnectPending.current) return
+
+    // Don't interrupt an in-flight request or HITL interaction — defer
+    // until idle. The backend's WebSocketSessionRegistry supports socket
+    // swaps, but the brief disconnect window can race with the user
+    // submitting a HITL response.
+    if (isStreaming || isLoading || pendingInteraction) return
+
+    // Reconnect with fresh credentials
+    tokenReconnectPending.current = false
+    const client = wsClientRef.current
+    if (client?.isConnected()) {
+      console.info('[WS] Token refreshed — reconnecting for fresh auth')
+      client.disconnect()
+      client.connect()
+    }
+  }, [idToken, isStreaming, isLoading, pendingInteraction])
 
   /**
    * Send a message via WebSocket


### PR DESCRIPTION
## Summary

- **server.js**: Remove the overly strict `expiresAt` gate from `extractIdTokenFromSession` — sending an expired idToken is better than sending nothing. The backend can still identify the caller, and the session refreshes within seconds of page load.
- **use-websocket-chat.ts**: Add a token-refresh-aware reconnect effect that watches `idToken` from `useAuth()`. When the token rotates (session refresh picks up new credentials from Starfleet), forces a WebSocket disconnect/reconnect so `server.js` decodes the fresh session JWT. Defers during streaming, loading, or pending HITL interactions.

Fixes the "UI stops responding after a few hours / page reopen" issue where users had to logout/login or clear cache to recover.

### Root cause

When a page is reopened after hours, the session JWT cookie still exists (24h maxAge) but the OAuth `expiresAt` inside it is stale. The WebSocket connects before the `SessionProvider` refreshes the token, and `extractIdTokenFromSession` rejects the expired token — sending **no auth** to the backend. ECI and other auth-gated services fail silently. There was also no mechanism to reconnect the WebSocket after the session refreshed.

## Test plan

- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] All 39 existing tests pass (29 websocket-chat + 10 connection-recovery)
- [ ] Manual: open app, wait for token refresh (~55 min or adjust `TOKEN_REFRESH_BUFFER_MINUTES`), verify console shows `[WS] Token refreshed — reconnecting for fresh auth`
- [ ] Manual: close tab, wait >1 hour, reopen — verify app works immediately without logout/login
- [ ] Manual: trigger HITL prompt, wait for token refresh, verify reconnect defers until HITL completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)