### PR TITLE
fix: broken periodic_cleanup import + add Dask memory/lifetime env vars

### DIFF
--- a/deploy/entrypoint.py
+++ b/deploy/entrypoint.py
@@ -118,7 +118,10 @@ def main() -> int:
     if memory_limit:
         worker_args += ["--memory-limit", memory_limit]
     if lifetime:
-        worker_args += ["--lifetime", lifetime, "--lifetime-restart"]
+        lifetime_restart = os.getenv("DASK_LIFETIME_RESTART", "true").lower() != "false"
+        worker_args += ["--lifetime", lifetime]
+        if lifetime_restart:
+            worker_args += ["--lifetime-restart"]
 
     worker_proc = subprocess.Popen(worker_args)
 

--- a/deploy/entrypoint.py
+++ b/deploy/entrypoint.py
@@ -78,6 +78,8 @@ def main() -> int:
     scheduler_port = int(os.getenv("DASK_SCHEDULER_PORT", "8786"))
     nworkers = os.getenv("DASK_NWORKERS", "1")
     nthreads = os.getenv("DASK_NTHREADS", "4")
+    memory_limit = os.getenv("DASK_MEMORY_LIMIT")
+    lifetime = os.getenv("DASK_LIFETIME")
 
     print("============================================", flush=True)
     print("NVIDIA NeMo Agent toolkit - Local Dask Mode", flush=True)
@@ -104,17 +106,21 @@ def main() -> int:
         _terminate_process(scheduler_proc)
         raise SystemExit(str(exc)) from exc
 
-    worker_proc = subprocess.Popen(
-        [
-            "dask-worker",
-            f"tcp://localhost:{scheduler_port}",
-            "--nworkers",
-            str(nworkers),
-            "--nthreads",
-            str(nthreads),
-            "--no-dashboard",
-        ],
-    )
+    worker_args = [
+        "dask-worker",
+        f"tcp://localhost:{scheduler_port}",
+        "--nworkers",
+        str(nworkers),
+        "--nthreads",
+        str(nthreads),
+        "--no-dashboard",
+    ]
+    if memory_limit:
+        worker_args += ["--memory-limit", memory_limit]
+    if lifetime:
+        worker_args += ["--lifetime", lifetime, "--lifetime-restart"]
+
+    worker_proc = subprocess.Popen(worker_args)
 
     print("Waiting for worker to connect...", flush=True)
     time.sleep(3)

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -619,7 +619,7 @@ def _start_periodic_cleanup(
     try:
         from dask.distributed import fire_and_forget
 
-        from nat.front_ends.fastapi.async_job import periodic_cleanup
+        from nat.front_ends.fastapi.async_jobs import periodic_cleanup
 
         cleanup_future = job_store.dask_client.submit(
             periodic_cleanup,


### PR DESCRIPTION
## Summary
- Fixes a silent typo that has prevented NAT's periodic job cleanup from ever running: `nat.front_ends.fastapi.async_job` → `async_jobs` (plural). Without this fix, `job_info` records accumulate in Postgres indefinitely and completed Dask futures never get cleared.
- Adds two new opt-in env vars to `deploy/entrypoint.py` for controlling Dask worker memory and lifetime: `DASK_MEMORY_LIMIT` and `DASK_LIFETIME`. Default behavior is unchanged when they are unset.

## Motivation

On a production deployment under stress testing (B200 cluster, 1788 sessions across phases 10-160 concurrent), we observed:

- Worker heartbeat timeouts at 160 concurrent, matching a classic memory-bloat → GC pause → heartbeat miss → cascade failure pattern
- Each Dask worker subprocess accumulating ~320 MiB of unique memory (PSS), totalling ~3.8 GiB / pod against a 4 GiB limit
- Log line on every pod startup:
  ```
  WARNING - aiq_api.routes.jobs:639 - Failed to submit periodic cleanup to Dask: No module named 'nat.front_ends.fastapi.async_job'
  ```

Verified the fix against `nvidia-nat==1.5.0` installed in the running container:

```python
>>> from nat.front_ends.fastapi.async_job import periodic_cleanup
ModuleNotFoundError: No module named 'nat.front_ends.fastapi.async_job'
>>> from nat.front_ends.fastapi.async_jobs import periodic_cleanup
<function periodic_cleanup at 0x7fc4bd98cfe0>
```

The env var additions give deployment operators a tool to bound worker memory growth proactively (via `--memory-limit` spill/restart) and to recycle workers on a fixed cadence (via `--lifetime --lifetime-restart`) without requiring container restarts.

## Changes

**`frontends/aiq_api/src/aiq_api/routes/jobs.py`**
- Line 622: `async_job` → `async_jobs` (one character)

**`deploy/entrypoint.py`**
- Read `DASK_MEMORY_LIMIT` and `DASK_LIFETIME` from env (both default unset)
- When set, append `--memory-limit <value>` and/or `--lifetime <seconds> --lifetime-restart` to the `dask-worker` args

## Test plan

- [ ] Existing tests pass (`test_periodic_cleanup.py` already mocks the import path and should continue to do so — verify the mock path matches)
- [ ] Verify locally with `DASK_MEMORY_LIMIT=800MB DASK_LIFETIME=3600` that the worker starts with those flags
- [ ] Verify periodic cleanup log line appears after start without the `No module named` warning
- [ ] Confirm in a long-running deployment that `job_info` row count stops growing unbounded

🤖 Generated with [Claude Code](https://claude.com/claude-code)