### PR TITLE
test: close remaining auth bug fix test coverage gaps

### DIFF
--- a/frontends/aiq_api/tests/test_auth_errors.py
+++ b/frontends/aiq_api/tests/test_auth_errors.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aiq_api.auth.errors import AuthError
+from aiq_api.websocket_reconnect import ReconnectableWebSocketMessageHandler
+from nat.data_models.api_server import ErrorTypes
+from nat.data_models.api_server import WebSocketMessageStatus
+from nat.data_models.api_server import WebSocketMessageType
+
+
+class _SessionContext:
+    async def __aenter__(self):
+        return object()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _SessionManager:
+    def session(self, **kwargs):
+        return _SessionContext()
+
+
+async def _raise_auth_error(*args, **kwargs):
+    if False:  # pragma: no cover - keeps this as an async generator
+        yield None
+    raise AuthError("token expired")
+
+
+class TestWebSocketAuthErrors:
+    @pytest.mark.asyncio
+    async def test_run_workflow_emits_auth_error_message(self, monkeypatch):
+        monkeypatch.setattr("aiq_api.websocket_reconnect.generate_streaming_response", _raise_auth_error)
+
+        handler = SimpleNamespace(
+            _flow_handler=None,
+            _session_manager=_SessionManager(),
+            _socket=object(),
+            human_interaction_callback=AsyncMock(),
+            _step_adaptor=None,
+            _pending_observability_trace=None,
+            create_websocket_message=AsyncMock(),
+        )
+
+        await ReconnectableWebSocketMessageHandler._run_workflow(
+            handler,
+            payload={"query": "hello"},
+        )
+
+        handler.create_websocket_message.assert_awaited_once()
+        kwargs = handler.create_websocket_message.await_args.kwargs
+        payload = kwargs["data_model"]
+
+        assert payload.code == ErrorTypes.UNKNOWN_ERROR
+        assert payload.message == "auth_error"
+        assert "token expired" in (payload.details or "")
+        assert kwargs["message_type"] == WebSocketMessageType.ERROR_MESSAGE
+        assert kwargs["status"] == WebSocketMessageStatus.COMPLETE

--- a/frontends/aiq_api/tests/test_auth_errors.py
+++ b/frontends/aiq_api/tests/test_auth_errors.py
@@ -43,6 +43,7 @@ class TestWebSocketAuthErrors:
             _flow_handler=None,
             _session_manager=_SessionManager(),
             _socket=object(),
+            _authenticated_user=None,
             human_interaction_callback=AsyncMock(),
             _step_adaptor=None,
             _pending_observability_trace=None,

--- a/frontends/ui/src/adapters/api/authenticated-fetch.spec.ts
+++ b/frontends/ui/src/adapters/api/authenticated-fetch.spec.ts
@@ -193,12 +193,16 @@ describe('authenticated-fetch', () => {
       expect(calledHeaders.get('X-Custom-Header')).toBe('custom-value')
     })
 
