### PR TITLE
Bump authlib to >=1.6.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ dev = [
 [tool.uv]
 prerelease = "if-necessary-or-explicit"
 override-dependencies = [
-    "authlib>=1.6.9,<2",
+    "authlib>=1.6.11,<2",
     "cryptography>=46.0.6,<47",
     "pillow>=12.2.0,<13",
     "pygments>=2.20.0,<3",

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ members = [
     "tavily-web-search",
 ]
 overrides = [
-    { name = "authlib", specifier = ">=1.6.9,<2" },
+    { name = "authlib", specifier = ">=1.6.11,<2" },
     { name = "cryptography", specifier = ">=46.0.6,<47" },
     { name = "pillow", specifier = ">=12.2.0,<13" },
     { name = "pygments", specifier = ">=2.20.0,<3" },
@@ -567,14 +567,14 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.9"
+version = "1.6.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/10/b325d58ffe86815b399334a101e63bc6fa4e1953921cb23703b48a0a0220/authlib-1.6.11.tar.gz", hash = "sha256:64db35b9b01aeccb4715a6c9a6613a06f2bd7be2ab9d2eb89edd1dfc7580a38f", size = 165359, upload-time = "2026-04-16T07:22:50.279Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/57/2f/55fca558f925a51db046e5b929deb317ddb05afed74b22d89f4eca578980/authlib-1.6.11-py2.py3-none-any.whl", hash = "sha256:c8687a9a26451c51a34a06fa17bb97cb15bba46a6a626755e2d7f50da8bff3e3", size = 244469, upload-time = "2026-04-16T07:22:48.413Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Raise authlib floor to ≥1.6.11 (still <2) to address [GHSA-jj8c-mmj3-mmgv](https://github.com/advisories/GHSA-jj8c-mmj3-mmgv).
- Refresh uv.lock so installs resolve to authlib 1.6.11.