### PR TITLE
Revert "fix: inject fresh idToken on WebSocket upgrade for reliable auth (#188)"

### DIFF
--- a/frontends/ui/server.js
+++ b/frontends/ui/server.js
@@ -24,7 +24,6 @@
 const http = require('http')
 const httpProxy = require('http-proxy')
 const { parse } = require('url')
-const { decode: decodeJwt } = require('next-auth/jwt')
 
 const dev = process.env.NODE_ENV !== 'production'
 const hostname = process.env.HOSTNAME || '0.0.0.0'
@@ -43,61 +42,6 @@ const getBackendWsUrl = () => {
 const BACKEND_HTTP_URL = getBackendUrl()
 const BACKEND_WS_URL = getBackendWsUrl()
 const NEXT_INTERNAL_URL = process.env.NEXT_INTERNAL_URL || 'http://localhost:3001'
-const NEXTAUTH_SECRET = process.env.NEXTAUTH_SECRET
-
-/**
- * Parse cookies from a raw Cookie header string.
- */
-const parseCookies = (cookieHeader) => {
-  const cookies = {}
-  if (!cookieHeader) return cookies
-  for (const part of cookieHeader.split(';')) {
-    const idx = part.indexOf('=')
-    if (idx > 0) {
-      cookies[part.slice(0, idx).trim()] = part.slice(idx + 1).trim()
-    }
-  }
-  return cookies
-}
-
-/**
- * Extract idToken from the NextAuth session JWT cookie.
- *
- * proxy.ts (Next.js middleware) sets the idToken cookie on HTTP responses,
- * but WebSocket upgrades bypass Next.js entirely — the gateway handles them
- * directly. If the browser hasn't received a recent HTTP response that set
- * the cookie (first load, expired token, stale cache), the WebSocket
- * connects without auth and downstream services that need the caller's
- * identity (e.g. ECI search) fail.
- *
- * This function decodes the NextAuth session JWT (which the browser always
- * sends) and extracts the idToken so the gateway can inject it into the
- * proxied WebSocket request.
- */
-const extractIdTokenFromSession = async (cookieHeader) => {
-  if (!NEXTAUTH_SECRET) return null
-  const cookies = parseCookies(cookieHeader)
-
-  // NextAuth 4 uses prefixed names when NEXTAUTH_URL is HTTPS
-  const sessionToken =
-    cookies['__Secure-next-auth.session-token'] ||
-    cookies['next-auth.session-token']
-  if (!sessionToken) return null
-
-  try {
-    const decoded = await decodeJwt({
-      token: sessionToken,
-      secret: NEXTAUTH_SECRET,
-    })
-    if (!decoded || decoded.error) return null
-    const expiresAt = decoded.expiresAt
-    if (!expiresAt || Date.now() >= expiresAt * 1000) return null
-    return decoded.idToken || null
-  } catch (err) {
-    console.error('[WS Auth] Failed to decode NextAuth session:', err.message)
-    return null
-  }
-}
 
 // In production, we run Next.js in the same process
 let nextApp = null
@@ -200,7 +144,7 @@ const startServer = async () => {
   })
 
   // WebSocket upgrade handler
-  server.on('upgrade', async (req, socket, head) => {
+  server.on('upgrade', (req, socket, head) => {
     socket.setKeepAlive?.(true, 15000)
     socket.setTimeout?.(0)
 
@@ -217,22 +161,6 @@ const startServer = async () => {
     if (pathname === '/websocket' || pathname.startsWith('/websocket')) {
       req.url = '/websocket' + (parsedUrl.search || '')
 
-      // Ensure the backend receives a fresh idToken for auth.
-      // proxy.ts (Next.js middleware) sets the idToken cookie on HTTP
-      // responses, but WebSocket upgrades bypass Next.js. The browser may
-      // send a stale or missing idToken cookie while the NextAuth session
-      // JWT (refreshed every ~30 min by the JWT callback) has the latest
-      // token. Always prefer the session JWT so the backend gets the
-      // freshest credential.
-      const idToken = await extractIdTokenFromSession(req.headers.cookie)
-      if (idToken) {
-        // Strip any existing idToken cookie and inject the fresh one
-        const cookieParts = (req.headers.cookie || '')
-          .split(';')
-          .filter((c) => !c.trim().startsWith('idToken='))
-        cookieParts.push(`idToken=${idToken}`)
-        req.headers.cookie = cookieParts.join('; ')
-      }
 
       backendProxy.ws(
         req,


### PR DESCRIPTION
## Summary

- Reverts e009f88 (PR #188) — the WebSocket idToken injection in server.js
- The token injection approach introduced a session bootstrap race: when users reopen the page after hours, `extractIdTokenFromSession` rejects the expired token and sends **no auth** to the backend, causing silent failures that require logout/login to recover
- Rolling back to the previous behavior until a more robust auth propagation approach is designed

## Test plan

- [ ] Deploy and verify users no longer need to logout/login after idle periods
- [ ] Verify WebSocket connections work without the token injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)