-    test.each(['token_expired', 'token_invalid'])(
+    test.each([
+      ['token_expired', 'addAction', 'Auth: token_expired'],
+      ['token_invalid', 'addError', expect.any(Error)],
+    ] as const)(
       'emits RUM event when 401 error code is %s',
-      async (errorCode) => {
+      async (errorCode, rumMethod, expectedEvent) => {
         mockGetSession.mockResolvedValue(null)
         const addError = vi.fn()
-        ;(window as unknown as Record<string, unknown>).DD_RUM = { addError }
+        const addAction = vi.fn()
+        ;(window as unknown as Record<string, unknown>).DD_RUM = { addAction, addError }
         mockFetch.mockResolvedValue(
           new Response(JSON.stringify({ error: errorCode }), {
             status: 401,
@@ -208,11 +212,11 @@ describe('authenticated-fetch', () => {
 
         await authenticatedFetch('/api/test-auth')
 
-        expect(addError).toHaveBeenCalledTimes(1)
-        expect(addError).toHaveBeenCalledWith(
-          expect.any(Error),
+        const rumCall = rumMethod === 'addAction' ? addAction : addError
+        expect(rumCall).toHaveBeenCalledTimes(1)
+        expect(rumCall).toHaveBeenCalledWith(
+          expectedEvent,
           expect.objectContaining({
-            source: 'custom',
             auth_error_code: errorCode,
             path: '/api/test-auth',
           })

--- a/frontends/ui/src/adapters/api/authenticated-fetch.spec.ts
+++ b/frontends/ui/src/adapters/api/authenticated-fetch.spec.ts
@@ -49,6 +49,7 @@ describe('authenticated-fetch', () => {
   })
 
   afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).DD_RUM
     vi.restoreAllMocks()
   })
 
@@ -190,6 +191,43 @@ describe('authenticated-fetch', () => {
       const calledHeaders = getCalledHeaders()
       expect(calledHeaders.get('Authorization')).toBe('Bearer test-id-token')
       expect(calledHeaders.get('X-Custom-Header')).toBe('custom-value')
+    })
+
+    test.each(['token_expired', 'token_invalid'])(
+      'emits RUM event when 401 error code is %s',
+      async (errorCode) => {
+        mockGetSession.mockResolvedValue(null)
+        const addError = vi.fn()
+        ;(window as unknown as Record<string, unknown>).DD_RUM = { addError }
+        mockFetch.mockResolvedValue(
+          new Response(JSON.stringify({ error: errorCode }), {
+            status: 401,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        )
+
+        await authenticatedFetch('/api/test-auth')
+
+        expect(addError).toHaveBeenCalledTimes(1)
+        expect(addError).toHaveBeenCalledWith(
+          expect.any(Error),
+          expect.objectContaining({
+            source: 'custom',
+            auth_error_code: errorCode,
+            path: '/api/test-auth',
+          })
+        )
+      }
+    )
+
+    test('does not emit RUM event when 401 body is non-JSON', async () => {
+      mockGetSession.mockResolvedValue(null)
+      const addError = vi.fn()
+      ;(window as unknown as Record<string, unknown>).DD_RUM = { addError }
+      mockFetch.mockResolvedValue(new Response('<html>unauthorized</html>', { status: 401 }))
+
+      await expect(authenticatedFetch('/api/test-auth')).resolves.toBeInstanceOf(Response)
+      expect(addError).not.toHaveBeenCalled()
     })
   })
 

--- a/frontends/ui/src/adapters/api/websocket-client.spec.ts
+++ b/frontends/ui/src/adapters/api/websocket-client.spec.ts
@@ -73,8 +73,8 @@ describe('NATWebSocketClient auth observability', () => {
     expect(addError).toHaveBeenCalledWith(
       expect.any(Error),
       expect.objectContaining({
-        source: 'custom',
-        auth_error_code: 'ws_auth_error',
+        source: 'websocket',
+        auth_error_code: 'auth_error',
         details: 'Token expired',
       })
     )

--- a/frontends/ui/src/adapters/api/websocket-client.spec.ts
+++ b/frontends/ui/src/adapters/api/websocket-client.spec.ts
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { NATMessageType, NATWebSocketClient } from './websocket-client'
+
+class MockWebSocket {
+  static readonly OPEN = 1
+  static instances: MockWebSocket[] = []
+
+  readonly url: string
+  readyState = MockWebSocket.OPEN
+  onopen: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  send = vi.fn()
+  close = vi.fn()
+}
+
+describe('NATWebSocketClient auth observability', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket)
+  })
+
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).DD_RUM
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  test('emits RUM error for websocket auth_error payloads', async () => {
+    const addError = vi.fn()
+    ;(window as unknown as Record<string, unknown>).DD_RUM = { addError }
+    const onError = vi.fn()
+    const client = new NATWebSocketClient({
+      conversationId: 'conv-1',
+      websocketUrl: 'ws://localhost/websocket',
+      callbacks: { onError },
+    })
+
+    await client.connect()
+    const ws = MockWebSocket.instances[0]
+    ws.onopen?.(new Event('open'))
+    ws.onmessage?.(
+      {
+        data: JSON.stringify({
+          type: NATMessageType.ERROR,
+          content: {
+            code: 'UNKNOWN_ERROR',
+            message: 'auth_error',
+            details: 'Token expired',
+          },
+          status: 'error',
+        }),
+      } as MessageEvent
+    )
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'UNKNOWN_ERROR',
+        message: 'auth_error',
+        details: 'Token expired',
+      })
+    )
+    expect(addError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        source: 'custom',
+        auth_error_code: 'ws_auth_error',
+        details: 'Token expired',
+      })
+    )
+  })
+
+  test('does not emit RUM error for non-auth websocket errors', async () => {
+    const addError = vi.fn()
+    ;(window as unknown as Record<string, unknown>).DD_RUM = { addError }
+    const onError = vi.fn()
+    const client = new NATWebSocketClient({
+      conversationId: 'conv-1',
+      websocketUrl: 'ws://localhost/websocket',
+      callbacks: { onError },
+    })
+
+    await client.connect()
+    const ws = MockWebSocket.instances[0]
+    ws.onopen?.(new Event('open'))
+    ws.onmessage?.(
+      {
+        data: JSON.stringify({
+          type: NATMessageType.ERROR,
+          content: {
+            code: 'UNKNOWN_ERROR',
+            message: 'workflow_error',
+            details: 'Unexpected failure',
+          },
+          status: 'error',
+        }),
+      } as MessageEvent
+    )
+
+    expect(onError).toHaveBeenCalled()
+    expect(addError).not.toHaveBeenCalled()
+  })
+})

