### PR TITLE
fix auth trust boundary and enforce async job ownership

### DIFF
--- a/deploy/compose/init-db.sql
+++ b/deploy/compose/init-db.sql
@@ -11,6 +11,7 @@
 --
 -- Tables in aiq_jobs:
 --   - job_info      — NAT JobStore metadata (status, timestamps, expiry)
+--   - job_access    — AIQ-owned job ownership/access control metadata
 --   - job_events    — SSE streaming events and job event persistence
 --   - summaries     — Document summaries (collection + filename keyed)
 --
@@ -50,6 +51,16 @@ CREATE TABLE IF NOT EXISTS job_info (
 
 CREATE INDEX IF NOT EXISTS idx_job_info_status ON job_info(status);
 CREATE INDEX IF NOT EXISTS idx_job_info_created_at ON job_info(created_at);
+
+CREATE TABLE IF NOT EXISTS job_access (
+    job_id VARCHAR PRIMARY KEY,
+    owner_auth_type VARCHAR NOT NULL,
+    owner_subject VARCHAR NOT NULL,
+    owner_email VARCHAR,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_access_owner ON job_access(owner_auth_type, owner_subject);
 
 -- Job events table (SSE streaming, event persistence)
 CREATE TABLE IF NOT EXISTS job_events (

--- a/deploy/helm/helm-charts-k8s/aiq/files/init-db.sql
+++ b/deploy/helm/helm-charts-k8s/aiq/files/init-db.sql
@@ -12,6 +12,7 @@
 --
 -- Tables in aiq_jobs:
 --   - job_info      — NAT JobStore metadata (status, timestamps, expiry)
+--   - job_access    — AIQ-owned job ownership/access control metadata
 --   - job_events    — SSE streaming events and job event persistence
 --   - summaries     — Document summaries (collection + filename keyed)
 --
@@ -51,6 +52,16 @@ CREATE TABLE IF NOT EXISTS job_info (
 
 CREATE INDEX IF NOT EXISTS idx_job_info_status ON job_info(status);
 CREATE INDEX IF NOT EXISTS idx_job_info_created_at ON job_info(created_at);
+
+CREATE TABLE IF NOT EXISTS job_access (
+    job_id VARCHAR PRIMARY KEY,
+    owner_auth_type VARCHAR NOT NULL,
+    owner_subject VARCHAR NOT NULL,
+    owner_email VARCHAR,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_access_owner ON job_access(owner_auth_type, owner_subject);
 
 -- Job events table (SSE streaming, event persistence)
 CREATE TABLE IF NOT EXISTS job_events (

--- a/frontends/aiq_api/src/aiq_api/auth/middleware.py
+++ b/frontends/aiq_api/src/aiq_api/auth/middleware.py
@@ -133,7 +133,6 @@ def _load_external_hostnames() -> set[str]:
 def is_external_request(headers: dict[bytes, bytes], external_hostnames: set[str] | None = None) -> bool:
     """Return ``True`` when the Host header matches an external-facing hostname."""
     host = headers.get(b"host", b"").decode().split(":")[0]
-    logger.info("Host: %s", host)
     return host in (external_hostnames or _load_external_hostnames())
 
 

--- a/frontends/aiq_api/src/aiq_api/auth/middleware.py
+++ b/frontends/aiq_api/src/aiq_api/auth/middleware.py
@@ -32,7 +32,7 @@ NAT workflow functions (which do not receive the ASGI ``Request`` object)
 can read the caller type without framework coupling.
 
     from aiq_api.auth.middleware import get_current_user
-    user = get_current_user()          # {"type": "internal"|"anonymous", ...}
+    user = get_current_user()          # {"type": "jwt"|"internal"|"anonymous"|...}
     skip = user.get("skip_clarifier")  # True / False
 
 ENVIRONMENT VARIABLES
@@ -60,6 +60,7 @@ ENVIRONMENT VARIABLES
 import json
 import logging
 import os
+from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any
 
@@ -86,6 +87,16 @@ def get_current_user() -> dict[str, Any]:
     the middleware is not registered or when called outside a request context.
     """
     return _current_user.get()
+
+
+@contextmanager
+def user_context(user: dict[str, Any]):
+    """Temporarily bind a resolved caller identity in the auth ContextVar."""
+    token = _current_user.set(user)
+    try:
+        yield
+    finally:
+        _current_user.reset(token)
 
 
 # ---------------------------------------------------------------------------
@@ -117,6 +128,52 @@ def _load_external_hostnames() -> set[str]:
     env = os.getenv("AIQ_EXTERNAL_HOSTNAMES", "")
     names = {h.strip() for h in env.split(",") if h.strip()}
     return names
+
+
+def is_external_request(headers: dict[bytes, bytes], external_hostnames: set[str] | None = None) -> bool:
+    """Return ``True`` when the Host header matches an external-facing hostname."""
+    host = headers.get(b"host", b"").decode().split(":")[0]
+    logger.info("Host: %s", host)
+    return host in (external_hostnames or _load_external_hostnames())
+
+
+def is_headless_request(headers: dict[bytes, bytes]) -> bool:
+    """Return ``True`` for headless callers that should skip the clarifier."""
+    return headers.get(b"x-aiq-mode", b"").decode().lower() == "headless"
+
+
+def extract_auth_token(headers: dict[bytes, bytes]) -> str | None:
+    """Extract a bearer token or idToken cookie from ASGI headers."""
+    auth = headers.get(b"authorization", b"").decode()
+    if auth.startswith("Bearer "):
+        return auth[7:]
+
+    cookie = headers.get(b"cookie", b"").decode()
+    for part in cookie.split(";"):
+        part = part.strip()
+        if part.startswith("idToken="):
+            return part[8:]
+    return None
+
+
+async def validate_token_with_validators(token: str, validators: list) -> dict[str, Any] | None:
+    """Try validators in order and return the first successful identity dict."""
+    for validator in validators:
+        if validator.can_handle(token):
+            user = await validator.validate(token)
+            if user is not None:
+                return user
+    logger.debug("Token rejected by all %d configured validator(s)", len(validators))
+    return None
+
+
+def detect_internal_caller(headers: dict[bytes, bytes]) -> dict[str, Any]:
+    """Classify an internal request without validating any presented token."""
+    token = extract_auth_token(headers)
+    headless = is_headless_request(headers)
+    if token:
+        return {"type": "unverified_jwt", "token": token, "skip_clarifier": headless}
+    return {"type": "internal", "skip_clarifier": headless}
 
 
 # ---------------------------------------------------------------------------
@@ -233,15 +290,11 @@ class AuthMiddleware:
             scope["state"] = {}
         scope["state"]["user"] = user
 
-        token = _current_user.set(user)
-        try:
+        with user_context(user):
             await self.app(scope, receive, send)
-        finally:
-            _current_user.reset(token)
 
     def _is_external(self, headers: dict[bytes, bytes]) -> bool:
-        host = headers.get(b"host", b"").decode().split(":")[0]
-        return host in self._external_hostnames
+        return is_external_request(headers, self._external_hostnames)
 
     def _path_allowed(self, path: str) -> bool:
         for allowed in EXTERNAL_ALLOWED_PATHS:
@@ -253,47 +306,17 @@ class AuthMiddleware:
         return False
 
     def _extract_token(self, headers: dict[bytes, bytes]) -> str | None:
-        auth = headers.get(b"authorization", b"").decode()
-        if auth.startswith("Bearer "):
-            return auth[7:]
-        # Fall back to idToken cookie (UI / browser callers)
-        cookie = headers.get(b"cookie", b"").decode()
-        for part in cookie.split(";"):
-            part = part.strip()
-            if part.startswith("idToken="):
-                return part[8:]
-        return None
+        return extract_auth_token(headers)
 
     def _is_headless(self, headers: dict[bytes, bytes]) -> bool:
-        return headers.get(b"x-aiq-mode", b"").decode().lower() == "headless"
+        return is_headless_request(headers)
 
     async def _validate_token(self, token: str) -> dict[str, Any] | None:
-        for validator in self._validators:
-            if validator.can_handle(token):
-                user = await validator.validate(token)
-                if user is not None:
-                    return user
-        logger.debug("Token rejected by all %d configured validator(s)", len(self._validators))
-        return None
+        return await validate_token_with_validators(token, self._validators)
 
     def _detect_internal_caller(self, headers: dict[bytes, bytes]) -> dict[str, Any]:
         """Classify an internal request without validating the token."""
-        auth = headers.get(b"authorization", b"").decode()
-        if auth.startswith("Bearer eyJ"):
-            token = auth[7:]
-            headless = self._is_headless(headers)
-            return {"type": "jwt", "token": token, "skip_clarifier": headless}
-
-        cookie = headers.get(b"cookie", b"").decode()
-        for part in cookie.split(";"):
-            part = part.strip()
-            if part.startswith("idToken="):
-                token = part[8:]
-                headless = self._is_headless(headers)
-                return {"type": "jwt", "token": token, "skip_clarifier": headless}
-
-        headless = self._is_headless(headers)
-        return {"type": "internal", "skip_clarifier": headless}
+        return detect_internal_caller(headers)
 
     @staticmethod
     async def _send_json(send: Send, status: int, body: dict) -> None:

--- a/frontends/aiq_api/src/aiq_api/auth/middleware.py
+++ b/frontends/aiq_api/src/aiq_api/auth/middleware.py
@@ -176,6 +176,41 @@ def detect_internal_caller(headers: dict[bytes, bytes]) -> dict[str, Any]:
     return {"type": "internal", "skip_clarifier": headless}
 
 
+async def resolve_request_user(
+    headers: dict[bytes, bytes],
+    *,
+    validators: list,
+    require_auth: bool,
+    external_hostnames: set[str] | None = None,
+) -> tuple[dict[str, Any] | None, int | None, bool]:
+    """Resolve request identity from validated credentials when present.
+
+    Returns a tuple of:
+      - resolved user dict, or None when the request should be rejected
+      - HTTP status code to use on rejection, or None on success
+      - whether the request was classified as external
+    """
+    is_external = is_external_request(headers, external_hostnames)
+    token = extract_auth_token(headers)
+
+    if token:
+        user = await validate_token_with_validators(token, validators)
+        if user is not None:
+            if is_headless_request(headers):
+                user["skip_clarifier"] = True
+            return user, None, is_external
+
+        if is_external and require_auth:
+            return None, 401, is_external
+
+    if is_external:
+        if not require_auth:
+            return {"type": "anonymous", "skip_clarifier": True}, None, is_external
+        return None, 401, is_external
+
+    return detect_internal_caller(headers), None, is_external
+
+
 # ---------------------------------------------------------------------------
 # Middleware
 # ---------------------------------------------------------------------------
@@ -235,43 +270,28 @@ class AuthMiddleware:
 
         headers = dict(scope.get("headers", []))
         path: str = scope["path"]
+        is_external = self._is_external(headers)
 
-        # 1. Internal traffic
-        if not self._is_external(headers):
-            user = self._detect_internal_caller(headers)
-            await self._call_app(scope, receive, send, user)
-            return
-
-        # 2. External — enforce path allowlist
-        if not self._path_allowed(path):
+        # External requests still honor the public path allowlist before auth.
+        if is_external and not self._path_allowed(path):
             await self._send_json(send, 404, {"detail": "Not found"})
             return
 
-        # 3. Auth-exempt paths
-        if path in AUTH_EXEMPT_PATHS:
+        if is_external and path in AUTH_EXEMPT_PATHS:
             user = {"type": "anonymous", "skip_clarifier": True}
             await self._call_app(scope, receive, send, user)
             return
 
-        # 4. Auth disabled — allow as anonymous
-        if not self.require_auth:
-            user = {"type": "anonymous", "skip_clarifier": True}
-            await self._call_app(scope, receive, send, user)
-            return
-
-        # 5. Auth enabled — require a valid JWT Bearer token
-        token = self._extract_token(headers)
-        if not token:
-            await self._send_json(send, 401, {"detail": "Missing auth token"})
-            return
-
-        user = await self._validate_token(token)
+        user, error_status, _ = await resolve_request_user(
+            headers,
+            validators=self._validators,
+            require_auth=self.require_auth,
+            external_hostnames=self._external_hostnames,
+        )
         if user is None:
-            await self._send_json(send, 401, {"detail": "Invalid or expired auth token"})
+            detail = "Invalid or expired auth token" if self._extract_token(headers) else "Missing auth token"
+            await self._send_json(send, error_status or 401, {"detail": detail})
             return
-
-        if self._is_headless(headers):
-            user["skip_clarifier"] = True
 
         await self._call_app(scope, receive, send, user)
 

--- a/frontends/aiq_api/src/aiq_api/jobs/__init__.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/__init__.py
@@ -13,46 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Async job infrastructure for AI-Q agents.
+"""Async job submodules for AI-Q."""
 
-This module provides agent-agnostic job execution infrastructure:
-- EventStore: SQLAlchemy-based event persistence for SSE streaming
-- AgentEventCallback: LangChain callback handler for event emission
-- run_agent_job: Dask task function for running any registered agent
-- submit_agent_job: Submit jobs from application code
-"""
-
-from .callbacks import AgentEventCallback
-from .callbacks import ArtifactType
-from .callbacks import EventCategory
-from .callbacks import EventData
-from .callbacks import EventState
-from .callbacks import IntermediateStepEvent
-from .callbacks import ToolArtifactMapping
-from .connection_manager import SSEConnectionManager
-from .connection_manager import get_connection_manager
-from .connection_manager import reset_connection_manager
-from .event_store import EventStore
-from .runner import CancellationMonitor
-from .runner import run_agent_job
-from .runner import run_with_cancellation
-from .submit import submit_agent_job
-
-__all__ = [
-    "AgentEventCallback",
-    "ArtifactType",
-    "CancellationMonitor",
-    "EventCategory",
-    "EventData",
-    "EventState",
-    "EventStore",
-    "IntermediateStepEvent",
-    "SSEConnectionManager",
-    "ToolArtifactMapping",
-    "get_connection_manager",
-    "reset_connection_manager",
-    "run_agent_job",
-    "run_with_cancellation",
-    "submit_agent_job",
-]
+__all__: list[str] = []

--- a/frontends/aiq_api/src/aiq_api/jobs/__init__.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/__init__.py
@@ -15,4 +15,11 @@
 
 """Async job submodules for AI-Q."""
 
-__all__: list[str] = []
+__all__ = [
+    "access",
+    "callbacks",
+    "connection_manager",
+    "event_store",
+    "runner",
+    "submit",
+]

--- a/frontends/aiq_api/src/aiq_api/jobs/access.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/access.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AIQ-owned async job access control helpers."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+from aiq_agent.auth import Principal
+from aiq_agent.auth import get_current_principal
+
+logger = logging.getLogger(__name__)
+
+_JOB_ACCESS_INDEX_SQL = "CREATE INDEX IF NOT EXISTS idx_job_access_owner ON job_access(owner_auth_type, owner_subject)"
+_JOB_ACCESS_SELECT_SQL = text(
+    "SELECT job_id, owner_auth_type, owner_subject, owner_email, created_at FROM job_access WHERE job_id = :job_id"
+)
+_JOB_ACCESS_DELETE_SQL = text("DELETE FROM job_access WHERE job_id = :job_id")
+_JOB_ACCESS_CLEANUP_SQL = text(
+    "DELETE FROM job_access "
+    "WHERE job_id NOT IN (SELECT job_id FROM job_info WHERE is_expired = false OR is_expired = 0)"
+)
+_JOB_INFO_DELETE_SQL = text("DELETE FROM job_info WHERE job_id = :job_id")
+_JOB_EVENTS_DELETE_SQL = text("DELETE FROM job_events WHERE job_id = :job_id")
+
+
+def _is_postgres(db_url: str) -> bool:
+    return db_url.startswith("postgres")
+
+
+def ensure_job_access_table(db_url: str) -> None:
+    """Create the AIQ-owned job access table if it does not exist."""
+    with _job_access_connection(db_url) as conn:
+        _ensure_job_access_schema(conn, db_url)
+        conn.commit()
+
+
+def create_job_access(job_id: str, principal: Principal, db_url: str) -> None:
+    """Persist the verified owner for a newly created job."""
+    with _job_access_connection(db_url) as conn:
+        _ensure_job_access_schema(conn, db_url)
+        conn.execute(_job_access_upsert_sql(db_url), _principal_params(job_id, principal))
+        conn.commit()
+
+
+def get_job_access(job_id: str, db_url: str) -> dict[str, Any] | None:
+    """Return job access metadata for a job."""
+    with _job_access_connection(db_url) as conn:
+        _ensure_job_access_schema(conn, db_url)
+        row = conn.execute(_JOB_ACCESS_SELECT_SQL, {"job_id": job_id}).mappings().first()
+    return dict(row) if row is not None else None
+
+
+def delete_job_access(job_id: str, db_url: str) -> int:
+    """Delete job access metadata for a specific job."""
+    with _job_access_connection(db_url) as conn:
+        _ensure_job_access_schema(conn, db_url)
+        result = conn.execute(_JOB_ACCESS_DELETE_SQL, {"job_id": job_id})
+        conn.commit()
+        return result.rowcount or 0
+
+
+def cleanup_job_access(db_url: str, conn: Connection | None = None) -> int:
+    """Delete access rows for expired or missing jobs."""
+    if conn is not None:
+        _ensure_job_access_schema(conn, db_url)
+        result = conn.execute(_JOB_ACCESS_CLEANUP_SQL)
+        return result.rowcount or 0
+
+    with _job_access_connection(db_url) as owned_conn:
+        _ensure_job_access_schema(owned_conn, db_url)
+        result = owned_conn.execute(_JOB_ACCESS_CLEANUP_SQL)
+        owned_conn.commit()
+        return result.rowcount or 0
+
+
+def rollback_job_submission(job_id: str, db_url: str) -> None:
+    """Best-effort rollback when ownership persistence fails after NAT job creation.
+
+    The submit path must not return an ownerless job ID. If job submission creates
+    NAT metadata but `job_access` cannot be written, remove the partial job state.
+    """
+    from .event_store import EventStore
+
+    EventStore._ensure_table_exists(db_url)
+    with _job_access_connection(db_url) as conn:
+        _ensure_job_access_schema(conn, db_url)
+        conn.execute(_JOB_ACCESS_DELETE_SQL, {"job_id": job_id})
+        conn.execute(_JOB_EVENTS_DELETE_SQL, {"job_id": job_id})
+        conn.execute(_JOB_INFO_DELETE_SQL, {"job_id": job_id})
+        conn.commit()
+
+
+def require_verified_principal() -> Principal:
+    """Return the verified request principal or raise a safe auth error."""
+    principal = get_current_principal()
+    if principal is None:
+        raise HTTPException(403, "Verified principal required for async job access")
+    return principal
+
+
+async def authorize_job_access(job_store: Any, db_url: str, job_id: str, principal: Principal) -> Any:
+    """Load a job only if the verified principal owns it."""
+    job = await job_store.get_job(job_id)
+    if not job:
+        raise HTTPException(404, f"Job not found: {job_id}")
+
+    access = get_job_access(job_id, db_url)
+    if access is None:
+        raise HTTPException(404, f"Job not found: {job_id}")
+
+    if not _principal_matches_access(principal, access):
+        raise HTTPException(404, f"Job not found: {job_id}")
+
+    return job
+
+
+def _principal_matches_access(principal: Principal, access: Mapping[str, Any]) -> bool:
+    return principal.type == access.get("owner_auth_type") and principal.sub == access.get("owner_subject")
+
+
+def _job_access_connection(db_url: str):
+    from .event_store import EventStore
+
+    engine = EventStore._get_or_create_sync_engine(db_url)
+    return engine.connect()
+
+
+def _ensure_job_access_schema(conn: Connection, db_url: str) -> None:
+    conn.execute(text(_job_access_table_sql(db_url)))
+    conn.execute(text(_JOB_ACCESS_INDEX_SQL))
+
+
+def _job_access_table_sql(db_url: str) -> str:
+    created_at_type = (
+        "TIMESTAMP WITH TIME ZONE DEFAULT NOW()" if _is_postgres(db_url) else "DATETIME DEFAULT CURRENT_TIMESTAMP"
+    )
+    return (
+        "CREATE TABLE IF NOT EXISTS job_access ("
+        "  job_id VARCHAR PRIMARY KEY,"
+        "  owner_auth_type VARCHAR NOT NULL,"
+        "  owner_subject VARCHAR NOT NULL,"
+        "  owner_email VARCHAR,"
+        f"  created_at {created_at_type}"
+        ")"
+    )
+
+
+def _job_access_upsert_sql(db_url: str):
+    postgres_upsert = (
+        "INSERT INTO job_access (job_id, owner_auth_type, owner_subject, owner_email) "
+        "VALUES (:job_id, :owner_auth_type, :owner_subject, :owner_email) "
+        "ON CONFLICT(job_id) DO UPDATE SET "
+        "owner_auth_type = excluded.owner_auth_type, "
+        "owner_subject = excluded.owner_subject, "
+        "owner_email = excluded.owner_email"
+    )
+    sqlite_upsert = (
+        "INSERT OR REPLACE INTO job_access (job_id, owner_auth_type, owner_subject, owner_email) "
+        "VALUES (:job_id, :owner_auth_type, :owner_subject, :owner_email)"
+    )
+    return text(postgres_upsert if _is_postgres(db_url) else sqlite_upsert)
+
+
+def _principal_params(job_id: str, principal: Principal) -> dict[str, str | None]:
+    return {
+        "job_id": job_id,
+        "owner_auth_type": principal.type,
+        "owner_subject": principal.sub,
+        "owner_email": principal.email,
+    }

--- a/frontends/aiq_api/src/aiq_api/jobs/access.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/access.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import os
 from collections.abc import Mapping
 from typing import Any
 
@@ -108,21 +110,59 @@ def rollback_job_submission(job_id: str, db_url: str) -> None:
         conn.commit()
 
 
+def _make_no_auth_principal(owner: str | None = None) -> Principal:
+    """Synthesize a principal for deployments with auth disabled (REQUIRE_AUTH=false).
+
+    Uses the middleware caller type as the principal type.  When an owner
+    identifier is provided it becomes the subject (useful for programmatic
+    job submission); otherwise the caller type is used as a stable subject.
+    """
+    try:
+        from aiq_api.auth.middleware import get_current_user
+
+        current_user = get_current_user()
+    except Exception:
+        current_user = {}
+
+    principal_type = str(current_user.get("type") or "anonymous")
+    subject = owner if owner else principal_type
+    email = owner if owner and "@" in owner else None
+    return Principal(type=principal_type, sub=subject, email=email)
+
+
 def require_verified_principal() -> Principal:
-    """Return the verified request principal or raise a safe auth error."""
+    """Return the verified request principal or raise a safe auth error.
+
+    When auth is disabled (REQUIRE_AUTH != true), synthesizes a principal
+    from the middleware caller identity so no-auth deployments can still
+    access async jobs.
+    """
     principal = get_current_principal()
-    if principal is None:
+    if principal is not None:
+        return principal
+
+    if os.environ.get("REQUIRE_AUTH", "false").lower() == "true":
         raise HTTPException(403, "Verified principal required for async job access")
-    return principal
+
+    return _make_no_auth_principal()
 
 
 async def authorize_job_access(job_store: Any, db_url: str, job_id: str, principal: Principal) -> Any:
-    """Load a job only if the verified principal owns it."""
+    """Load a job, enforcing ownership when auth is enabled.
+
+    When REQUIRE_AUTH=false, ownership is not enforced — any caller may access
+    any existing job.  Ownership records are still written at submit time for
+    audit purposes and to support future auth enablement without data migration.
+    """
     job = await job_store.get_job(job_id)
     if not job:
         raise HTTPException(404, f"Job not found: {job_id}")
 
-    access = get_job_access(job_id, db_url)
+    if os.environ.get("REQUIRE_AUTH", "false").lower() != "true":
+        return job
+
+    loop = asyncio.get_running_loop()
+    access = await loop.run_in_executor(None, get_job_access, job_id, db_url)
     if access is None:
         raise HTTPException(404, f"Job not found: {job_id}")
 

--- a/frontends/aiq_api/src/aiq_api/jobs/access.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/access.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Mapping
 from typing import Any
 
@@ -28,7 +27,7 @@ from sqlalchemy.engine import Connection
 from aiq_agent.auth import Principal
 from aiq_agent.auth import get_current_principal
 
-logger = logging.getLogger(__name__)
+_job_access_schema_initialized: set[str] = set()
 
 _JOB_ACCESS_INDEX_SQL = "CREATE INDEX IF NOT EXISTS idx_job_access_owner ON job_access(owner_auth_type, owner_subject)"
 _JOB_ACCESS_SELECT_SQL = text(
@@ -36,8 +35,7 @@ _JOB_ACCESS_SELECT_SQL = text(
 )
 _JOB_ACCESS_DELETE_SQL = text("DELETE FROM job_access WHERE job_id = :job_id")
 _JOB_ACCESS_CLEANUP_SQL = text(
-    "DELETE FROM job_access "
-    "WHERE job_id NOT IN (SELECT job_id FROM job_info WHERE is_expired = false OR is_expired = 0)"
+    "DELETE FROM job_access WHERE job_id NOT IN (SELECT job_id FROM job_info WHERE is_expired IS NOT TRUE)"
 )
 _JOB_INFO_DELETE_SQL = text("DELETE FROM job_info WHERE job_id = :job_id")
 _JOB_EVENTS_DELETE_SQL = text("DELETE FROM job_events WHERE job_id = :job_id")
@@ -67,7 +65,7 @@ def get_job_access(job_id: str, db_url: str) -> dict[str, Any] | None:
     with _job_access_connection(db_url) as conn:
         _ensure_job_access_schema(conn, db_url)
         row = conn.execute(_JOB_ACCESS_SELECT_SQL, {"job_id": job_id}).mappings().first()
-    return dict(row) if row is not None else None
+        return dict(row) if row is not None else None
 
 
 def delete_job_access(job_id: str, db_url: str) -> int:
@@ -146,8 +144,11 @@ def _job_access_connection(db_url: str):
 
 
 def _ensure_job_access_schema(conn: Connection, db_url: str) -> None:
+    if db_url in _job_access_schema_initialized:
+        return
     conn.execute(text(_job_access_table_sql(db_url)))
     conn.execute(text(_JOB_ACCESS_INDEX_SQL))
+    _job_access_schema_initialized.add(db_url)
 
 
 def _job_access_table_sql(db_url: str) -> str:

--- a/frontends/aiq_api/src/aiq_api/jobs/submit.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/submit.py
@@ -29,6 +29,7 @@ from aiq_agent.auth import Principal
 from aiq_agent.auth import get_current_principal
 
 from ..registry import get_agent_config
+from .access import _make_no_auth_principal
 from .access import create_job_access
 from .access import rollback_job_submission
 from .runner import run_agent_job
@@ -39,9 +40,9 @@ logger = logging.getLogger(__name__)
 def _resolve_submission_principal(owner: str) -> Principal | None:
     """Resolve the best available principal for async job ownership.
 
-    Verified middleware identity remains the preferred source. For deployments
-    with auth disabled, fall back to a compatibility principal so legacy
-    internal/anonymous flows can still submit async jobs.
+    Used only when submit_agent_job is called programmatically without an
+    explicit principal.  Verified middleware identity is preferred; falls back
+    to a compatibility principal when auth is disabled.
     """
     principal = get_current_principal()
     if principal is not None:
@@ -50,17 +51,7 @@ def _resolve_submission_principal(owner: str) -> Principal | None:
     if os.environ.get("REQUIRE_AUTH", "false").lower() == "true":
         return None
 
-    try:
-        from aiq_api.auth.middleware import get_current_user
-
-        current_user = get_current_user()
-    except Exception:
-        current_user = {}
-
-    principal_type = str(current_user.get("type") or "anonymous")
-    subject = owner if owner else principal_type
-    email = owner if "@" in owner else None
-    return Principal(type=principal_type, sub=subject, email=email)
+    return _make_no_auth_principal(owner)
 
 
 def _get_parent_trace_context() -> tuple[

--- a/frontends/aiq_api/src/aiq_api/jobs/submit.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/submit.py
@@ -21,6 +21,7 @@ Provides functions to submit agent jobs to the Dask cluster.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 
@@ -218,6 +219,7 @@ async def submit_agent_job(
 
     job_store = JobStore(scheduler_address=scheduler_address, db_url=db_url)
     resolved_job_id = job_store.ensure_job_id(job_id)
+    loop = asyncio.get_running_loop()
 
     try:
         await job_store.submit_job(
@@ -240,10 +242,10 @@ async def submit_agent_job(
                 auth_token,
             ],
         )
-        create_job_access(resolved_job_id, principal, db_url)
+        await loop.run_in_executor(None, create_job_access, resolved_job_id, principal, db_url)
     except Exception:
         try:
-            rollback_job_submission(resolved_job_id, db_url)
+            await loop.run_in_executor(None, rollback_job_submission, resolved_job_id, db_url)
             logger.warning(
                 "Rolled back partial async job submission for %s after access persistence failure. "
                 "The Dask worker may still be running and should be investigated if it continues writing state.",

--- a/frontends/aiq_api/src/aiq_api/jobs/submit.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/submit.py
@@ -35,6 +35,33 @@ from .runner import run_agent_job
 logger = logging.getLogger(__name__)
 
 
+def _resolve_submission_principal(owner: str) -> Principal | None:
+    """Resolve the best available principal for async job ownership.
+
+    Verified middleware identity remains the preferred source. For deployments
+    with auth disabled, fall back to a compatibility principal so legacy
+    internal/anonymous flows can still submit async jobs.
+    """
+    principal = get_current_principal()
+    if principal is not None:
+        return principal
+
+    if os.environ.get("REQUIRE_AUTH", "false").lower() == "true":
+        return None
+
+    try:
+        from aiq_api.auth.middleware import get_current_user
+
+        current_user = get_current_user()
+    except Exception:
+        current_user = {}
+
+    principal_type = str(current_user.get("type") or "anonymous")
+    subject = owner if owner else principal_type
+    email = owner if "@" in owner else None
+    return Principal(type=principal_type, sub=subject, email=email)
+
+
 def _get_parent_trace_context() -> tuple[
     str | None,  # parent_span_id
     str | None,  # parent_function_id
@@ -185,7 +212,7 @@ async def submit_agent_job(
         auth_token = get_auth_token()
 
     if principal is None:
-        principal = get_current_principal()
+        principal = _resolve_submission_principal(owner)
     if principal is None:
         raise RuntimeError("Verified current principal required for async job submission")
 
@@ -217,6 +244,11 @@ async def submit_agent_job(
     except Exception:
         try:
             rollback_job_submission(resolved_job_id, db_url)
+            logger.warning(
+                "Rolled back partial async job submission for %s after access persistence failure. "
+                "The Dask worker may still be running and should be investigated if it continues writing state.",
+                resolved_job_id,
+            )
         except Exception as cleanup_error:
             logger.warning(
                 "Failed to roll back partial async job submission for %s after access persistence failure: %s",

--- a/frontends/aiq_api/src/aiq_api/jobs/submit.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/submit.py
@@ -24,7 +24,12 @@ from __future__ import annotations
 import logging
 import os
 
+from aiq_agent.auth import Principal
+from aiq_agent.auth import get_current_principal
+
 from ..registry import get_agent_config
+from .access import create_job_access
+from .access import rollback_job_submission
 from .runner import run_agent_job
 
 logger = logging.getLogger(__name__)
@@ -87,6 +92,7 @@ async def submit_agent_job(
     agent_type: str,
     input_text: str,
     owner: str,
+    principal: Principal | None = None,
     job_id: str | None = None,
     expiry_seconds: int = 86400,
     available_documents: list[dict] | None = None,
@@ -103,6 +109,7 @@ async def submit_agent_job(
         agent_type: Agent type identifier (e.g., 'deep_researcher').
         input_text: The user's query/request.
         owner: Owner email for the job.
+        principal: Verified principal that owns the job.
         job_id: Optional custom job ID.
         expiry_seconds: Job expiry time in seconds (default 24h).
         available_documents: Optional list of document dicts with file_name and summary.
@@ -177,35 +184,54 @@ async def submit_agent_job(
 
         auth_token = get_auth_token()
 
+    if principal is None:
+        principal = get_current_principal()
+    if principal is None:
+        raise RuntimeError("Verified current principal required for async job submission")
+
     job_store = JobStore(scheduler_address=scheduler_address, db_url=db_url)
     resolved_job_id = job_store.ensure_job_id(job_id)
 
-    await job_store.submit_job(
-        job_id=resolved_job_id,
-        expiry_seconds=expiry_seconds,
-        job_fn=run_agent_job,
-        job_args=[
-            not use_threads,  # configure_logging
-            log_level,
-            scheduler_address,
-            db_url,
-            config_path,
-            resolved_job_id,
-            input_text,
-            agent_config.class_path,
-            agent_config.config_name,
-            *_get_parent_trace_context(),
-            available_documents,
-            data_sources,
-            auth_token,
-        ],
-    )
+    try:
+        await job_store.submit_job(
+            job_id=resolved_job_id,
+            expiry_seconds=expiry_seconds,
+            job_fn=run_agent_job,
+            job_args=[
+                not use_threads,  # configure_logging
+                log_level,
+                scheduler_address,
+                db_url,
+                config_path,
+                resolved_job_id,
+                input_text,
+                agent_config.class_path,
+                agent_config.config_name,
+                *_get_parent_trace_context(),
+                available_documents,
+                data_sources,
+                auth_token,
+            ],
+        )
+        create_job_access(resolved_job_id, principal, db_url)
+    except Exception:
+        try:
+            rollback_job_submission(resolved_job_id, db_url)
+        except Exception as cleanup_error:
+            logger.warning(
+                "Failed to roll back partial async job submission for %s after access persistence failure: %s",
+                resolved_job_id,
+                cleanup_error,
+            )
+        raise
 
     logger.info(
-        "Submitted %s job %s for owner %s",
+        "Submitted %s job %s for owner %s (%s:%s)",
         agent_type,
         resolved_job_id,
         owner,
+        principal.type,
+        principal.sub,
     )
     return resolved_job_id
 

--- a/frontends/aiq_api/src/aiq_api/plugin.py
+++ b/frontends/aiq_api/src/aiq_api/plugin.py
@@ -53,11 +53,12 @@ from nat.front_ends.fastapi.fastapi_front_end_plugin import FastApiFrontEndPlugi
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontEndPluginWorker
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontEndPluginWorkerBase
 
-from .jobs import EventStore
-from .jobs import get_connection_manager
+from .jobs.connection_manager import get_connection_manager
+from .jobs.event_store import EventStore
 from .routes.collections import add_collection_routes
 from .routes.documents import add_document_routes
 from .routes.jobs import register_job_routes
+from .websocket_reconnect import configure_websocket_auth
 from .websocket_reconnect import install_reconnectable_handler
 
 logger = logging.getLogger(__name__)
@@ -215,6 +216,7 @@ class AIQAPIWorker(FastApiFrontEndPluginWorker):
                 "or declare an 'aiq_api.validators' entry point in your package."
             )
         app.add_middleware(AuthMiddleware, validators=validators, require_auth=require_auth)
+        configure_websocket_auth(validators=validators, require_auth=require_auth)
         logger.info(
             "AuthMiddleware registered (require_auth=%s, validators=%s)",
             require_auth,

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -36,7 +36,6 @@ from typing import TYPE_CHECKING
 
 from fastapi import FastAPI
 from fastapi import HTTPException
-from fastapi import Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from pydantic import ConfigDict
@@ -163,8 +162,11 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
     from aiq_agent.common.data_source_registry import get_all_sources
     from nat.front_ends.fastapi.async_jobs.job_store import JobStatus
 
-    from ..jobs import EventStore
-    from ..jobs.runner import run_agent_job
+    from ..jobs.access import authorize_job_access
+    from ..jobs.access import ensure_job_access_table
+    from ..jobs.access import require_verified_principal
+    from ..jobs.event_store import EventStore
+    from ..jobs.submit import submit_agent_job as submit_authorized_job
 
     if not get_all_sources():
         logger.warning(
@@ -237,13 +239,14 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         db_url[:50],
         default_expiry_seconds,
     )
+    ensure_job_access_table(db_url)
 
     @app.get("/health", tags=["health"], summary="Health check")
     async def health_check():
         """Health check endpoint that validates DB connectivity."""
         from sqlalchemy import text
 
-        from ..jobs import EventStore
+        from ..jobs.event_store import EventStore
 
         result = {"status": "ok", "dask_available": dask_available, "db": "ok"}
 
@@ -279,50 +282,44 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
             503: {"description": "Dask scheduler not available"},
         },
     )
-    async def submit_job(req: JobSubmitRequest, request: Request) -> JobStatusResponse:
+    async def submit_job(req: JobSubmitRequest) -> JobStatusResponse:
         """Submit a new async job for deep research or other registered agents."""
         try:
-            agent_config = get_agent_config(req.agent_type)
+            get_agent_config(req.agent_type)
         except KeyError as e:
             raise HTTPException(400, str(e))
 
-        resolved_job_id = job_store.ensure_job_id(req.job_id)
         expiry = req.expiry_seconds if req.expiry_seconds is not None else default_expiry_seconds
+        principal = require_verified_principal()
 
         # Propagate auth token to Dask worker for requires_auth data sources
         from aiq_agent.auth import get_auth_token
 
         auth_token = get_auth_token()
+        try:
+            job_id = await submit_authorized_job(
+                agent_type=req.agent_type,
+                input_text=req.input,
+                owner=principal.email or principal.sub,
+                principal=principal,
+                job_id=req.job_id,
+                expiry_seconds=expiry,
+                auth_token=auth_token,
+            )
+        except RuntimeError as e:
+            raise HTTPException(403, str(e))
+        except Exception as e:
+            logger.warning("Failed to submit authorized job: %s", e)
+            raise HTTPException(500, "Failed to persist async job authorization metadata")
 
-        job_args = [
-            not use_threads,  # configure_logging
-            log_level,
-            scheduler_address,
-            db_url,
-            config_path,
-            resolved_job_id,
-            req.input,
-            agent_config.class_path,
-            agent_config.config_name,
-            None,  # parent_span_id
-            None,  # parent_function_id
-            None,  # parent_function_name
-            None,  # parent_workflow_run_id
-            None,  # parent_workflow_trace_id
-            None,  # parent_conversation_id
-            None,  # available_documents
-            None,  # data_sources
-            auth_token,  # auth_token
-        ]
-
-        job_id, _ = await job_store.submit_job(
-            job_id=resolved_job_id,
-            expiry_seconds=expiry,
-            job_fn=run_agent_job,
-            job_args=job_args,
+        logger.info(
+            "Submitted %s job %s (expiry=%ds) for principal %s:%s",
+            req.agent_type,
+            job_id,
+            expiry,
+            principal.type,
+            principal.sub,
         )
-
-        logger.info("Submitted %s job %s (expiry=%ds)", req.agent_type, job_id, expiry)
         return JobStatusResponse(
             job_id=job_id,
             status=JobStatus.SUBMITTED.value,
@@ -337,11 +334,10 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         description="Get the current status of an async job by its ID.",
         responses={404: {"description": "Job not found"}},
     )
-    async def get_job_status(job_id: str, request: Request) -> JobStatusResponse:
+    async def get_job_status(job_id: str) -> JobStatusResponse:
         """Get the current status of a job."""
-        job = await job_store.get_job(job_id)
-        if not job:
-            raise HTTPException(404, f"Job not found: {job_id}")
+        principal = require_verified_principal()
+        job = await authorize_job_access(job_store, db_url, job_id, principal)
 
         return JobStatusResponse(
             job_id=job_id,
@@ -360,11 +356,10 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         ),
         responses={404: {"description": "Job not found"}},
     )
-    async def stream_job_events(job_id: str, request: Request) -> StreamingResponse:
+    async def stream_job_events(job_id: str) -> StreamingResponse:
         """SSE stream for job events from beginning."""
-        job = await job_store.get_job(job_id)
-        if not job:
-            raise HTTPException(404, f"Job not found: {job_id}")
+        principal = require_verified_principal()
+        await authorize_job_access(job_store, db_url, job_id, principal)
 
         return StreamingResponse(
             _sse_generator(job_store, job_id, db_url, start_event_id=0),
@@ -379,11 +374,10 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         description="Resume an SSE stream from a specific event ID. Use for reconnection after network interruption.",
         responses={404: {"description": "Job not found"}},
     )
-    async def stream_job_events_from(job_id: str, last_event_id: int, request: Request) -> StreamingResponse:
+    async def stream_job_events_from(job_id: str, last_event_id: int) -> StreamingResponse:
         """SSE stream for job events from specific event ID (for reconnection)."""
-        job = await job_store.get_job(job_id)
-        if not job:
-            raise HTTPException(404, f"Job not found: {job_id}")
+        principal = require_verified_principal()
+        await authorize_job_access(job_store, db_url, job_id, principal)
 
         return StreamingResponse(
             _sse_generator(job_store, job_id, db_url, start_event_id=last_event_id),
@@ -401,11 +395,10 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
             404: {"description": "Job not found"},
         },
     )
-    async def cancel_job(job_id: str, request: Request) -> dict:
+    async def cancel_job(job_id: str) -> dict:
         """Cancel a running job."""
-        job = await job_store.get_job(job_id)
-        if not job:
-            raise HTTPException(404, f"Job not found: {job_id}")
+        principal = require_verified_principal()
+        job = await authorize_job_access(job_store, db_url, job_id, principal)
 
         if job.status != JobStatus.RUNNING.value:
             raise HTTPException(400, f"Job not running: {job_id} (status: {job.status})")
@@ -434,11 +427,10 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         description="Get tool calls, outputs, and sources collected during job execution.",
         responses={404: {"description": "Job not found"}},
     )
-    async def get_job_state(job_id: str, request: Request) -> JobStateResponse:
+    async def get_job_state(job_id: str) -> JobStateResponse:
         """Get artifacts from event store."""
-        job = await job_store.get_job(job_id)
-        if not job:
-            raise HTTPException(404, f"Job not found: {job_id}")
+        principal = require_verified_principal()
+        await authorize_job_access(job_store, db_url, job_id, principal)
 
         artifacts = await _get_job_artifacts(db_url, job_id)
         return JobStateResponse(
@@ -456,11 +448,10 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         description="Get the final research report from a completed job.",
         responses={404: {"description": "Job not found"}},
     )
-    async def get_job_report(job_id: str, request: Request) -> JobReportResponse:
+    async def get_job_report(job_id: str) -> JobReportResponse:
         """Get the final report from a completed job."""
-        job = await job_store.get_job(job_id)
-        if not job:
-            raise HTTPException(404, f"Job not found: {job_id}")
+        principal = require_verified_principal()
+        job = await authorize_job_access(job_store, db_url, job_id, principal)
 
         report = None
         if job.output:
@@ -499,7 +490,7 @@ def _find_stale_jobs(db_url: str, running_status: str) -> list[str]:
     from sqlalchemy import inspect
     from sqlalchemy import text
 
-    from ..jobs import EventStore
+    from ..jobs.event_store import EventStore
 
     EventStore._ensure_table_exists(db_url)
     engine = EventStore._get_or_create_sync_engine(db_url)
@@ -544,7 +535,7 @@ async def _reap_ghost_jobs(job_store, db_url: str) -> None:
     """
     from nat.front_ends.fastapi.async_jobs.job_store import JobStatus
 
-    from ..jobs import EventStore
+    from ..jobs.event_store import EventStore
 
     logger.info(
         "Ghost job reaper started (timeout=%ds, interval=%ds)",
@@ -704,11 +695,12 @@ async def _run_event_cleanup(db_url: str, retention_seconds: int, is_postgres: b
     so concurrent pods skip the cycle rather than doing redundant work. The lock is
     automatically released on commit/rollback, avoiding leak risks.
     """
-    from ..jobs import EventStore
+    from ..jobs.access import cleanup_job_access
+    from ..jobs.event_store import EventStore
 
     loop = asyncio.get_running_loop()
 
-    def _do_cleanup() -> tuple[int, int]:
+    def _do_cleanup() -> tuple[int, int, int]:
         from sqlalchemy import text
 
         engine = EventStore._get_or_create_sync_engine(db_url)
@@ -723,7 +715,7 @@ async def _run_event_cleanup(db_url: str, retention_seconds: int, is_postgres: b
                     {"lock_id": _PG_ADVISORY_LOCK_ID},
                 ).scalar()
                 if not locked:
-                    return (0, 0)
+                    return (0, 0, 0)
 
             # 1. Time-based: delete events older than retention period
             if is_postgres:
@@ -745,17 +737,19 @@ async def _run_event_cleanup(db_url: str, retention_seconds: int, is_postgres: b
                 text("DELETE FROM job_events WHERE job_id IN (SELECT job_id FROM job_info WHERE is_expired = true)")
             )
             expired_deleted = expired_result.rowcount
+            access_deleted = cleanup_job_access(db_url, conn=conn)
 
             conn.commit()
-            return (time_deleted, expired_deleted)
+            return (time_deleted, expired_deleted, access_deleted)
 
-    time_deleted, expired_deleted = await loop.run_in_executor(None, _do_cleanup)
+    time_deleted, expired_deleted, access_deleted = await loop.run_in_executor(None, _do_cleanup)
 
-    if time_deleted > 0 or expired_deleted > 0:
+    if time_deleted > 0 or expired_deleted > 0 or access_deleted > 0:
         logger.info(
-            "Event cleanup: %d old events removed, %d events for expired jobs removed",
+            "Event cleanup: %d old events removed, %d events for expired jobs removed, %d access rows removed",
             time_deleted,
             expired_deleted,
+            access_deleted,
         )
 
 
@@ -925,7 +919,7 @@ async def _get_job_artifacts(db_url: str, job_id: str) -> dict | None:
     Returns:
         Dict with 'tools', 'outputs', and 'sources' (counts), or None if no artifacts found.
     """
-    from ..jobs import EventStore
+    from ..jobs.event_store import EventStore
 
     try:
         events = await EventStore.get_events_async(db_url, job_id, 0, 10000)
@@ -976,7 +970,7 @@ async def _sse_generator(job_store, job_id: str, db_url: str, start_event_id: in
     PostgreSQL: Uses LISTEN/NOTIFY for real-time push-based events (sub-10ms latency).
     SQLite: Uses polling (0.5s interval) since SQLite doesn't support pub-sub.
     """
-    from ..jobs import EventStore
+    from ..jobs.event_store import EventStore
 
     if EventStore.is_postgres(db_url):
         try:
@@ -1004,8 +998,8 @@ async def _sse_generator_postgres(job_store, job_id: str, db_url: str, start_eve
 
     from nat.front_ends.fastapi.async_jobs.job_store import JobStatus
 
-    from ..jobs import EventStore
-    from ..jobs import get_connection_manager
+    from ..jobs.connection_manager import get_connection_manager
+    from ..jobs.event_store import EventStore
 
     connection_manager = get_connection_manager()
     last_status = None
@@ -1188,8 +1182,8 @@ async def _sse_generator_polling(job_store, job_id: str, db_url: str, start_even
 
     from nat.front_ends.fastapi.async_jobs.job_store import JobStatus
 
-    from ..jobs import EventStore
-    from ..jobs import get_connection_manager
+    from ..jobs.connection_manager import get_connection_manager
+    from ..jobs.event_store import EventStore
 
     connection_manager = get_connection_manager()
     last_status = None

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -239,7 +239,7 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         db_url[:50],
         default_expiry_seconds,
     )
-    ensure_job_access_table(db_url)
+    await asyncio.get_running_loop().run_in_executor(None, ensure_job_access_table, db_url)
 
     @app.get("/health", tags=["health"], summary="Health check")
     async def health_check():

--- a/frontends/aiq_api/src/aiq_api/websocket_reconnect.py
+++ b/frontends/aiq_api/src/aiq_api/websocket_reconnect.py
@@ -28,11 +28,8 @@ from pydantic import ValidationError
 from starlette.websockets import WebSocketDisconnect
 
 from aiq_api.auth.middleware import detect_internal_caller
-from aiq_api.auth.middleware import extract_auth_token
-from aiq_api.auth.middleware import is_external_request
-from aiq_api.auth.middleware import is_headless_request
+from aiq_api.auth.middleware import resolve_request_user
 from aiq_api.auth.middleware import user_context
-from aiq_api.auth.middleware import validate_token_with_validators
 from nat.data_models.api_server import Error
 from nat.data_models.api_server import ErrorTypes
 from nat.data_models.api_server import ResponseObservabilityTrace
@@ -79,25 +76,22 @@ def configure_websocket_auth(
 async def authenticate_websocket_connection(socket: WebSocket) -> tuple[dict[str, Any] | None, int | None]:
     """Resolve the caller identity for a WebSocket handshake."""
     headers = dict(socket.scope.get("headers", []))
-    token = extract_auth_token(headers)
+    user, error_status, is_external = await resolve_request_user(
+        headers,
+        validators=_auth_validators,
+        require_auth=_require_auth,
+        external_hostnames=_external_hostnames,
+    )
+    if user is not None:
+        return user, None
 
-    if not is_external_request(headers, _external_hostnames):
+    if not is_external:
         return detect_internal_caller(headers), None
 
-    if not _require_auth:
-        return {"type": "anonymous", "skip_clarifier": True}, None
-
-    if not token:
+    if error_status == 401:
         return None, WS_POLICY_VIOLATION
 
-    user = await validate_token_with_validators(token, _auth_validators)
-    if user is None:
-        return None, WS_POLICY_VIOLATION
-
-    if is_headless_request(headers):
-        user["skip_clarifier"] = True
-
-    return user, None
+    return None, WS_POLICY_VIOLATION
 
 
 class WebSocketSessionRegistry:

--- a/frontends/aiq_api/src/aiq_api/websocket_reconnect.py
+++ b/frontends/aiq_api/src/aiq_api/websocket_reconnect.py
@@ -27,6 +27,12 @@ from pydantic import BaseModel
 from pydantic import ValidationError
 from starlette.websockets import WebSocketDisconnect
 
+from aiq_api.auth.middleware import detect_internal_caller
+from aiq_api.auth.middleware import extract_auth_token
+from aiq_api.auth.middleware import is_external_request
+from aiq_api.auth.middleware import is_headless_request
+from aiq_api.auth.middleware import user_context
+from aiq_api.auth.middleware import validate_token_with_validators
 from nat.data_models.api_server import Error
 from nat.data_models.api_server import ErrorTypes
 from nat.data_models.api_server import ResponseObservabilityTrace
@@ -44,10 +50,54 @@ from nat.data_models.interactive import HumanPromptNotification
 from nat.data_models.interactive import HumanResponse
 from nat.data_models.interactive import HumanResponseNotification
 from nat.data_models.interactive import InteractionPrompt
+from nat.front_ends.fastapi.auth_flow_handlers.websocket_flow_handler import WebSocketAuthenticationFlowHandler
 from nat.front_ends.fastapi.message_handler import WebSocketMessageHandler
 from nat.front_ends.fastapi.response_helpers import generate_streaming_response
 
 logger = logging.getLogger(__name__)
+
+_auth_validators: list = []
+_require_auth = False
+_external_hostnames: set[str] | None = None
+WS_POLICY_VIOLATION = 1008
+SESSION_COOKIE_NAME = "nat-session"
+
+
+def configure_websocket_auth(
+    *,
+    validators: list | None = None,
+    require_auth: bool = False,
+    external_hostnames: set[str] | None = None,
+) -> None:
+    """Configure WebSocket auth to mirror the HTTP middleware validator chain."""
+    global _auth_validators, _require_auth, _external_hostnames
+    _auth_validators = list(validators or [])
+    _require_auth = require_auth
+    _external_hostnames = external_hostnames
+
+
+async def authenticate_websocket_connection(socket: WebSocket) -> tuple[dict[str, Any] | None, int | None]:
+    """Resolve the caller identity for a WebSocket handshake."""
+    headers = dict(socket.scope.get("headers", []))
+    token = extract_auth_token(headers)
+
+    if not is_external_request(headers, _external_hostnames):
+        return detect_internal_caller(headers), None
+
+    if not _require_auth:
+        return {"type": "anonymous", "skip_clarifier": True}, None
+
+    if not token:
+        return None, WS_POLICY_VIOLATION
+
+    user = await validate_token_with_validators(token, _auth_validators)
+    if user is None:
+        return None, WS_POLICY_VIOLATION
+
+    if is_headless_request(headers):
+        user["skip_clarifier"] = True
+
+    return user, None
 
 
 class WebSocketSessionRegistry:
@@ -156,9 +206,16 @@ class ReconnectableWebSocketMessageHandler(WebSocketMessageHandler):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._user_interaction_response: asyncio.Future[TextContent] | None = None
+        self._authenticated_user: dict[str, Any] | None = None
 
     async def run(self) -> None:
         """Process websocket messages and allow reconnect HITL responses."""
+        if self._authenticated_user is None:
+            self._authenticated_user, close_code = await authenticate_websocket_connection(self._socket)
+            if close_code is not None:
+                await self._socket.close(code=close_code)
+                return
+
         while True:
             try:
                 message: dict[str, Any] = await self._socket.receive_json()
@@ -211,7 +268,9 @@ class ReconnectableWebSocketMessageHandler(WebSocketMessageHandler):
     async def process_workflow_request(self, user_message_as_validated_type: WebSocketUserMessage) -> None:
         """Process user messages and register sockets for reconnect."""
         await _registry.set_socket(user_message_as_validated_type.conversation_id, self._socket)
-        await super().process_workflow_request(user_message_as_validated_type)
+        current_user = self._authenticated_user or detect_internal_caller(dict(self._socket.scope.get("headers", [])))
+        with user_context(current_user):
+            await super().process_workflow_request(user_message_as_validated_type)
         # TODO(NAT-upstream): _running_workflow_task is currently always None
         # because NAT's message_handler.py assigns via method chaining:
         #   self._running_workflow_task = asyncio.create_task(...).add_done_callback(cb)
@@ -346,46 +405,48 @@ class ReconnectableWebSocketMessageHandler(WebSocketMessageHandler):
         output_type: type | None = None,
     ) -> None:
         """Run the workflow without breaking reconnect message delivery."""
-        try:
-            auth_callback = self._flow_handler.authenticate if self._flow_handler else None
-            async with self._session_manager.session(
-                user_message_id=user_message_id,
-                conversation_id=conversation_id,
-                http_connection=self._socket,
-                user_input_callback=self.human_interaction_callback,
-                user_authentication_callback=auth_callback,
-            ) as session:
-                async for value in generate_streaming_response(
-                    payload,
-                    session=session,
-                    streaming=True,
-                    step_adaptor=self._step_adaptor,
-                    result_type=result_type,
-                    output_type=output_type,
-                ):
-                    if isinstance(value, ResponseObservabilityTrace):
-                        if self._pending_observability_trace is None:
-                            self._pending_observability_trace = value
-                    else:
-                        await self.create_websocket_message(
-                            data_model=value,
-                            status=WebSocketMessageStatus.IN_PROGRESS,
-                        )
+        current_user = self._authenticated_user or detect_internal_caller(dict(self._socket.scope.get("headers", [])))
+        with user_context(current_user):
+            try:
+                auth_callback = self._flow_handler.authenticate if self._flow_handler else None
+                async with self._session_manager.session(
+                    user_message_id=user_message_id,
+                    conversation_id=conversation_id,
+                    http_connection=self._socket,
+                    user_input_callback=self.human_interaction_callback,
+                    user_authentication_callback=auth_callback,
+                ) as session:
+                    async for value in generate_streaming_response(
+                        payload,
+                        session=session,
+                        streaming=True,
+                        step_adaptor=self._step_adaptor,
+                        result_type=result_type,
+                        output_type=output_type,
+                    ):
+                        if isinstance(value, ResponseObservabilityTrace):
+                            if self._pending_observability_trace is None:
+                                self._pending_observability_trace = value
+                        else:
+                            await self.create_websocket_message(
+                                data_model=value,
+                                status=WebSocketMessageStatus.IN_PROGRESS,
+                            )
 
-            await self.create_websocket_message(
-                data_model=SystemResponseContent(),
-                message_type=WebSocketMessageType.RESPONSE_MESSAGE,
-                status=WebSocketMessageStatus.COMPLETE,
-            )
-
-            if self._pending_observability_trace:
                 await self.create_websocket_message(
-                    data_model=self._pending_observability_trace,
-                    message_type=WebSocketMessageType.OBSERVABILITY_TRACE_MESSAGE,
+                    data_model=SystemResponseContent(),
+                    message_type=WebSocketMessageType.RESPONSE_MESSAGE,
+                    status=WebSocketMessageStatus.COMPLETE,
                 )
-                self._pending_observability_trace = None
-        except Exception:
-            logger.exception("Error running workflow")
+
+                if self._pending_observability_trace:
+                    await self.create_websocket_message(
+                        data_model=self._pending_observability_trace,
+                        message_type=WebSocketMessageType.OBSERVABILITY_TRACE_MESSAGE,
+                    )
+                    self._pending_observability_trace = None
+            except Exception:
+                logger.exception("Error running workflow")
 
 
 def install_reconnectable_handler() -> None:  # TODO: upstream to NAT
@@ -394,6 +455,70 @@ def install_reconnectable_handler() -> None:  # TODO: upstream to NAT
     if _installed:
         return
     from nat.front_ends.fastapi import fastapi_front_end_plugin_worker as worker_module
+    from nat.front_ends.fastapi.routes import websocket as websocket_routes
 
     worker_module.WebSocketMessageHandler = ReconnectableWebSocketMessageHandler
+    websocket_routes.WebSocketMessageHandler = ReconnectableWebSocketMessageHandler
+
+    def patched_websocket_endpoint(*, worker: Any, session_manager: Any):
+        """Build websocket endpoint handler with reconnect support and verified auth."""
+
+        async def _websocket_endpoint(websocket: WebSocket):
+            session_id = websocket.query_params.get("session")
+            if session_id and not websocket_routes._SAFE_SESSION_ID_RE.match(session_id):
+                logger.warning("WebSocket: Rejected session ID with unsafe characters")
+                await websocket.close(code=WS_POLICY_VIOLATION, reason="Invalid session ID")
+                return
+
+            if session_id:
+                headers = list(websocket.scope.get("headers", []))
+                cookie_header = f"{SESSION_COOKIE_NAME}={session_id}"
+
+                cookie_exists = False
+                existing_session_cookie = False
+
+                for i, (name, value) in enumerate(headers):
+                    if name != b"cookie":
+                        continue
+
+                    cookie_exists = True
+                    cookie_str = value.decode()
+
+                    if f"{SESSION_COOKIE_NAME}=" in cookie_str:
+                        existing_session_cookie = True
+                        logger.info("WebSocket: Session cookie already present in headers (same-origin)")
+                    else:
+                        headers[i] = (name, f"{cookie_str}; {cookie_header}".encode())
+                        logger.info(
+                            "WebSocket: Added session cookie to existing cookie header: %s",
+                            session_id[:10] + "...",
+                        )
+                    break
+
+                if not cookie_exists and not existing_session_cookie:
+                    headers.append((b"cookie", cookie_header.encode()))
+                    logger.info("WebSocket: Added new session cookie header: %s", session_id[:10] + "...")
+
+                websocket.scope["headers"] = headers
+
+            user, close_code = await authenticate_websocket_connection(websocket)
+            if close_code is not None:
+                await websocket.close(code=close_code)
+                return
+
+            async with ReconnectableWebSocketMessageHandler(
+                websocket,
+                session_manager,
+                worker.get_step_adaptor(),
+                worker,
+            ) as handler:
+                handler._authenticated_user = user
+                flow_handler = WebSocketAuthenticationFlowHandler(worker._add_flow, worker._remove_flow, handler)
+                handler.set_flow_handler(flow_handler)
+                with user_context(user or detect_internal_caller(dict(websocket.scope.get("headers", [])))):
+                    await handler.run()
+
+        return _websocket_endpoint
+
+    websocket_routes.websocket_endpoint = patched_websocket_endpoint
     _installed = True

--- a/frontends/aiq_api/tests/test_auth.py
+++ b/frontends/aiq_api/tests/test_auth.py
@@ -422,7 +422,7 @@ class TestAuthMiddlewareInternal:
         finally:
             middleware_module._current_user.reset(token)
 
-        assert state["user"]["type"] == "jwt"
+        assert state["user"]["type"] == "unverified_jwt"
         assert state["user"]["token"] == "eyJhbGciOiJIUzI1NiJ9.x.y"
 
     @pytest.mark.asyncio
@@ -439,7 +439,7 @@ class TestAuthMiddlewareInternal:
         )
         await mw(scope, AsyncMock(), send)
 
-        assert state["user"]["type"] == "jwt"
+        assert state["user"]["type"] == "unverified_jwt"
         assert state["user"]["token"] == "cookieval"
 
 

--- a/frontends/aiq_api/tests/test_auth.py
+++ b/frontends/aiq_api/tests/test_auth.py
@@ -405,30 +405,32 @@ class TestAuthMiddlewareAuthFlow:
 
 class TestAuthMiddlewareInternal:
     @pytest.mark.asyncio
-    async def test_internal_sets_jwt_user_for_bearer_jwt(self, capture_asgi):
+    async def test_internal_validates_bearer_jwt_when_validator_accepts(self, capture_asgi):
         app, state = capture_asgi
-        mw = AuthMiddleware(app, require_auth=True, external_hostnames=set())
-        token = middleware_module._current_user.set({})
+        mock_v = MagicMock()
+        mock_v.can_handle.return_value = True
+        mock_v.validate = AsyncMock(return_value={"type": "starfleet", "sub": "user-1", "token": "good"})
+        mw = AuthMiddleware(app, validators=[mock_v], require_auth=True, external_hostnames=set())
 
         async def send(msg):
             pass
 
-        try:
-            scope = _http_scope(
-                "/any/path",
-                extra_headers=[(b"authorization", b"Bearer eyJhbGciOiJIUzI1NiJ9.x.y")],
-            )
-            await mw(scope, AsyncMock(), send)
-        finally:
-            middleware_module._current_user.reset(token)
+        scope = _http_scope(
+            "/any/path",
+            extra_headers=[(b"authorization", b"Bearer eyJhbGciOiJIUzI1NiJ9.x.y")],
+        )
+        await mw(scope, AsyncMock(), send)
 
-        assert state["user"]["type"] == "unverified_jwt"
-        assert state["user"]["token"] == "eyJhbGciOiJIUzI1NiJ9.x.y"
+        assert state["user"]["type"] == "starfleet"
+        assert state["user"]["sub"] == "user-1"
 
     @pytest.mark.asyncio
-    async def test_internal_idtoken_cookie(self, capture_asgi):
+    async def test_internal_idtoken_cookie_stays_unverified_without_valid_identity(self, capture_asgi):
         app, state = capture_asgi
-        mw = AuthMiddleware(app, require_auth=False, external_hostnames=set())
+        mock_v = MagicMock()
+        mock_v.can_handle.return_value = True
+        mock_v.validate = AsyncMock(return_value=None)
+        mw = AuthMiddleware(app, validators=[mock_v], require_auth=False, external_hostnames=set())
 
         async def send(msg):
             pass
@@ -441,6 +443,26 @@ class TestAuthMiddlewareInternal:
 
         assert state["user"]["type"] == "unverified_jwt"
         assert state["user"]["token"] == "cookieval"
+
+    @pytest.mark.asyncio
+    async def test_internal_invalid_bearer_token_falls_back_to_internal_when_auth_not_required(self, capture_asgi):
+        app, state = capture_asgi
+        mock_v = MagicMock()
+        mock_v.can_handle.return_value = True
+        mock_v.validate = AsyncMock(return_value=None)
+        mw = AuthMiddleware(app, validators=[mock_v], require_auth=False, external_hostnames=set())
+
+        async def send(msg):
+            pass
+
+        scope = _http_scope(
+            "/any/path",
+            extra_headers=[(b"authorization", b"Bearer badtoken")],
+        )
+        await mw(scope, AsyncMock(), send)
+
+        assert state["user"]["type"] == "unverified_jwt"
+        assert state["user"]["token"] == "badtoken"
 
 
 class TestAuthMiddlewareHelpers:

--- a/frontends/aiq_api/tests/test_job_access.py
+++ b/frontends/aiq_api/tests/test_job_access.py
@@ -13,6 +13,7 @@ import pytest
 from fastapi import HTTPException
 
 from aiq_agent.auth import Principal
+from aiq_api.jobs import access as job_access
 from aiq_api.jobs.access import authorize_job_access
 from aiq_api.jobs.access import cleanup_job_access
 from aiq_api.jobs.access import create_job_access
@@ -29,8 +30,10 @@ def db_url(tmp_path):
 @pytest.fixture(autouse=True)
 def clear_event_store_caches():
     EventStore._tables_initialized.clear()
+    job_access._job_access_schema_initialized.clear()
     yield
     EventStore._tables_initialized.clear()
+    job_access._job_access_schema_initialized.clear()
 
 
 def _insert_job_info(db_url: str, job_id: str, *, is_expired: bool = False) -> None:

--- a/frontends/aiq_api/tests/test_job_access.py
+++ b/frontends/aiq_api/tests/test_job_access.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from aiq_agent.auth import Principal
+from aiq_api.jobs.access import authorize_job_access
+from aiq_api.jobs.access import cleanup_job_access
+from aiq_api.jobs.access import create_job_access
+from aiq_api.jobs.access import ensure_job_access_table
+from aiq_api.jobs.access import get_job_access
+from aiq_api.jobs.event_store import EventStore
+
+
+@pytest.fixture
+def db_url(tmp_path):
+    return f"sqlite+aiosqlite:///{tmp_path / 'test_job_access.db'}"
+
+
+@pytest.fixture(autouse=True)
+def clear_event_store_caches():
+    EventStore._tables_initialized.clear()
+    yield
+    EventStore._tables_initialized.clear()
+
+
+def _insert_job_info(db_url: str, job_id: str, *, is_expired: bool = False) -> None:
+    from sqlalchemy import text
+
+    engine = EventStore._get_or_create_sync_engine(db_url)
+    with engine.connect() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS job_info ("
+                "  job_id TEXT PRIMARY KEY,"
+                "  status TEXT,"
+                "  config_file TEXT,"
+                "  error TEXT,"
+                "  output_path TEXT,"
+                "  created_at DATETIME,"
+                "  updated_at DATETIME,"
+                "  expiry_seconds INTEGER,"
+                "  output TEXT,"
+                "  is_expired BOOLEAN DEFAULT 0"
+                ")"
+            )
+        )
+        now = datetime.now(UTC).replace(tzinfo=None)
+        conn.execute(
+            text(
+                "INSERT OR REPLACE INTO job_info "
+                "(job_id, status, created_at, updated_at, expiry_seconds, is_expired) "
+                "VALUES (:job_id, 'running', :ts, :ts, 3600, :is_expired)"
+            ),
+            {"job_id": job_id, "ts": now, "is_expired": is_expired},
+        )
+        conn.commit()
+
+
+class TestJobAccessStorage:
+    def test_create_and_get_job_access(self, db_url):
+        principal = Principal(type="jwt", sub="user-1", email="alice@example.com")
+
+        create_job_access("job-1", principal, db_url)
+
+        access = get_job_access("job-1", db_url)
+        assert access is not None
+        assert access["owner_auth_type"] == "jwt"
+        assert access["owner_subject"] == "user-1"
+        assert access["owner_email"] == "alice@example.com"
+
+    def test_cleanup_removes_expired_and_orphaned_access_rows(self, db_url):
+        ensure_job_access_table(db_url)
+        principal = Principal(type="jwt", sub="user-1")
+        create_job_access("live-job", principal, db_url)
+        create_job_access("expired-job", principal, db_url)
+        create_job_access("orphan-job", principal, db_url)
+
+        _insert_job_info(db_url, "live-job", is_expired=False)
+        _insert_job_info(db_url, "expired-job", is_expired=True)
+
+        deleted = cleanup_job_access(db_url)
+
+        assert deleted == 2
+        assert get_job_access("live-job", db_url) is not None
+        assert get_job_access("expired-job", db_url) is None
+        assert get_job_access("orphan-job", db_url) is None
+
+
+class TestAuthorizeJobAccess:
+    def test_owner_can_access_job(self, db_url):
+        _insert_job_info(db_url, "job-1")
+        principal = Principal(type="jwt", sub="user-1")
+        create_job_access("job-1", principal, db_url)
+        job = SimpleNamespace(job_id="job-1", status="running", created_at=None, error=None)
+        job_store = SimpleNamespace(get_job=AsyncMock(return_value=job))
+
+        result = asyncio.run(authorize_job_access(job_store, db_url, "job-1", principal))
+
+        assert result is job
+
+    def test_cross_user_access_denied_with_404(self, db_url):
+        _insert_job_info(db_url, "job-1")
+        create_job_access("job-1", Principal(type="jwt", sub="user-1"), db_url)
+        job = SimpleNamespace(job_id="job-1", status="running", created_at=None, error=None)
+        job_store = SimpleNamespace(get_job=AsyncMock(return_value=job))
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(authorize_job_access(job_store, db_url, "job-1", Principal(type="jwt", sub="user-2")))
+
+        assert exc.value.status_code == 404
+
+    def test_missing_access_row_denied_with_404(self, db_url):
+        _insert_job_info(db_url, "job-1")
+        job = SimpleNamespace(job_id="job-1", status="running", created_at=None, error=None)
+        job_store = SimpleNamespace(get_job=AsyncMock(return_value=job))
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(authorize_job_access(job_store, db_url, "job-1", Principal(type="jwt", sub="user-1")))
+
+        assert exc.value.status_code == 404
+
+    def test_missing_job_returns_404_before_access_check(self, db_url):
+        job_store = SimpleNamespace(get_job=AsyncMock(return_value=None))
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(authorize_job_access(job_store, db_url, "job-1", Principal(type="jwt", sub="user-1")))
+
+        assert exc.value.status_code == 404

--- a/frontends/ui/src/adapters/auth/config.ts
+++ b/frontends/ui/src/adapters/auth/config.ts
@@ -108,32 +108,6 @@ export const SESSION_MAX_AGE_SECONDS =
   parsePositiveIntEnv(process.env.SESSION_MAX_AGE_HOURS, 24) * 60 * 60
 
 // ---------------------------------------------------------------------------
-// Token refresh (delegates to active provider)
-// ---------------------------------------------------------------------------
-
-const refreshAccessToken = async (token: JWT): Promise<JWT> => {
-  if (!activeProvider) {
-    console.error('[Auth] Token refresh called but no auth provider is configured')
-    return { ...token, error: 'RefreshAccessTokenError' }
-  }
-
-  try {
-    const refreshed = await refreshProviderToken(token.refreshToken as string)
-
-    return {
-      ...token,
-      accessToken: refreshed.access_token,
-      idToken: refreshed.id_token ?? token.idToken,
-      expiresAt: Math.floor(Date.now() / 1000) + refreshed.expires_in,
-      refreshToken: refreshed.refresh_token ?? token.refreshToken,
-    }
-  } catch (error) {
-    console.error('[Auth] Token refresh failed:', error)
-    return { ...token, error: 'RefreshAccessTokenError' }
-  }
-}
-
-// ---------------------------------------------------------------------------
 // NextAuth configuration
 // ---------------------------------------------------------------------------
 
@@ -212,6 +186,31 @@ export const authOptions: AuthOptions = {
   },
 
   debug: process.env.NODE_ENV === 'development',
+}
+
+/**
+ * Refresh the access token by delegating to the active provider.
+ */
+const refreshAccessToken = async (token: JWT): Promise<JWT> => {
+  if (!activeProvider) {
+    console.error('[Auth] Token refresh called but no auth provider is configured')
+    return { ...token, error: 'RefreshAccessTokenError' }
+  }
+
+  try {
+    const refreshed = await refreshProviderToken(token.refreshToken as string)
+
+    return {
+      ...token,
+      accessToken: refreshed.access_token,
+      idToken: refreshed.id_token ?? token.idToken,
+      expiresAt: Math.floor(Date.now() / 1000) + refreshed.expires_in,
+      refreshToken: refreshed.refresh_token ?? token.refreshToken,
+    }
+  } catch (error) {
+    console.error('[Auth] Token refresh failed:', error)
+    return { ...token, error: 'RefreshAccessTokenError' }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/frontends/ui/src/adapters/auth/session.ts
+++ b/frontends/ui/src/adapters/auth/session.ts
@@ -1,6 +1,3 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
-
 /**
  * Session Hook Adapter
  *
@@ -41,7 +38,7 @@ const DEFAULT_USER = {
  * if (isLoading) return <Spinner />
  * if (!isAuthenticated) return <Button onClick={signIn}>Sign In</Button>
  *
- * // Use idToken for backend API calls (not available when !authRequired)
+ * // Use idToken for backend API calls (only available when authRequired)
  * if (idToken) {
  *   await fetch('/api/data', {
  *     headers: { 'Authorization': `Bearer ${idToken}` }
@@ -52,9 +49,9 @@ const DEFAULT_USER = {
  * ```
  */
 export const useAuth = (): AuthContext => {
-  const { authRequired, authProviderId, sessionRefreshIntervalSeconds } = useAppConfig()
+  const { authRequired, authProviderId } = useAppConfig()
   const authRequiredRef = useRef(authRequired)
-  const { data: session, status, update } = useNextAuthSession()
+  const { data: session, status } = useNextAuthSession()
   const hasTriggeredReauth = useRef(false)
 
   if (authRequiredRef.current !== authRequired) {
@@ -82,16 +79,6 @@ export const useAuth = (): AuthContext => {
     }
   }, [session?.error, authRequired, handleSignOut])
 
-  useEffect(() => {
-    if (!authRequired) return
-    if (status !== 'authenticated') return
-
-    const interval = setInterval(() => {
-      update()
-    }, sessionRefreshIntervalSeconds * 1000)
-
-    return () => clearInterval(interval)
-  }, [status, update, authRequired, sessionRefreshIntervalSeconds])
 
   if (!authRequired) {
     return {

--- a/frontends/ui/src/shared/context/AppConfigContext.tsx
+++ b/frontends/ui/src/shared/context/AppConfigContext.tsx
@@ -41,7 +41,7 @@ export interface FileUploadConfig {
 export interface AppConfig {
   /** Whether authentication is required (set REQUIRE_AUTH=true to enable OAuth) */
   authRequired: boolean
-  /** The NextAuth provider ID for signIn() calls (e.g. 'oauth', 'nvlogin', 'disabled-auth') */
+  /** The NextAuth provider ID for signIn() calls (e.g. 'oauth', 'disabled-auth') */
   authProviderId: string
   /** Client-side session polling interval in seconds, derived from TOKEN_REFRESH_BUFFER_SECONDS */
   sessionRefreshIntervalSeconds: number

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -255,12 +255,12 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
         # Check if Dask scheduler is available
         scheduler_address = os.environ.get("NAT_DASK_SCHEDULER_ADDRESS")
         if scheduler_address:
-            from aiq_agent.auth import get_current_user_info
-            from aiq_api.jobs import submit_agent_job
+            from aiq_agent.auth import get_current_principal
+            from aiq_api.jobs.submit import submit_agent_job
 
             async def _submit_deep_job(state: ChatResearcherState) -> str:
-                user_info = get_current_user_info()
-                owner = user_info.email if user_info and user_info.email else "anonymous"
+                principal = get_current_principal()
+                owner = principal.email if principal and principal.email else "anonymous"
                 query = state.original_query
                 if not query:
                     if not state.messages:
@@ -343,15 +343,15 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
             else:
                 logger.info("Thread ID for checkpointing: %s", nat_context_conversation_id)
 
-        from aiq_agent.auth import get_current_user_info
+        from aiq_agent.auth import get_current_principal
 
-        user_info = get_current_user_info()
+        principal = get_current_principal()
         user_info_dict = None
-        if user_info:
+        if principal:
             logger.debug("User authenticated")
             user_info_dict = {
-                "name": user_info.name,
-                "email": user_info.email,
+                "name": principal.name,
+                "email": principal.email,
             }
 
         # Decide whether to skip the clarifier for this request.

--- a/src/aiq_agent/auth/__init__.py
+++ b/src/aiq_agent/auth/__init__.py
@@ -19,22 +19,28 @@ This module provides token retrieval and user info utilities that can be used
 by any tool or agent.
 """
 
+from .utils import Principal
 from .utils import UserInfo
 from .utils import clear_token_fetchers
-from .utils import decode_jwt_payload
+from .utils import decode_unverified_jwt_payload
 from .utils import get_auth_token
+from .utils import get_current_principal
 from .utils import get_current_user_info
-from .utils import get_user_info_from_token
+from .utils import get_user_info_from_unverified_token
+from .utils import get_verified_current_user
 from .utils import register_token_fetcher
 from .utils import unregister_token_fetcher
 
 __all__ = [
+    "Principal",
     "UserInfo",
     "clear_token_fetchers",
-    "decode_jwt_payload",
+    "decode_unverified_jwt_payload",
     "get_auth_token",
+    "get_current_principal",
     "get_current_user_info",
-    "get_user_info_from_token",
+    "get_user_info_from_unverified_token",
+    "get_verified_current_user",
     "register_token_fetcher",
     "unregister_token_fetcher",
 ]

--- a/src/aiq_agent/auth/utils.py
+++ b/src/aiq_agent/auth/utils.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Shared authentication utilities for token retrieval and user info.
+"""Shared authentication utilities for token retrieval and request identity.
 
-These utilities can be used by any tool or agent to get auth tokens or user info.
+These utilities can be used by any tool or agent to get auth tokens.
+Trusted request identity must come from verified middleware context, not from
+raw JWT payload decoding.
 
 Token sources checked in priority order by ``get_auth_token()``:
 
@@ -94,7 +96,14 @@ class UserInfo(BaseModel):
     name: str | None = None
 
 
-def decode_jwt_payload(token: str) -> dict:
+class Principal(BaseModel):
+    type: str
+    sub: str
+    email: str | None = None
+    name: str | None = None
+
+
+def decode_unverified_jwt_payload(token: str) -> dict:
     """Decode the payload section of a JWT token without verification."""
     try:
         parts = token.split(".")
@@ -113,9 +122,9 @@ def decode_jwt_payload(token: str) -> dict:
         return {}
 
 
-def get_user_info_from_token(id_token: str) -> UserInfo:
-    """Extract user information from a JWT ID token."""
-    payload = decode_jwt_payload(id_token)
+def get_user_info_from_unverified_token(id_token: str) -> UserInfo:
+    """Extract user display fields from an unverified JWT token."""
+    payload = decode_unverified_jwt_payload(id_token)
 
     email = payload.get("email")
     name = (
@@ -123,6 +132,18 @@ def get_user_info_from_token(id_token: str) -> UserInfo:
     )
 
     return UserInfo(email=email, name=name)
+
+
+def decode_jwt_payload(token: str) -> dict:
+    """Deprecated alias for unverified JWT payload decoding."""
+    logger.warning("decode_jwt_payload() is deprecated; use decode_unverified_jwt_payload()")
+    return decode_unverified_jwt_payload(token)
+
+
+def get_user_info_from_token(id_token: str) -> UserInfo:
+    """Deprecated alias for unverified JWT display field extraction."""
+    logger.warning("get_user_info_from_token() is deprecated; use get_user_info_from_unverified_token()")
+    return get_user_info_from_unverified_token(id_token)
 
 
 def get_auth_token() -> str | None:
@@ -176,23 +197,55 @@ def get_auth_token() -> str | None:
     return None
 
 
+def get_current_principal() -> Principal | None:
+    """Return the verified current request principal from middleware context."""
+    try:
+        from aiq_api.auth.middleware import get_current_user
+    except ImportError:
+        logger.debug("Verified request principal unavailable: aiq_api.auth.middleware not importable")
+        return None
+    except Exception as e:
+        logger.debug("Verified request principal unavailable: %s", e)
+        return None
+
+    try:
+        current_user = get_current_user()
+    except Exception as e:
+        logger.debug("Failed to read current user from middleware context: %s", e)
+        return None
+
+    if not isinstance(current_user, dict):
+        logger.debug("Ignoring non-dict current user context")
+        return None
+
+    principal_type = current_user.get("type")
+    sub = current_user.get("sub")
+    if not principal_type or not sub:
+        # Middleware may expose anonymous/internal callers or raw JWTs captured
+        # on internal traffic. Without a verified subject, the identity is not trusted.
+        return None
+
+    return Principal(
+        type=str(principal_type),
+        sub=str(sub),
+        email=current_user.get("email"),
+        name=current_user.get("name"),
+    )
+
+
+def get_verified_current_user() -> Principal | None:
+    """Return the verified current request principal from middleware context."""
+    return get_current_principal()
+
+
 def get_current_user_info() -> UserInfo | None:
     """
-    Get current user information from the first available token source.
+    Get trusted current user information from verified middleware context.
 
     Returns:
-        ``UserInfo`` with email / name, or ``None`` if no token is available.
+        ``UserInfo`` with email / name, or ``None`` if no verified principal is available.
     """
-    token = get_auth_token()
-
-    if token:
-        try:
-            user_info = get_user_info_from_token(token)
-            logger.debug("User info extracted successfully")
-            return user_info
-        except Exception as e:
-            logger.error("Could not extract user info from token: %s", e)
-            return None
-
-    logger.debug("No token available for user info extraction")
-    return None
+    principal = get_current_principal()
+    if principal is None:
+        return None
+    return UserInfo(email=principal.email, name=principal.name)

--- a/tests/aiq_agent/async_api/test_websocket_reconnect.py
+++ b/tests/aiq_agent/async_api/test_websocket_reconnect.py
@@ -697,6 +697,18 @@ async def test_authenticate_websocket_connection_rejects_missing_external_token(
 
 
 @pytest.mark.asyncio
+async def test_authenticate_websocket_connection_validates_internal_token_when_present() -> None:
+    validator = DummyValidator(user={"type": "starfleet", "sub": "user-1", "skip_clarifier": False})
+    configure_websocket_auth(validators=[validator], require_auth=True, external_hostnames={"localhost"})
+    socket = DummySocket(headers=[(b"host", b"aiq-agent"), (b"cookie", b"idToken=test-token")])
+
+    user, close_code = await authenticate_websocket_connection(socket)
+
+    assert close_code is None
+    assert user == {"type": "starfleet", "sub": "user-1", "skip_clarifier": False}
+
+
+@pytest.mark.asyncio
 async def test_run_closes_socket_when_websocket_auth_fails() -> None:
     configure_websocket_auth(validators=[], require_auth=True, external_hostnames={"localhost"})
     socket = DummySocket(headers=[(b"host", b"localhost")])

--- a/tests/aiq_agent/async_api/test_websocket_reconnect.py
+++ b/tests/aiq_agent/async_api/test_websocket_reconnect.py
@@ -21,14 +21,18 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 
 import pytest
 from pydantic import BaseModel
 from starlette.websockets import WebSocketDisconnect
 
 from aiq_api import websocket_reconnect
+from aiq_api.auth.middleware import get_current_user
 from aiq_api.websocket_reconnect import ReconnectableWebSocketMessageHandler
 from aiq_api.websocket_reconnect import WebSocketSessionRegistry
+from aiq_api.websocket_reconnect import authenticate_websocket_connection
+from aiq_api.websocket_reconnect import configure_websocket_auth
 from nat.data_models.api_server import TextContent
 from nat.data_models.api_server import UserMessageContent
 from nat.data_models.api_server import UserMessageContentRoleType
@@ -46,11 +50,14 @@ class DummySocket:
         self,
         messages: list[dict] | None = None,
         raise_on_send: bool = False,
+        headers: list[tuple[bytes, bytes]] | None = None,
     ) -> None:
         self._messages = messages or []
         self._index = 0
         self.raise_on_send = raise_on_send
         self.sent: list[dict] = []
+        self.closed_with: int | None = None
+        self.scope = {"headers": headers or [], "type": "websocket"}
 
     async def receive_json(self) -> dict:
         if self._index >= len(self._messages):
@@ -64,6 +71,9 @@ class DummySocket:
             raise RuntimeError("send failed")
         self.sent.append(payload)
 
+    async def close(self, code: int) -> None:
+        self.closed_with = code
+
 
 class DummySessionManager:
     """Minimal session manager stub for handler initialization."""
@@ -73,6 +83,10 @@ class DummySessionManager:
 
     def get_workflow_streaming_output_schema(self):
         return None
+
+    @asynccontextmanager
+    async def session(self, **_kwargs):
+        yield object()
 
 
 class DummyStepAdaptor:
@@ -96,6 +110,20 @@ class DummyMessage(BaseModel):
     """Simple pydantic message for tests."""
 
     content: str = "ok"
+
+
+class DummyValidator:
+    def __init__(self, user: dict | None = None) -> None:
+        self.user = user
+        self.tokens: list[str] = []
+
+    def can_handle(self, token: str) -> bool:
+        self.tokens.append(token)
+        return True
+
+    async def validate(self, token: str) -> dict | None:
+        self.tokens.append(token)
+        return self.user
 
 
 @pytest.fixture(name="event_loop")
@@ -642,3 +670,69 @@ def test_install_reconnectable_handler(monkeypatch) -> None:
     assert worker_module.WebSocketMessageHandler is ReconnectableWebSocketMessageHandler
     worker_module.WebSocketMessageHandler = original_handler
     monkeypatch.setattr(websocket_reconnect, "_installed", False)
+
+
+@pytest.mark.asyncio
+async def test_authenticate_websocket_connection_validates_external_token() -> None:
+    validator = DummyValidator(user={"type": "starfleet", "sub": "user-1", "skip_clarifier": False})
+    configure_websocket_auth(validators=[validator], require_auth=True, external_hostnames={"localhost"})
+    socket = DummySocket(headers=[(b"host", b"localhost"), (b"cookie", b"idToken=test-token")])
+
+    user, close_code = await authenticate_websocket_connection(socket)
+
+    assert close_code is None
+    assert user == {"type": "starfleet", "sub": "user-1", "skip_clarifier": False}
+    assert validator.tokens == ["test-token", "test-token"]
+
+
+@pytest.mark.asyncio
+async def test_authenticate_websocket_connection_rejects_missing_external_token() -> None:
+    configure_websocket_auth(validators=[], require_auth=True, external_hostnames={"localhost"})
+    socket = DummySocket(headers=[(b"host", b"localhost")])
+
+    user, close_code = await authenticate_websocket_connection(socket)
+
+    assert user is None
+    assert close_code == 1008
+
+
+@pytest.mark.asyncio
+async def test_run_closes_socket_when_websocket_auth_fails() -> None:
+    configure_websocket_auth(validators=[], require_auth=True, external_hostnames={"localhost"})
+    socket = DummySocket(headers=[(b"host", b"localhost")])
+    handler = ReconnectableWebSocketMessageHandler(
+        socket=socket,
+        session_manager=DummySessionManager(),
+        step_adaptor=DummyStepAdaptor(),
+        worker=DummyWorker(),
+    )
+
+    await handler.run()
+
+    assert socket.closed_with == 1008
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_binds_authenticated_user_context(monkeypatch) -> None:
+    configure_websocket_auth(validators=[], require_auth=False, external_hostnames={"localhost"})
+    socket = DummySocket(headers=[(b"host", b"localhost")])
+    handler = ReconnectableWebSocketMessageHandler(
+        socket=socket,
+        session_manager=DummySessionManager(),
+        step_adaptor=DummyStepAdaptor(),
+        worker=DummyWorker(),
+    )
+    handler._authenticated_user = {"type": "starfleet", "sub": "user-1", "skip_clarifier": False}
+
+    seen_users: list[dict] = []
+
+    async def fake_stream(*_args, **_kwargs):
+        seen_users.append(get_current_user())
+        if False:
+            yield None
+
+    monkeypatch.setattr(websocket_reconnect, "generate_streaming_response", fake_stream)
+
+    await handler._run_workflow(payload="hello", conversation_id="conv-1")
+
+    assert seen_users == [{"type": "starfleet", "sub": "user-1", "skip_clarifier": False}]

--- a/tests/aiq_agent/auth/test_auth_utils.py
+++ b/tests/aiq_agent/auth/test_auth_utils.py
@@ -20,12 +20,16 @@ Module under test: src/aiq_agent/auth/utils.py
 
 import base64
 import json
+from unittest.mock import patch
 
 import pytest
 
 from aiq_agent.auth import clear_token_fetchers
+from aiq_agent.auth import decode_unverified_jwt_payload
 from aiq_agent.auth import get_auth_token
+from aiq_agent.auth import get_current_principal
 from aiq_agent.auth import get_current_user_info
+from aiq_agent.auth import get_user_info_from_unverified_token
 from aiq_agent.auth import register_token_fetcher
 
 
@@ -89,15 +93,51 @@ def test_clear_token_fetchers():
     assert get_auth_token() is None
 
 
-def test_get_current_user_info_uses_registered_fetcher():
-    """get_current_user_info delegates to get_auth_token, which uses registered fetchers."""
+def test_decode_unverified_jwt_payload_extracts_claims():
     jwt = _make_jwt({"email": "alice@nvidia.com", "name": "Alice"})
-    register_token_fetcher(lambda: jwt)
+    payload = decode_unverified_jwt_payload(jwt)
+    assert payload["email"] == "alice@nvidia.com"
+    assert payload["name"] == "Alice"
 
-    user_info = get_current_user_info()
+
+def test_get_user_info_from_unverified_token_extracts_display_fields():
+    jwt = _make_jwt({"email": "alice@nvidia.com", "name": "Alice"})
+    user_info = get_user_info_from_unverified_token(jwt)
+    assert user_info.email == "alice@nvidia.com"
+    assert user_info.name == "Alice"
+
+
+def test_get_current_principal_uses_verified_middleware_context():
+    with patch("aiq_api.auth.middleware.get_current_user", return_value={"type": "jwt", "sub": "user-1"}):
+        principal = get_current_principal()
+
+    assert principal is not None
+    assert principal.type == "jwt"
+    assert principal.sub == "user-1"
+
+
+def test_get_current_principal_rejects_unverified_token_context():
+    with patch("aiq_api.auth.middleware.get_current_user", return_value={"type": "unverified_jwt", "token": "x.y.z"}):
+        assert get_current_principal() is None
+
+
+def test_get_current_user_info_uses_verified_middleware_context():
+    with patch(
+        "aiq_api.auth.middleware.get_current_user",
+        return_value={"type": "jwt", "sub": "user-1", "email": "alice@nvidia.com", "name": "Alice"},
+    ):
+        user_info = get_current_user_info()
+
     assert user_info is not None
     assert user_info.email == "alice@nvidia.com"
     assert user_info.name == "Alice"
+
+
+def test_get_current_user_info_ignores_registered_unverified_token_fetcher():
+    jwt = _make_jwt({"email": "alice@nvidia.com", "name": "Alice"})
+    register_token_fetcher(lambda: jwt)
+    with patch("aiq_api.auth.middleware.get_current_user", return_value={"type": "internal", "skip_clarifier": False}):
+        assert get_current_user_info() is None
 
 
 def test_register_token_fetcher_deduplication():

--- a/tests/aiq_agent/jobs/test_runner.py
+++ b/tests/aiq_agent/jobs/test_runner.py
@@ -476,6 +476,7 @@ class TestSubmitDeepResearchJob:
             "os.environ",
             {
                 "NAT_DASK_SCHEDULER_ADDRESS": "tcp://localhost:8786",
+                "REQUIRE_AUTH": "true",
             },
         ):
             with patch("nat.front_ends.fastapi.async_jobs.job_store.JobStore", return_value=mock_job_store):
@@ -488,6 +489,41 @@ class TestSubmitDeepResearchJob:
                         )
 
         mock_job_store.submit_job.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_submit_uses_compatibility_principal_when_auth_disabled(self):
+        """Test submit_agent_job still works without verified principal when auth is disabled."""
+        from aiq_api.jobs.submit import submit_agent_job
+
+        mock_job_store = MagicMock()
+        mock_job_store.ensure_job_id.return_value = "test-job-id"
+        mock_job_store.submit_job = AsyncMock(return_value=None)
+
+        with patch.dict(
+            "os.environ",
+            {
+                "NAT_DASK_SCHEDULER_ADDRESS": "tcp://localhost:8786",
+                "NAT_JOB_STORE_DB_URL": "sqlite:///./test.db",
+                "REQUIRE_AUTH": "false",
+            },
+        ):
+            with patch("nat.front_ends.fastapi.async_jobs.job_store.JobStore", return_value=mock_job_store):
+                with patch("aiq_api.jobs.submit.get_current_principal", return_value=None):
+                    with patch(
+                        "aiq_api.jobs.submit.create_job_access",
+                    ) as create_job_access:
+                        result = await submit_agent_job(
+                            agent_type="deep_researcher",
+                            input_text="test query",
+                            owner="test@example.com",
+                        )
+
+        assert result == "test-job-id"
+        create_job_access.assert_called_once()
+        principal = create_job_access.call_args.args[1]
+        assert principal.type == "internal"
+        assert principal.sub == "test@example.com"
+        assert principal.email == "test@example.com"
 
     @pytest.mark.asyncio
     async def test_submit_rolls_back_when_job_access_persistence_fails(self):

--- a/tests/aiq_agent/jobs/test_runner.py
+++ b/tests/aiq_agent/jobs/test_runner.py
@@ -69,6 +69,7 @@ from unittest.mock import patch
 
 import pytest
 
+from aiq_agent.auth import Principal
 from aiq_api.jobs.callbacks import ArtifactType
 from aiq_api.jobs.callbacks import DeepResearchEventCallback
 from aiq_api.jobs.callbacks import EventCategory
@@ -363,6 +364,8 @@ class TestDeepResearchEventCallback:
 class TestSubmitDeepResearchJob:
     """Tests for the submit_deep_research_job function."""
 
+    principal = Principal(type="test", sub="user-1", email="test@example.com", name="Test User")
+
     @pytest.mark.asyncio
     async def test_submit_without_scheduler_raises(self):
         """Test submit_deep_research_job raises without NAT_DASK_SCHEDULER_ADDRESS."""
@@ -393,10 +396,12 @@ class TestSubmitDeepResearchJob:
             },
         ):
             with patch("nat.front_ends.fastapi.async_jobs.job_store.JobStore", return_value=mock_job_store):
-                result = await submit_deep_research_job(
-                    input_text="test query",
-                    owner="test@example.com",
-                )
+                with patch("aiq_api.jobs.submit.get_current_principal", return_value=self.principal):
+                    with patch("aiq_api.jobs.submit.create_job_access"):
+                        result = await submit_deep_research_job(
+                            input_text="test query",
+                            owner="test@example.com",
+                        )
 
         assert result == "test-job-id"
         mock_job_store.submit_job.assert_called_once()
@@ -418,12 +423,14 @@ class TestSubmitDeepResearchJob:
             },
         ):
             with patch("nat.front_ends.fastapi.async_jobs.job_store.JobStore", return_value=mock_job_store):
-                result = await submit_agent_job(
-                    agent_type="deep_researcher",
-                    input_text="test query",
-                    owner="test@example.com",
-                    data_sources=["web_search"],
-                )
+                with patch("aiq_api.jobs.submit.get_current_principal", return_value=self.principal):
+                    with patch("aiq_api.jobs.submit.create_job_access"):
+                        result = await submit_agent_job(
+                            agent_type="deep_researcher",
+                            input_text="test query",
+                            owner="test@example.com",
+                            data_sources=["web_search"],
+                        )
 
         assert result == "test-job-id"
         mock_job_store.submit_job.assert_called_once()
@@ -447,14 +454,73 @@ class TestSubmitDeepResearchJob:
             },
         ):
             with patch("nat.front_ends.fastapi.async_jobs.job_store.JobStore", return_value=mock_job_store):
-                result = await submit_deep_research_job(
-                    input_text="test query",
-                    owner="test@example.com",
-                    job_id="custom-job-id",
-                )
+                with patch("aiq_api.jobs.submit.get_current_principal", return_value=self.principal):
+                    with patch("aiq_api.jobs.submit.create_job_access"):
+                        result = await submit_deep_research_job(
+                            input_text="test query",
+                            owner="test@example.com",
+                            job_id="custom-job-id",
+                        )
 
         assert result == "custom-job-id"
         mock_job_store.ensure_job_id.assert_called_with("custom-job-id")
+
+    @pytest.mark.asyncio
+    async def test_submit_requires_verified_principal(self):
+        """Test submit_agent_job fails closed when no verified principal is available."""
+        from aiq_api.jobs.submit import submit_agent_job
+
+        mock_job_store = MagicMock()
+
+        with patch.dict(
+            "os.environ",
+            {
+                "NAT_DASK_SCHEDULER_ADDRESS": "tcp://localhost:8786",
+            },
+        ):
+            with patch("nat.front_ends.fastapi.async_jobs.job_store.JobStore", return_value=mock_job_store):
+                with patch("aiq_api.jobs.submit.get_current_principal", return_value=None):
+                    with pytest.raises(RuntimeError, match="Verified current principal required"):
+                        await submit_agent_job(
+                            agent_type="deep_researcher",
+                            input_text="test query",
+                            owner="test@example.com",
+                        )
+
+        mock_job_store.submit_job.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_submit_rolls_back_when_job_access_persistence_fails(self):
+        """Test submit_agent_job rolls back partial submission on access persistence failure."""
+        from aiq_api.jobs.submit import submit_agent_job
+
+        mock_job_store = MagicMock()
+        mock_job_store.ensure_job_id.return_value = "test-job-id"
+        mock_job_store.submit_job = AsyncMock(return_value=None)
+
+        with patch.dict(
+            "os.environ",
+            {
+                "NAT_DASK_SCHEDULER_ADDRESS": "tcp://localhost:8786",
+                "NAT_JOB_STORE_DB_URL": "sqlite:///./test.db",
+            },
+        ):
+            with patch("nat.front_ends.fastapi.async_jobs.job_store.JobStore", return_value=mock_job_store):
+                with patch("aiq_api.jobs.submit.get_current_principal", return_value=self.principal):
+                    with patch(
+                        "aiq_api.jobs.submit.create_job_access",
+                        side_effect=RuntimeError("db write failed"),
+                    ):
+                        with patch("aiq_api.jobs.submit.rollback_job_submission") as rollback_job_submission:
+                            with pytest.raises(RuntimeError, match="db write failed"):
+                                await submit_agent_job(
+                                    agent_type="deep_researcher",
+                                    input_text="test query",
+                                    owner="test@example.com",
+                                )
+
+        mock_job_store.submit_job.assert_called_once()
+        rollback_job_submission.assert_called_once_with("test-job-id", "sqlite:///./test.db")
 
 
 class TestEventStore:


### PR DESCRIPTION
## Summary

  This PR fixes two auth/security issues in aiq:

  1. Unverified JWT payloads were being used as trusted user identity in request-backed flows.
  2. Async job endpoints lacked object-level authorization and only checked request auth + job existence.

  ## Changes

  ### 1. Trusted identity now comes only from verified middleware context

  - Added verified principal helpers in aiq_agent.auth:
      - get_current_principal()
      - get_verified_current_user()
  - Changed get_current_user_info() to read only from verified middleware context.
  - Renamed unsafe JWT helpers to make their trust boundary explicit:
      - decode_unverified_jwt_payload()
      - get_user_info_from_unverified_token()
  - Kept the raw decode behavior only as explicitly unverified helpers.
  - Updated request-backed chat_researcher flows to use the verified principal instead of deriving identity from raw token payloads.
  - Updated middleware internal caller labeling so raw internal JWT/cookie traffic is marked unverified_jwt, not a trusted auth type.

  ### 2. Async job object-level authorization

  - Added a separate AIQ-owned job_access table keyed by job_id.
  - Persist ownership at submission time using verified principal identity:
      - owner_auth_type
      - owner_subject
      - owner_email
  - Added shared authorization helpers to require:
      - job exists
      - job_access row exists
      - requesting principal matches stored owner
  - Applied ownership enforcement to async job endpoints:
      - status
      - stream
      - stream resume
      - cancel
      - state
      - report
  - Unauthorized or ownerless job access now returns 404.

  ### 3. WebSocket auth bridge for UI-backed chat (transitional)

  - Added a transitional WebSocket auth path in aiq_api so UI WebSocket chat can establish verified identity before the UI moves fully to HTTP/SSE.
  - Moved WebSocket auth to the actual socket route boundary rather than relying only on handler-level monkeypatching.
  - Reused the same validator chain and trusted principal shape as HTTP auth.

  ### 4. DB init and cleanup

  - Added idempotent job_access creation to both init SQL paths:
      - deploy/compose/init-db.sql
      - deploy/helm/helm-charts-k8s/aiq/files/init-db.sql
  - Added cleanup for stale job_access rows alongside job cleanup.
  - Ensured submit fails closed and rolls back partial job state if access metadata persistence fails.

  ### 5. Code quality / cleanup

  - Removed package-level lazy export workaround for aiq_api.jobs.
  - Switched callers to direct submodule imports.
  - Removed internal-only UI auth/Datadog changes from this repo so public aiq remains free of NVIDIA-internal UI overlays.

  ## Security impact

  This PR closes:

  - the request-identity trust-boundary issue where decoded JWT payloads could be mistaken for authenticated identity
  - the authenticated BOLA/IDOR-style gap on async job endpoints

  Trusted authorization decisions now use verified principal identity (type + sub), and async job access is enforced per object rather than per request only.

  ## Testing

  Validated in local/dev environments with:

  - auth helper behavior for verified principal resolution
  - async job ownership persistence in job_access
  - cross-principal access denial (404) for async jobs
  - idempotent schema creation for job_access
  - WebSocket/UI chat verified-principal propagation in internal testing
  - targeted compile/test checks for touched modules

  ## Notes

  - Deprecated unsafe JWT helper aliases remain in utils.py for compatibility, but they are no longer part of the public auth surface.
  - The WebSocket auth path is a transitional bridge until the UI fully migrates to authenticated HTTP/SSE.