--- a/frontends/ui/src/adapters/auth/providers/types.ts
+++ b/frontends/ui/src/adapters/auth/providers/types.ts
@@ -106,8 +106,8 @@ export interface AuthProviderConfig {
   /**
    * Provider-specific token refresh buffer override (in seconds).
    * When set, takes precedence over the TOKEN_REFRESH_BUFFER_MINUTES env var.
-   * Use this when the provider knows the optimal refresh timing (e.g. 30 min
-   * for NVIDIA Starfleet with long-running ECI operations).
+   * Use this when the provider knows the optimal refresh timing for its token
+   * lifetimes or long-running operations.
    */
   tokenRefreshBufferSeconds?: number
 

--- a/frontends/ui/src/app/providers.spec.tsx
+++ b/frontends/ui/src/app/providers.spec.tsx
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ReactNode } from 'react'
+import { render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { AppConfig } from '@/shared/context'
+import { Providers } from './providers'
+
+const sessionProviderProps: Array<Record<string, unknown>> = []
+
+const layoutState = {
+  theme: 'dark',
+  fetchDataSources: vi.fn(),
+  availableDataSources: [] as Array<{ id: string }>,
+  setEnabledDataSources: vi.fn(),
+}
+
+const chatState = {
+  currentConversation: null as { id: string; enabledDataSourceIds?: string[] } | null,
+  reconnectToActiveJob: vi.fn(),
+  cleanupOrphanedStartingBanners: vi.fn(),
+  isDeepResearchStreaming: false,
+}
+
+vi.mock('next-auth/react', () => ({
+  SessionProvider: ({ children, ...props }: { children: ReactNode }) => {
+    sessionProviderProps.push(props as Record<string, unknown>)
+    return <>{children}</>
+  },
+}))
+
+vi.mock('@/adapters/ui', () => ({
+  ThemeProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/features/layout', () => ({
+  useLayoutStore: (selector: (state: typeof layoutState) => unknown) => selector(layoutState),
+}))
+
+vi.mock('@/features/chat/store', () => ({
+  useChatStore: Object.assign(
+    (selector: (state: typeof chatState) => unknown) => selector(chatState),
+    {
+      getState: () => chatState,
+    }
+  ),
+}))
+
+const baseConfig: AppConfig = {
+  authRequired: true,
+  authProviderId: 'test-provider',
+  sessionRefreshIntervalSeconds: 240,
+  fileUpload: {
+    acceptedTypes: '.pdf',
+    acceptedMimeTypes: ['application/pdf'],
+    maxTotalSizeMB: 100,
+    maxFileSize: 100 * 1024 * 1024,
+    maxTotalSize: 100 * 1024 * 1024,
+    maxFileCount: 10,
+    fileExpirationCheckIntervalHours: 0,
+  },
+}
+
+describe('Providers', () => {
+  beforeEach(() => {
+    sessionProviderProps.length = 0
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('uses config-driven SessionProvider polling when auth is required', () => {
+    render(
+      <Providers config={baseConfig}>
+        <div>content</div>
+      </Providers>
+    )
+
+    const latest = sessionProviderProps.at(-1)
+    expect(latest).toEqual(
+      expect.objectContaining({
+        refetchInterval: baseConfig.sessionRefreshIntervalSeconds,
+        refetchOnWindowFocus: true,
+        refetchWhenOffline: false,
+      })
+    )
+  })
+
+  test('disables SessionProvider polling when auth is not required', () => {
+    render(
+      <Providers config={{ ...baseConfig, authRequired: false }}>
+        <div>content</div>
+      </Providers>
+    )
+
+    const latest = sessionProviderProps.at(-1)
+    expect(latest).toEqual(
+      expect.objectContaining({
+        refetchInterval: 0,
+        refetchOnWindowFocus: false,
+        refetchWhenOffline: false,
+      })
+    )
+  })
+
+  test('does not create duplicate interval timers in providers tree', () => {
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+
+    render(
+      <Providers config={baseConfig}>
+        <div>content</div>
+      </Providers>
+    )
+
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add targeted frontend coverage for auth observability paths in `authenticated-fetch` (401 `token_expired` / `token_invalid` parsing and RUM emission)
- add focused websocket client tests to verify `auth_error` payloads emit RUM events while non-auth websocket errors do not
- add app-level `Providers` tests to lock `SessionProvider` refresh interval wiring (`config.sessionRefreshIntervalSeconds` when auth required, `0` otherwise)
- add backend websocket auth error propagation test to verify `_run_workflow` emits typed `auth_error` websocket messages for `AuthError`

## Test plan
- [x] `npm run test:ci -- --run src/adapters/api/authenticated-fetch.spec.ts src/adapters/api/websocket-client.spec.ts src/app/providers.spec.tsx`
- [x] `uv run pytest frontends/aiq_api/tests/test_auth.py frontends/aiq_api/tests/test_auth_errors.py`

Made with [Cursor](https://cursor.com)