### PR TITLE
Add request trace classification and pseudonymous ids

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -128,3 +128,10 @@ FILE_EXPIRATION_CHECK_INTERVAL_HOURS=0
 # - /app/configs/config_web_default_llamaindex.yml
 # - /app/configs/config_web_frag.yml
 # BACKEND_CONFIG=
+#
+# Optional trace enrichment for aiq_api auth middleware:
+# AIQ_TRACE_USER_IDENTITY_MODE=none
+# AIQ_TRACE_USER_IDENTITY_HMAC_SECRET=
+# AIQ_TRACE_CLIENT_ID_MODE=none
+# AIQ_TRACE_CLIENT_ID_HMAC_SECRET=
+# AIQ_TRACE_CLIENT_IP_HEADERS=x-real-ip,x-forwarded-for

--- a/docs/source/customization/configuration-reference.md
+++ b/docs/source/customization/configuration-reference.md
@@ -78,6 +78,16 @@ general:
 | `front_end.expiry_seconds` | `int` | `86400` | How long completed jobs remain in the database (seconds). |
 | `front_end.cors` | `object` | -- | CORS settings for the API server. |
 
+For `aiq_api`, request-trace enrichment is configured via environment variables
+rather than YAML fields. See `frontends/aiq_api/README.md` and the
+[Observability](../deployment/observability.md) guide for:
+
+- `AIQ_TRACE_USER_IDENTITY_MODE`
+- `AIQ_TRACE_USER_IDENTITY_HMAC_SECRET`
+- `AIQ_TRACE_CLIENT_ID_MODE`
+- `AIQ_TRACE_CLIENT_ID_HMAC_SECRET`
+- `AIQ_TRACE_CLIENT_IP_HEADERS`
+
 ---
 
 ## `llms` Section

--- a/docs/source/deployment/observability.md
+++ b/docs/source/deployment/observability.md
@@ -206,6 +206,52 @@ general:
 | `redaction_headers` | Request headers checked to determine whether to redact. |
 | `resource_attributes` | Custom OTEL resource attributes attached to all spans. |
 
+### Request Classification Tags
+
+When the `aiq_api` auth middleware is enabled, request spans can include a set
+of low-risk request tags plus optional pseudonymous identity tags.
+
+Always-on request tags:
+
+- `aiq.caller.type` -- resolved caller type from auth middleware
+- `aiq.auth.transport` -- `bearer`, `cookie`, or `none`
+- `aiq.auth.verified` -- whether the request resolved to a verified principal
+- `aiq.access.channel` -- inferred request channel or the explicit `X-AIQ-Access-Channel` header
+
+Optional pseudonymous tags:
+
+- `enduser.id`, `aiq.user.id`, `aiq.auth.type` -- controlled by `AIQ_TRACE_USER_IDENTITY_MODE`
+- `aiq.user.email`, `aiq.user.name` -- added only in `full` mode
+- `aiq.client.id` -- controlled by `AIQ_TRACE_CLIENT_ID_MODE=ip`
+
+Environment variables:
+
+- `AIQ_TRACE_USER_IDENTITY_MODE=none|id|full`
+- `AIQ_TRACE_USER_IDENTITY_HMAC_SECRET=<secret>`
+- `AIQ_TRACE_CLIENT_ID_MODE=none|ip`
+- `AIQ_TRACE_CLIENT_ID_HMAC_SECRET=<secret>`
+- `AIQ_TRACE_CLIENT_IP_HEADERS=x-real-ip,x-forwarded-for`
+
+The `id` and `ip` modes emit HMAC-derived pseudonymous identifiers rather than
+raw subjects or raw IP addresses.
+
+### Access Channel Header
+
+Deployment-specific wrappers can set the optional request header
+`X-AIQ-Access-Channel` to separate traffic sources without modifying public
+middleware. Supported values are:
+
+- `ui`
+- `skill`
+- `api`
+- `headless`
+- `anonymous`
+- `internal`
+- `unknown`
+
+When absent, the middleware falls back to generic inference from auth transport
+and request shape.
+
 ### Batch Configuration
 
 The exporter supports standard OTEL batch settings:

--- a/docs/source/deployment/production.md
+++ b/docs/source/deployment/production.md
@@ -120,6 +120,19 @@ Set `LOG_LEVEL=DEBUG` for verbose output during troubleshooting. Use `LOG_LEVEL=
 
 The backend supports OpenTelemetry-compatible tracing. See [Observability](./observability.md) for setup guides covering Phoenix, LangSmith, Weave, and the OTEL Collector with privacy redaction.
 
+If you are deploying the `aiq_api` front-end and want request correlation in
+traces, set the relevant environment variables at deploy time rather than
+hardcoding them in code:
+
+- `AIQ_TRACE_USER_IDENTITY_MODE`
+- `AIQ_TRACE_USER_IDENTITY_HMAC_SECRET`
+- `AIQ_TRACE_CLIENT_ID_MODE`
+- `AIQ_TRACE_CLIENT_ID_HMAC_SECRET`
+- `AIQ_TRACE_CLIENT_IP_HEADERS`
+
+Deployment-specific wrappers may also set `X-AIQ-Access-Channel` to distinguish
+UI, skill, and API traffic at the request level.
+
 ### Metrics to Watch
 
 | Metric | Source | What to look for |

--- a/frontends/aiq_api/README.md
+++ b/frontends/aiq_api/README.md
@@ -198,6 +198,11 @@ is disabled by default and opt-in via the `REQUIRE_AUTH` environment variable.
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `REQUIRE_AUTH` | Enforce authentication on all non-exempt routes | `false` |
+| `AIQ_TRACE_USER_IDENTITY_MODE` | Control whether verified user identity is attached to request traces: `none`, `id`, or `full` | `none` |
+| `AIQ_TRACE_USER_IDENTITY_HMAC_SECRET` | Secret used to pseudonymize verified user IDs in traces when identity tagging is enabled | unset |
+| `AIQ_TRACE_CLIENT_ID_MODE` | Control whether a pseudonymous client identifier is attached to request traces: `none` or `ip` | `none` |
+| `AIQ_TRACE_CLIENT_ID_HMAC_SECRET` | Secret used to pseudonymize client IDs when client tagging is enabled; falls back to the user-identity secret | unset |
+| `AIQ_TRACE_CLIENT_IP_HEADERS` | Ordered comma-separated client IP headers to trust before falling back to the ASGI client address | `x-real-ip,x-forwarded-for` |
 
 ### Enabling authentication
 
@@ -206,6 +211,59 @@ starts.  The server raises a `RuntimeError` at startup if auth is required but
 no validators are registered.
 
 Two registration mechanisms are supported — pick whichever fits your deployment:
+
+### Trace identity tagging
+
+Auth middleware can enrich active Datadog / OpenTelemetry request spans with
+low-risk request tags and optional pseudonymous identity tags.
+
+Always-on request tags:
+
+- `aiq.caller.type`: resolved caller type from the auth middleware
+- `aiq.auth.transport`: `bearer`, `cookie`, or `none`
+- `aiq.auth.verified`: whether the request resolved to a verified principal
+- `aiq.access.channel`: inferred or explicitly supplied access channel
+
+Optional user identity tags are controlled by `AIQ_TRACE_USER_IDENTITY_MODE`:
+
+- `none`: disable user identity tagging entirely
+- `id`: tag only pseudonymous stable identifiers (`enduser.id`, `aiq.user.id`, `aiq.auth.type`)
+- `full`: tag pseudonymous identifiers plus `aiq.user.email` and `aiq.user.name` when present
+
+Only verified principals are tagged. Anonymous, internal, and unverified JWT
+fallback callers are never attached to traces.
+Set `AIQ_TRACE_USER_IDENTITY_HMAC_SECRET` when using `id` or `full`; otherwise
+identity tagging is skipped.
+
+Optional client correlation is controlled by `AIQ_TRACE_CLIENT_ID_MODE`:
+
+- `none`: disable client correlation
+- `ip`: add `aiq.client.id` as an HMAC-derived pseudonymous identifier from the
+  client IP
+
+Set `AIQ_TRACE_CLIENT_ID_HMAC_SECRET` when using `ip`. If unset, the middleware
+falls back to `AIQ_TRACE_USER_IDENTITY_HMAC_SECRET`. `AIQ_TRACE_CLIENT_IP_HEADERS`
+controls which ingress headers are consulted first.
+
+### Access Channel Header
+
+Upstream middleware accepts an optional low-cardinality request header:
+
+- `X-AIQ-Access-Channel: <channel>`
+
+Supported values are:
+
+- `ui`
+- `skill`
+- `api`
+- `headless`
+- `anonymous`
+- `internal`
+- `unknown`
+
+When absent, the middleware falls back to generic inference from auth transport
+and request shape. Deployment-specific wrappers can set this header explicitly
+to separate UI, skill, and API traffic without modifying public middleware.
 
 #### 1. Programmatic (`register_validator`)
 

--- a/frontends/aiq_api/src/aiq_api/auth/middleware.py
+++ b/frontends/aiq_api/src/aiq_api/auth/middleware.py
@@ -423,7 +423,7 @@ async def resolve_request_user(
 
 def _build_trace_user_tags(user: dict[str, Any], mode: str, secret: str | None) -> dict[str, str]:
     """Return trace tags for verified user identities according to policy."""
-    if mode == "none":
+    if mode == "none" or not _is_verified_trace_user(user):
         return {}
 
     principal_sub = user.get("sub")
@@ -542,8 +542,6 @@ def attach_request_to_active_trace(
         client_ip_headers=client_ip_headers,
     )
     tags.update(_build_trace_user_tags(user, user_identity_mode, user_identity_secret))
-    if not tags:
-        return
 
     _tag_current_ddtrace_span(tags)
     _tag_current_otel_span(tags)

--- a/frontends/aiq_api/src/aiq_api/auth/middleware.py
+++ b/frontends/aiq_api/src/aiq_api/auth/middleware.py
@@ -87,14 +87,11 @@ ENVIRONMENT VARIABLES
     to the ASGI client address. Defaults to ``x-real-ip,x-forwarded-for``.
 """
 
-import hmac
 import json
 import logging
 import os
 from contextlib import contextmanager
 from contextvars import ContextVar
-from hashlib import sha256
-from importlib import import_module
 from typing import Any
 
 from starlette.types import ASGIApp
@@ -102,7 +99,20 @@ from starlette.types import Receive
 from starlette.types import Scope
 from starlette.types import Send
 
+from . import utils as auth_utils
+from .utils import _load_trace_client_id_mode
+from .utils import _load_trace_client_id_secret
+from .utils import _load_trace_client_ip_headers
+from .utils import _load_trace_user_identity_mode
+from .utils import _load_trace_user_identity_secret
+from .utils import attach_request_to_active_trace
+from .utils import is_headless_request
+
 logger = logging.getLogger(__name__)
+
+# Backwards-compatible aliases for tests and internal helper imports.
+_build_pseudonymous_trace_user_id = auth_utils._build_pseudonymous_trace_user_id
+_build_pseudonymous_trace_client_id = auth_utils._build_pseudonymous_trace_client_id
 
 # ---------------------------------------------------------------------------
 # ContextVar — carries the resolved caller identity through the call stack
@@ -154,19 +164,6 @@ EXTERNAL_ALLOWED_PATHS: list[str] = [
 
 # External paths that require no token (monitoring, etc.)
 AUTH_EXEMPT_PATHS: set[str] = {"/health", "/docs", "/redoc", "/openapi.json"}
-TRACE_USER_IDENTITY_MODES = frozenset({"none", "id", "full"})
-TRACE_CLIENT_ID_MODES = frozenset({"none", "ip"})
-TRACE_ACCESS_CHANNELS = frozenset(
-    {
-        "ui",
-        "skill",
-        "api",
-        "headless",
-        "anonymous",
-        "internal",
-        "unknown",
-    }
-)
 
 
 def _load_external_hostnames() -> set[str]:
@@ -176,98 +173,10 @@ def _load_external_hostnames() -> set[str]:
     return names
 
 
-def _load_trace_user_identity_mode() -> str:
-    """Read and normalize the trace user identity tagging mode."""
-    raw = os.getenv("AIQ_TRACE_USER_IDENTITY_MODE", "none").strip().lower()
-    aliases = {
-        "0": "none",
-        "false": "none",
-        "off": "none",
-        "1": "id",
-        "true": "id",
-        "on": "id",
-        "basic": "id",
-    }
-    mode = aliases.get(raw, raw)
-    if mode not in TRACE_USER_IDENTITY_MODES:
-        logger.warning(
-            "Invalid AIQ_TRACE_USER_IDENTITY_MODE=%r; expected one of %s. Falling back to 'none'.",
-            raw,
-            sorted(TRACE_USER_IDENTITY_MODES),
-        )
-        return "none"
-    return mode
-
-
-def _load_trace_user_identity_secret() -> str | None:
-    """Read the secret used to pseudonymize trace user identity."""
-    secret = os.getenv("AIQ_TRACE_USER_IDENTITY_HMAC_SECRET", "").strip()
-    return secret or None
-
-
-def _load_trace_client_id_mode() -> str:
-    """Read and normalize the trace client-id tagging mode."""
-    raw = os.getenv("AIQ_TRACE_CLIENT_ID_MODE", "none").strip().lower()
-    aliases = {
-        "0": "none",
-        "false": "none",
-        "off": "none",
-        "1": "ip",
-        "true": "ip",
-        "on": "ip",
-    }
-    mode = aliases.get(raw, raw)
-    if mode not in TRACE_CLIENT_ID_MODES:
-        logger.warning(
-            "Invalid AIQ_TRACE_CLIENT_ID_MODE=%r; expected one of %s. Falling back to 'none'.",
-            raw,
-            sorted(TRACE_CLIENT_ID_MODES),
-        )
-        return "none"
-    return mode
-
-
-def _load_trace_client_id_secret() -> str | None:
-    """Read the secret used to pseudonymize trace client identity."""
-    secret = os.getenv("AIQ_TRACE_CLIENT_ID_HMAC_SECRET", "").strip()
-    if secret:
-        return secret
-    return _load_trace_user_identity_secret()
-
-
-def _load_trace_client_ip_headers() -> list[str]:
-    """Read preferred client IP headers in lookup order."""
-    raw = os.getenv("AIQ_TRACE_CLIENT_IP_HEADERS", "x-real-ip,x-forwarded-for")
-    headers = [header.strip().lower() for header in raw.split(",") if header.strip()]
-    return headers
-
-
-def _build_pseudonymous_trace_user_id(principal_type: str, principal_sub: str, secret: str | None) -> str | None:
-    """Return a stable pseudonymous trace user ID derived from the verified principal."""
-    if not secret:
-        return None
-
-    payload = f"{principal_type}:{principal_sub}".encode()
-    return hmac.new(secret.encode(), payload, sha256).hexdigest()
-
-
-def _build_pseudonymous_trace_client_id(client_value: str, secret: str | None) -> str | None:
-    """Return a stable pseudonymous client ID derived from client network identity."""
-    if not secret or not client_value:
-        return None
-
-    return hmac.new(secret.encode(), f"client:{client_value}".encode(), sha256).hexdigest()
-
-
 def is_external_request(headers: dict[bytes, bytes], external_hostnames: set[str] | None = None) -> bool:
     """Return ``True`` when the Host header matches an external-facing hostname."""
     host = headers.get(b"host", b"").decode().split(":")[0]
     return host in (external_hostnames or _load_external_hostnames())
-
-
-def is_headless_request(headers: dict[bytes, bytes]) -> bool:
-    """Return ``True`` for headless callers that should skip the clarifier."""
-    return headers.get(b"x-aiq-mode", b"").decode().lower() == "headless"
 
 
 def extract_auth_token(headers: dict[bytes, bytes]) -> str | None:
@@ -282,88 +191,6 @@ def extract_auth_token(headers: dict[bytes, bytes]) -> str | None:
         if part.startswith("idToken="):
             return part[8:]
     return None
-
-
-def _extract_auth_transport(headers: dict[bytes, bytes]) -> str:
-    """Return the request auth transport shape."""
-    auth = headers.get(b"authorization", b"").decode()
-    if auth.startswith("Bearer "):
-        return "bearer"
-
-    cookie = headers.get(b"cookie", b"").decode()
-    for part in cookie.split(";"):
-        if part.strip().startswith("idToken="):
-            return "cookie"
-    return "none"
-
-
-def _extract_header_text(headers: dict[bytes, bytes], name: str) -> str | None:
-    """Return a decoded header value for a lowercase header name."""
-    value = headers.get(name.encode())
-    if not value:
-        return None
-    decoded = value.decode().strip()
-    return decoded or None
-
-
-def _extract_client_ip(headers: dict[bytes, bytes], scope: Scope, header_names: list[str]) -> str | None:
-    """Return the best available client IP from trusted headers or ASGI scope."""
-    for header_name in header_names:
-        value = _extract_header_text(headers, header_name)
-        if not value:
-            continue
-        if header_name == "x-forwarded-for":
-            candidate = value.split(",")[0].strip()
-        else:
-            candidate = value
-        if candidate:
-            return candidate
-
-    client = scope.get("client")
-    if isinstance(client, (list, tuple)) and client:
-        host = client[0]
-        if isinstance(host, str) and host.strip():
-            return host.strip()
-    return None
-
-
-def _extract_explicit_access_channel(headers: dict[bytes, bytes]) -> str | None:
-    """Return an explicit low-cardinality access-channel override header when present."""
-    value = _extract_header_text(headers, "x-aiq-access-channel")
-    if not value:
-        return None
-    channel = value.lower()
-    if channel in TRACE_ACCESS_CHANNELS:
-        return channel
-    logger.warning("Ignoring unsupported X-AIQ-Access-Channel=%r", value)
-    return None
-
-
-def _infer_access_channel(headers: dict[bytes, bytes], user: dict[str, Any], auth_transport: str) -> str:
-    """Infer a low-cardinality access channel for observability."""
-    if explicit := _extract_explicit_access_channel(headers):
-        return explicit
-
-    caller_type = str(user.get("type") or "")
-    headless = is_headless_request(headers)
-    if auth_transport == "cookie":
-        return "ui"
-    if headless and auth_transport == "bearer":
-        return "headless"
-    if caller_type == "anonymous":
-        return "anonymous"
-    if caller_type == "internal":
-        return "internal"
-    if auth_transport == "bearer":
-        return "api"
-    return "unknown"
-
-
-def _is_verified_trace_user(user: dict[str, Any]) -> bool:
-    """Return whether the resolved request user is a verified authenticated principal."""
-    principal_sub = user.get("sub")
-    principal_type = str(user.get("type") or "")
-    return bool(principal_sub and principal_type not in {"anonymous", "internal", "unverified_jwt"})
 
 
 async def validate_token_with_validators(token: str, validators: list) -> dict[str, Any] | None:
@@ -419,129 +246,6 @@ async def resolve_request_user(
         return None, 401, is_external
 
     return detect_internal_caller(headers), None, is_external
-
-
-def _build_trace_user_tags(user: dict[str, Any], mode: str, secret: str | None) -> dict[str, str]:
-    """Return trace tags for verified user identities according to policy."""
-    if mode == "none" or not _is_verified_trace_user(user):
-        return {}
-
-    principal_sub = user.get("sub")
-    principal_type = user.get("type")
-    if not principal_sub or not principal_type:
-        return {}
-
-    pseudonymous_id = _build_pseudonymous_trace_user_id(str(principal_type), str(principal_sub), secret)
-    if pseudonymous_id is None:
-        logger.warning(
-            "AIQ_TRACE_USER_IDENTITY_MODE=%s but AIQ_TRACE_USER_IDENTITY_HMAC_SECRET is not set; "
-            "skipping user identity trace tags.",
-            mode,
-        )
-        return {}
-
-    tags = {
-        "enduser.id": pseudonymous_id,
-        "aiq.user.id": pseudonymous_id,
-        "aiq.auth.type": str(principal_type),
-    }
-    if mode == "full":
-        if email := user.get("email"):
-            tags["aiq.user.email"] = str(email)
-        if name := user.get("name"):
-            tags["aiq.user.name"] = str(name)
-    return tags
-
-
-def _build_common_trace_tags(
-    headers: dict[bytes, bytes],
-    scope: Scope,
-    user: dict[str, Any],
-    *,
-    client_id_mode: str,
-    client_id_secret: str | None,
-    client_ip_headers: list[str],
-) -> dict[str, str]:
-    """Return always-on low-risk trace tags describing request origin and auth shape."""
-    auth_transport = _extract_auth_transport(headers)
-    tags = {
-        "aiq.caller.type": str(user.get("type") or "unknown"),
-        "aiq.auth.transport": auth_transport,
-        "aiq.auth.verified": "true" if _is_verified_trace_user(user) else "false",
-        "aiq.access.channel": _infer_access_channel(headers, user, auth_transport),
-    }
-
-    if client_id_mode == "ip":
-        client_ip = _extract_client_ip(headers, scope, client_ip_headers)
-        client_id = _build_pseudonymous_trace_client_id(client_ip or "", client_id_secret)
-        if client_id:
-            tags["aiq.client.id"] = client_id
-
-    return tags
-
-
-def _tag_current_ddtrace_span(tags: dict[str, str]) -> None:
-    """Attach user tags to the active Datadog span when ddtrace is installed."""
-    if not tags:
-        return
-
-    try:
-        tracer = import_module("ddtrace").tracer
-        span = tracer.current_span()
-    except Exception:
-        return
-
-    if span is None:
-        return
-
-    for key, value in tags.items():
-        try:
-            span.set_tag(key, value)
-        except Exception:
-            logger.debug("Failed to set Datadog span tag %s", key, exc_info=True)
-
-
-def _tag_current_otel_span(tags: dict[str, str]) -> None:
-    """Attach user tags to the active OpenTelemetry span when present."""
-    if not tags:
-        return
-
-    try:
-        span = import_module("opentelemetry.trace").get_current_span()
-    except Exception:
-        return
-
-    for key, value in tags.items():
-        try:
-            span.set_attribute(key, value)
-        except Exception:
-            logger.debug("Failed to set OpenTelemetry span attribute %s", key, exc_info=True)
-
-
-def attach_request_to_active_trace(
-    headers: dict[bytes, bytes],
-    scope: Scope,
-    user: dict[str, Any],
-    *,
-    user_identity_mode: str,
-    user_identity_secret: str | None,
-    client_id_mode: str,
-    client_id_secret: str | None,
-    client_ip_headers: list[str],
-) -> None:
-    """Attach request classification and optional pseudonymous identity to active trace spans."""
-    tags = _build_common_trace_tags(
-        headers,
-        scope,
-        user,
-        client_id_mode=client_id_mode,
-        client_id_secret=client_id_secret,
-        client_ip_headers=client_ip_headers,
-    )
-    tags.update(_build_trace_user_tags(user, user_identity_mode, user_identity_secret))
-
-    _tag_current_ddtrace_span(tags)
-    _tag_current_otel_span(tags)
 
 
 # ---------------------------------------------------------------------------

--- a/frontends/aiq_api/src/aiq_api/auth/middleware.py
+++ b/frontends/aiq_api/src/aiq_api/auth/middleware.py
@@ -511,9 +511,6 @@ def _tag_current_otel_span(tags: dict[str, str]) -> None:
     except Exception:
         return
 
-    if span is None:
-        return
-
     for key, value in tags.items():
         try:
             span.set_attribute(key, value)

--- a/frontends/aiq_api/src/aiq_api/auth/middleware.py
+++ b/frontends/aiq_api/src/aiq_api/auth/middleware.py
@@ -55,13 +55,46 @@ ENVIRONMENT VARIABLES
 ``AIQ_JWT_AUDIENCE``
     Optional ``aud`` claim to verify.  Leave unset to skip audience
     verification.
+
+``AIQ_TRACE_USER_IDENTITY_MODE``
+    Controls whether verified user identity is attached to active trace spans.
+    Supported values:
+    - ``none``: do not attach any user identity tags
+    - ``id``: attach pseudonymous stable identifiers only (``enduser.id``, ``aiq.user.id``,
+      ``aiq.auth.type``)
+    - ``full``: attach identifiers plus ``aiq.user.email`` and
+      ``aiq.user.name`` when present
+    Defaults to ``none``.
+
+``AIQ_TRACE_USER_IDENTITY_HMAC_SECRET``
+    Secret used to derive pseudonymous trace user IDs from verified subjects
+    when ``AIQ_TRACE_USER_IDENTITY_MODE`` is ``id`` or ``full``. If unset,
+    user identity tagging is disabled even when a mode is configured.
+
+``AIQ_TRACE_CLIENT_ID_MODE``
+    Controls whether a pseudonymous client identifier is attached to trace spans.
+    Supported values:
+    - ``none``: do not attach a client identifier
+    - ``ip``: derive a pseudonymous client ID from the request IP
+    Defaults to ``none``.
+
+``AIQ_TRACE_CLIENT_ID_HMAC_SECRET``
+    Secret used to derive pseudonymous client IDs. Falls back to
+    ``AIQ_TRACE_USER_IDENTITY_HMAC_SECRET`` when unset.
+
+``AIQ_TRACE_CLIENT_IP_HEADERS``
+    Comma-separated header names to check for the client IP before falling back
+    to the ASGI client address. Defaults to ``x-real-ip,x-forwarded-for``.
 """
 
+import hmac
 import json
 import logging
 import os
 from contextlib import contextmanager
 from contextvars import ContextVar
+from hashlib import sha256
+from importlib import import_module
 from typing import Any
 
 from starlette.types import ASGIApp
@@ -121,6 +154,19 @@ EXTERNAL_ALLOWED_PATHS: list[str] = [
 
 # External paths that require no token (monitoring, etc.)
 AUTH_EXEMPT_PATHS: set[str] = {"/health", "/docs", "/redoc", "/openapi.json"}
+TRACE_USER_IDENTITY_MODES = frozenset({"none", "id", "full"})
+TRACE_CLIENT_ID_MODES = frozenset({"none", "ip"})
+TRACE_ACCESS_CHANNELS = frozenset(
+    {
+        "ui",
+        "skill",
+        "api",
+        "headless",
+        "anonymous",
+        "internal",
+        "unknown",
+    }
+)
 
 
 def _load_external_hostnames() -> set[str]:
@@ -128,6 +174,89 @@ def _load_external_hostnames() -> set[str]:
     env = os.getenv("AIQ_EXTERNAL_HOSTNAMES", "")
     names = {h.strip() for h in env.split(",") if h.strip()}
     return names
+
+
+def _load_trace_user_identity_mode() -> str:
+    """Read and normalize the trace user identity tagging mode."""
+    raw = os.getenv("AIQ_TRACE_USER_IDENTITY_MODE", "none").strip().lower()
+    aliases = {
+        "0": "none",
+        "false": "none",
+        "off": "none",
+        "1": "id",
+        "true": "id",
+        "on": "id",
+        "basic": "id",
+    }
+    mode = aliases.get(raw, raw)
+    if mode not in TRACE_USER_IDENTITY_MODES:
+        logger.warning(
+            "Invalid AIQ_TRACE_USER_IDENTITY_MODE=%r; expected one of %s. Falling back to 'none'.",
+            raw,
+            sorted(TRACE_USER_IDENTITY_MODES),
+        )
+        return "none"
+    return mode
+
+
+def _load_trace_user_identity_secret() -> str | None:
+    """Read the secret used to pseudonymize trace user identity."""
+    secret = os.getenv("AIQ_TRACE_USER_IDENTITY_HMAC_SECRET", "").strip()
+    return secret or None
+
+
+def _load_trace_client_id_mode() -> str:
+    """Read and normalize the trace client-id tagging mode."""
+    raw = os.getenv("AIQ_TRACE_CLIENT_ID_MODE", "none").strip().lower()
+    aliases = {
+        "0": "none",
+        "false": "none",
+        "off": "none",
+        "1": "ip",
+        "true": "ip",
+        "on": "ip",
+    }
+    mode = aliases.get(raw, raw)
+    if mode not in TRACE_CLIENT_ID_MODES:
+        logger.warning(
+            "Invalid AIQ_TRACE_CLIENT_ID_MODE=%r; expected one of %s. Falling back to 'none'.",
+            raw,
+            sorted(TRACE_CLIENT_ID_MODES),
+        )
+        return "none"
+    return mode
+
+
+def _load_trace_client_id_secret() -> str | None:
+    """Read the secret used to pseudonymize trace client identity."""
+    secret = os.getenv("AIQ_TRACE_CLIENT_ID_HMAC_SECRET", "").strip()
+    if secret:
+        return secret
+    return _load_trace_user_identity_secret()
+
+
+def _load_trace_client_ip_headers() -> list[str]:
+    """Read preferred client IP headers in lookup order."""
+    raw = os.getenv("AIQ_TRACE_CLIENT_IP_HEADERS", "x-real-ip,x-forwarded-for")
+    headers = [header.strip().lower() for header in raw.split(",") if header.strip()]
+    return headers
+
+
+def _build_pseudonymous_trace_user_id(principal_type: str, principal_sub: str, secret: str | None) -> str | None:
+    """Return a stable pseudonymous trace user ID derived from the verified principal."""
+    if not secret:
+        return None
+
+    payload = f"{principal_type}:{principal_sub}".encode()
+    return hmac.new(secret.encode(), payload, sha256).hexdigest()
+
+
+def _build_pseudonymous_trace_client_id(client_value: str, secret: str | None) -> str | None:
+    """Return a stable pseudonymous client ID derived from client network identity."""
+    if not secret or not client_value:
+        return None
+
+    return hmac.new(secret.encode(), f"client:{client_value}".encode(), sha256).hexdigest()
 
 
 def is_external_request(headers: dict[bytes, bytes], external_hostnames: set[str] | None = None) -> bool:
@@ -153,6 +282,88 @@ def extract_auth_token(headers: dict[bytes, bytes]) -> str | None:
         if part.startswith("idToken="):
             return part[8:]
     return None
+
+
+def _extract_auth_transport(headers: dict[bytes, bytes]) -> str:
+    """Return the request auth transport shape."""
+    auth = headers.get(b"authorization", b"").decode()
+    if auth.startswith("Bearer "):
+        return "bearer"
+
+    cookie = headers.get(b"cookie", b"").decode()
+    for part in cookie.split(";"):
+        if part.strip().startswith("idToken="):
+            return "cookie"
+    return "none"
+
+
+def _extract_header_text(headers: dict[bytes, bytes], name: str) -> str | None:
+    """Return a decoded header value for a lowercase header name."""
+    value = headers.get(name.encode())
+    if not value:
+        return None
+    decoded = value.decode().strip()
+    return decoded or None
+
+
+def _extract_client_ip(headers: dict[bytes, bytes], scope: Scope, header_names: list[str]) -> str | None:
+    """Return the best available client IP from trusted headers or ASGI scope."""
+    for header_name in header_names:
+        value = _extract_header_text(headers, header_name)
+        if not value:
+            continue
+        if header_name == "x-forwarded-for":
+            candidate = value.split(",")[0].strip()
+        else:
+            candidate = value
+        if candidate:
+            return candidate
+
+    client = scope.get("client")
+    if isinstance(client, (list, tuple)) and client:
+        host = client[0]
+        if isinstance(host, str) and host.strip():
+            return host.strip()
+    return None
+
+
+def _extract_explicit_access_channel(headers: dict[bytes, bytes]) -> str | None:
+    """Return an explicit low-cardinality access-channel override header when present."""
+    value = _extract_header_text(headers, "x-aiq-access-channel")
+    if not value:
+        return None
+    channel = value.lower()
+    if channel in TRACE_ACCESS_CHANNELS:
+        return channel
+    logger.warning("Ignoring unsupported X-AIQ-Access-Channel=%r", value)
+    return None
+
+
+def _infer_access_channel(headers: dict[bytes, bytes], user: dict[str, Any], auth_transport: str) -> str:
+    """Infer a low-cardinality access channel for observability."""
+    if explicit := _extract_explicit_access_channel(headers):
+        return explicit
+
+    caller_type = str(user.get("type") or "")
+    headless = is_headless_request(headers)
+    if auth_transport == "cookie":
+        return "ui"
+    if headless and auth_transport == "bearer":
+        return "headless"
+    if caller_type == "anonymous":
+        return "anonymous"
+    if caller_type == "internal":
+        return "internal"
+    if auth_transport == "bearer":
+        return "api"
+    return "unknown"
+
+
+def _is_verified_trace_user(user: dict[str, Any]) -> bool:
+    """Return whether the resolved request user is a verified authenticated principal."""
+    principal_sub = user.get("sub")
+    principal_type = str(user.get("type") or "")
+    return bool(principal_sub and principal_type not in {"anonymous", "internal", "unverified_jwt"})
 
 
 async def validate_token_with_validators(token: str, validators: list) -> dict[str, Any] | None:
@@ -210,6 +421,134 @@ async def resolve_request_user(
     return detect_internal_caller(headers), None, is_external
 
 
+def _build_trace_user_tags(user: dict[str, Any], mode: str, secret: str | None) -> dict[str, str]:
+    """Return trace tags for verified user identities according to policy."""
+    if mode == "none":
+        return {}
+
+    principal_sub = user.get("sub")
+    principal_type = user.get("type")
+    if not principal_sub or not principal_type:
+        return {}
+
+    pseudonymous_id = _build_pseudonymous_trace_user_id(str(principal_type), str(principal_sub), secret)
+    if pseudonymous_id is None:
+        logger.warning(
+            "AIQ_TRACE_USER_IDENTITY_MODE=%s but AIQ_TRACE_USER_IDENTITY_HMAC_SECRET is not set; "
+            "skipping user identity trace tags.",
+            mode,
+        )
+        return {}
+
+    tags = {
+        "enduser.id": pseudonymous_id,
+        "aiq.user.id": pseudonymous_id,
+        "aiq.auth.type": str(principal_type),
+    }
+    if mode == "full":
+        if email := user.get("email"):
+            tags["aiq.user.email"] = str(email)
+        if name := user.get("name"):
+            tags["aiq.user.name"] = str(name)
+    return tags
+
+
+def _build_common_trace_tags(
+    headers: dict[bytes, bytes],
+    scope: Scope,
+    user: dict[str, Any],
+    *,
+    client_id_mode: str,
+    client_id_secret: str | None,
+    client_ip_headers: list[str],
+) -> dict[str, str]:
+    """Return always-on low-risk trace tags describing request origin and auth shape."""
+    auth_transport = _extract_auth_transport(headers)
+    tags = {
+        "aiq.caller.type": str(user.get("type") or "unknown"),
+        "aiq.auth.transport": auth_transport,
+        "aiq.auth.verified": "true" if _is_verified_trace_user(user) else "false",
+        "aiq.access.channel": _infer_access_channel(headers, user, auth_transport),
+    }
+
+    if client_id_mode == "ip":
+        client_ip = _extract_client_ip(headers, scope, client_ip_headers)
+        client_id = _build_pseudonymous_trace_client_id(client_ip or "", client_id_secret)
+        if client_id:
+            tags["aiq.client.id"] = client_id
+
+    return tags
+
+
+def _tag_current_ddtrace_span(tags: dict[str, str]) -> None:
+    """Attach user tags to the active Datadog span when ddtrace is installed."""
+    if not tags:
+        return
+
+    try:
+        tracer = import_module("ddtrace").tracer
+        span = tracer.current_span()
+    except Exception:
+        return
+
+    if span is None:
+        return
+
+    for key, value in tags.items():
+        try:
+            span.set_tag(key, value)
+        except Exception:
+            logger.debug("Failed to set Datadog span tag %s", key, exc_info=True)
+
+
+def _tag_current_otel_span(tags: dict[str, str]) -> None:
+    """Attach user tags to the active OpenTelemetry span when present."""
+    if not tags:
+        return
+
+    try:
+        span = import_module("opentelemetry.trace").get_current_span()
+    except Exception:
+        return
+
+    if span is None:
+        return
+
+    for key, value in tags.items():
+        try:
+            span.set_attribute(key, value)
+        except Exception:
+            logger.debug("Failed to set OpenTelemetry span attribute %s", key, exc_info=True)
+
+
+def attach_request_to_active_trace(
+    headers: dict[bytes, bytes],
+    scope: Scope,
+    user: dict[str, Any],
+    *,
+    user_identity_mode: str,
+    user_identity_secret: str | None,
+    client_id_mode: str,
+    client_id_secret: str | None,
+    client_ip_headers: list[str],
+) -> None:
+    """Attach request classification and optional pseudonymous identity to active trace spans."""
+    tags = _build_common_trace_tags(
+        headers,
+        scope,
+        user,
+        client_id_mode=client_id_mode,
+        client_id_secret=client_id_secret,
+        client_ip_headers=client_ip_headers,
+    )
+    tags.update(_build_trace_user_tags(user, user_identity_mode, user_identity_secret))
+    if not tags:
+        return
+
+    _tag_current_ddtrace_span(tags)
+    _tag_current_otel_span(tags)
+
+
 # ---------------------------------------------------------------------------
 # Middleware
 # ---------------------------------------------------------------------------
@@ -245,6 +584,11 @@ class AuthMiddleware:
         self.require_auth = require_auth
         self._validators: list = validators or []
         self._external_hostnames: set[str] = external_hostnames or _load_external_hostnames()
+        self._trace_user_identity_mode: str = _load_trace_user_identity_mode()
+        self._trace_user_identity_secret: str | None = _load_trace_user_identity_secret()
+        self._trace_client_id_mode: str = _load_trace_client_id_mode()
+        self._trace_client_id_secret: str | None = _load_trace_client_id_secret()
+        self._trace_client_ip_headers: list[str] = _load_trace_client_ip_headers()
 
         if require_auth and not self._validators:
             logger.warning(
@@ -256,6 +600,17 @@ class AuthMiddleware:
             require_auth,
             [type(v).__name__ for v in self._validators],
             self._external_hostnames,
+        )
+        logger.info(
+            "AuthMiddleware trace user identity mode=%s secret_configured=%s",
+            self._trace_user_identity_mode,
+            bool(self._trace_user_identity_secret),
+        )
+        logger.info(
+            "AuthMiddleware trace client id mode=%s secret_configured=%s ip_headers=%s",
+            self._trace_client_id_mode,
+            bool(self._trace_client_id_secret),
+            self._trace_client_ip_headers,
         )
 
     # ------------------------------------------------------------------
@@ -278,7 +633,7 @@ class AuthMiddleware:
 
         if is_external and path in AUTH_EXEMPT_PATHS:
             user = {"type": "anonymous", "skip_clarifier": True}
-            await self._call_app(scope, receive, send, user)
+            await self._call_app(scope, receive, send, headers, user)
             return
 
         user, error_status, _ = await resolve_request_user(
@@ -292,7 +647,7 @@ class AuthMiddleware:
             await self._send_json(send, error_status or 401, {"detail": detail})
             return
 
-        await self._call_app(scope, receive, send, user)
+        await self._call_app(scope, receive, send, headers, user)
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -303,11 +658,22 @@ class AuthMiddleware:
         scope: Scope,
         receive: Receive,
         send: Send,
+        headers: dict[bytes, bytes],
         user: dict[str, Any],
     ) -> None:
         if "state" not in scope:
             scope["state"] = {}
         scope["state"]["user"] = user
+        attach_request_to_active_trace(
+            headers,
+            scope,
+            user,
+            user_identity_mode=self._trace_user_identity_mode,
+            user_identity_secret=self._trace_user_identity_secret,
+            client_id_mode=self._trace_client_id_mode,
+            client_id_secret=self._trace_client_id_secret,
+            client_ip_headers=self._trace_client_ip_headers,
+        )
 
         with user_context(user):
             await self.app(scope, receive, send)

--- a/frontends/aiq_api/src/aiq_api/auth/middleware.py
+++ b/frontends/aiq_api/src/aiq_api/auth/middleware.py
@@ -363,10 +363,13 @@ class AuthMiddleware:
         if "state" not in scope:
             scope["state"] = {}
         scope["state"]["user"] = user
+        is_external = self._is_external(headers)
+        trust_access_channel_override = (not is_external) or bool(user.get("sub"))
         attach_request_to_active_trace(
             headers,
             scope,
             user,
+            trust_access_channel_override=trust_access_channel_override,
             user_identity_mode=self._trace_user_identity_mode,
             user_identity_secret=self._trace_user_identity_secret,
             client_id_mode=self._trace_client_id_mode,

--- a/frontends/aiq_api/src/aiq_api/auth/utils.py
+++ b/frontends/aiq_api/src/aiq_api/auth/utils.py
@@ -168,8 +168,11 @@ def _extract_client_ip(headers: dict[bytes, bytes], scope: Scope, header_names: 
     return None
 
 
-def _extract_explicit_access_channel(headers: dict[bytes, bytes]) -> str | None:
+def _extract_explicit_access_channel(headers: dict[bytes, bytes], *, allow_override: bool) -> str | None:
     """Return an explicit low-cardinality access-channel override header when present."""
+    if not allow_override:
+        return None
+
     value = _extract_header_text(headers, "x-aiq-access-channel")
     if not value:
         return None
@@ -180,9 +183,15 @@ def _extract_explicit_access_channel(headers: dict[bytes, bytes]) -> str | None:
     return None
 
 
-def _infer_access_channel(headers: dict[bytes, bytes], user: dict[str, Any], auth_transport: str) -> str:
+def _infer_access_channel(
+    headers: dict[bytes, bytes],
+    user: dict[str, Any],
+    auth_transport: str,
+    *,
+    allow_explicit_override: bool,
+) -> str:
     """Infer a low-cardinality access channel for observability."""
-    if explicit := _extract_explicit_access_channel(headers):
+    if explicit := _extract_explicit_access_channel(headers, allow_override=allow_explicit_override):
         return explicit
 
     caller_type = str(user.get("type") or "")
@@ -244,6 +253,7 @@ def _build_common_trace_tags(
     scope: Scope,
     user: dict[str, Any],
     *,
+    trust_access_channel_override: bool,
     client_id_mode: str,
     client_id_secret: str | None,
     client_ip_headers: list[str],
@@ -254,7 +264,12 @@ def _build_common_trace_tags(
         "aiq.caller.type": str(user.get("type") or "unknown"),
         "aiq.auth.transport": auth_transport,
         "aiq.auth.verified": "true" if _is_verified_trace_user(user) else "false",
-        "aiq.access.channel": _infer_access_channel(headers, user, auth_transport),
+        "aiq.access.channel": _infer_access_channel(
+            headers,
+            user,
+            auth_transport,
+            allow_explicit_override=trust_access_channel_override,
+        ),
     }
 
     if client_id_mode == "ip":
@@ -309,6 +324,7 @@ def attach_request_to_active_trace(
     scope: Scope,
     user: dict[str, Any],
     *,
+    trust_access_channel_override: bool,
     user_identity_mode: str,
     user_identity_secret: str | None,
     client_id_mode: str,
@@ -320,6 +336,7 @@ def attach_request_to_active_trace(
         headers,
         scope,
         user,
+        trust_access_channel_override=trust_access_channel_override,
         client_id_mode=client_id_mode,
         client_id_secret=client_id_secret,
         client_ip_headers=client_ip_headers,

--- a/frontends/aiq_api/src/aiq_api/auth/utils.py
+++ b/frontends/aiq_api/src/aiq_api/auth/utils.py
@@ -1,0 +1,330 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for auth-related request classification and trace enrichment."""
+
+import hmac
+import logging
+import os
+from hashlib import sha256
+from importlib import import_module
+from typing import Any
+
+from starlette.types import Scope
+
+logger = logging.getLogger(__name__)
+
+TRACE_USER_IDENTITY_MODES = frozenset({"none", "id", "full"})
+TRACE_CLIENT_ID_MODES = frozenset({"none", "ip"})
+TRACE_ACCESS_CHANNELS = frozenset(
+    {
+        "ui",
+        "skill",
+        "api",
+        "headless",
+        "anonymous",
+        "internal",
+        "unknown",
+    }
+)
+
+
+def _load_trace_user_identity_mode() -> str:
+    """Read and normalize the trace user identity tagging mode."""
+    raw = os.getenv("AIQ_TRACE_USER_IDENTITY_MODE", "none").strip().lower()
+    aliases = {
+        "0": "none",
+        "false": "none",
+        "off": "none",
+        "1": "id",
+        "true": "id",
+        "on": "id",
+        "basic": "id",
+    }
+    mode = aliases.get(raw, raw)
+    if mode not in TRACE_USER_IDENTITY_MODES:
+        logger.warning(
+            "Invalid AIQ_TRACE_USER_IDENTITY_MODE=%r; expected one of %s. Falling back to 'none'.",
+            raw,
+            sorted(TRACE_USER_IDENTITY_MODES),
+        )
+        return "none"
+    return mode
+
+
+def _load_trace_user_identity_secret() -> str | None:
+    """Read the secret used to pseudonymize trace user identity."""
+    secret = os.getenv("AIQ_TRACE_USER_IDENTITY_HMAC_SECRET", "").strip()
+    return secret or None
+
+
+def _load_trace_client_id_mode() -> str:
+    """Read and normalize the trace client-id tagging mode."""
+    raw = os.getenv("AIQ_TRACE_CLIENT_ID_MODE", "none").strip().lower()
+    aliases = {
+        "0": "none",
+        "false": "none",
+        "off": "none",
+        "1": "ip",
+        "true": "ip",
+        "on": "ip",
+    }
+    mode = aliases.get(raw, raw)
+    if mode not in TRACE_CLIENT_ID_MODES:
+        logger.warning(
+            "Invalid AIQ_TRACE_CLIENT_ID_MODE=%r; expected one of %s. Falling back to 'none'.",
+            raw,
+            sorted(TRACE_CLIENT_ID_MODES),
+        )
+        return "none"
+    return mode
+
+
+def _load_trace_client_id_secret() -> str | None:
+    """Read the secret used to pseudonymize trace client identity."""
+    secret = os.getenv("AIQ_TRACE_CLIENT_ID_HMAC_SECRET", "").strip()
+    if secret:
+        return secret
+    return _load_trace_user_identity_secret()
+
+
+def _load_trace_client_ip_headers() -> list[str]:
+    """Read preferred client IP headers in lookup order."""
+    raw = os.getenv("AIQ_TRACE_CLIENT_IP_HEADERS", "x-real-ip,x-forwarded-for")
+    return [header.strip().lower() for header in raw.split(",") if header.strip()]
+
+
+def is_headless_request(headers: dict[bytes, bytes]) -> bool:
+    """Return ``True`` for headless callers that should skip the clarifier."""
+    return headers.get(b"x-aiq-mode", b"").decode().lower() == "headless"
+
+
+def _build_pseudonymous_trace_user_id(principal_type: str, principal_sub: str, secret: str | None) -> str | None:
+    """Return a stable pseudonymous trace user ID derived from the verified principal."""
+    if not secret:
+        return None
+
+    payload = f"{principal_type}:{principal_sub}".encode()
+    return hmac.new(secret.encode(), payload, sha256).hexdigest()
+
+
+def _build_pseudonymous_trace_client_id(client_value: str, secret: str | None) -> str | None:
+    """Return a stable pseudonymous client ID derived from client network identity."""
+    if not secret or not client_value:
+        return None
+
+    return hmac.new(secret.encode(), f"client:{client_value}".encode(), sha256).hexdigest()
+
+
+def _extract_auth_transport(headers: dict[bytes, bytes]) -> str:
+    """Return the request auth transport shape."""
+    auth = headers.get(b"authorization", b"").decode()
+    if auth.startswith("Bearer "):
+        return "bearer"
+
+    cookie = headers.get(b"cookie", b"").decode()
+    for part in cookie.split(";"):
+        if part.strip().startswith("idToken="):
+            return "cookie"
+    return "none"
+
+
+def _extract_header_text(headers: dict[bytes, bytes], name: str) -> str | None:
+    """Return a decoded header value for a lowercase header name."""
+    value = headers.get(name.encode())
+    if not value:
+        return None
+    decoded = value.decode().strip()
+    return decoded or None
+
+
+def _extract_client_ip(headers: dict[bytes, bytes], scope: Scope, header_names: list[str]) -> str | None:
+    """Return the best available client IP from trusted headers or ASGI scope."""
+    for header_name in header_names:
+        value = _extract_header_text(headers, header_name)
+        if not value:
+            continue
+        candidate = value.split(",")[0].strip() if header_name == "x-forwarded-for" else value
+        if candidate:
+            return candidate
+
+    client = scope.get("client")
+    if isinstance(client, (list, tuple)) and client:
+        host = client[0]
+        if isinstance(host, str) and host.strip():
+            return host.strip()
+    return None
+
+
+def _extract_explicit_access_channel(headers: dict[bytes, bytes]) -> str | None:
+    """Return an explicit low-cardinality access-channel override header when present."""
+    value = _extract_header_text(headers, "x-aiq-access-channel")
+    if not value:
+        return None
+    channel = value.lower()
+    if channel in TRACE_ACCESS_CHANNELS:
+        return channel
+    logger.warning("Ignoring unsupported X-AIQ-Access-Channel=%r", value)
+    return None
+
+
+def _infer_access_channel(headers: dict[bytes, bytes], user: dict[str, Any], auth_transport: str) -> str:
+    """Infer a low-cardinality access channel for observability."""
+    if explicit := _extract_explicit_access_channel(headers):
+        return explicit
+
+    caller_type = str(user.get("type") or "")
+    headless = is_headless_request(headers)
+    if auth_transport == "cookie":
+        return "ui"
+    if headless and auth_transport == "bearer":
+        return "headless"
+    if caller_type == "anonymous":
+        return "anonymous"
+    if caller_type == "internal":
+        return "internal"
+    if auth_transport == "bearer":
+        return "api"
+    return "unknown"
+
+
+def _is_verified_trace_user(user: dict[str, Any]) -> bool:
+    """Return whether the resolved request user is a verified authenticated principal."""
+    principal_sub = user.get("sub")
+    principal_type = str(user.get("type") or "")
+    return bool(principal_sub and principal_type not in {"anonymous", "internal", "unverified_jwt"})
+
+
+def _build_trace_user_tags(user: dict[str, Any], mode: str, secret: str | None) -> dict[str, str]:
+    """Return trace tags for verified user identities according to policy."""
+    if mode == "none" or not _is_verified_trace_user(user):
+        return {}
+
+    principal_sub = user.get("sub")
+    principal_type = user.get("type")
+    if not principal_sub or not principal_type:
+        return {}
+
+    pseudonymous_id = _build_pseudonymous_trace_user_id(str(principal_type), str(principal_sub), secret)
+    if pseudonymous_id is None:
+        logger.warning(
+            "AIQ_TRACE_USER_IDENTITY_MODE=%s but AIQ_TRACE_USER_IDENTITY_HMAC_SECRET is not set; "
+            "skipping user identity trace tags.",
+            mode,
+        )
+        return {}
+
+    tags = {
+        "enduser.id": pseudonymous_id,
+        "aiq.user.id": pseudonymous_id,
+        "aiq.auth.type": str(principal_type),
+    }
+    if mode == "full":
+        if email := user.get("email"):
+            tags["aiq.user.email"] = str(email)
+        if name := user.get("name"):
+            tags["aiq.user.name"] = str(name)
+    return tags
+
+
+def _build_common_trace_tags(
+    headers: dict[bytes, bytes],
+    scope: Scope,
+    user: dict[str, Any],
+    *,
+    client_id_mode: str,
+    client_id_secret: str | None,
+    client_ip_headers: list[str],
+) -> dict[str, str]:
+    """Return always-on low-risk trace tags describing request origin and auth shape."""
+    auth_transport = _extract_auth_transport(headers)
+    tags = {
+        "aiq.caller.type": str(user.get("type") or "unknown"),
+        "aiq.auth.transport": auth_transport,
+        "aiq.auth.verified": "true" if _is_verified_trace_user(user) else "false",
+        "aiq.access.channel": _infer_access_channel(headers, user, auth_transport),
+    }
+
+    if client_id_mode == "ip":
+        client_ip = _extract_client_ip(headers, scope, client_ip_headers)
+        client_id = _build_pseudonymous_trace_client_id(client_ip or "", client_id_secret)
+        if client_id:
+            tags["aiq.client.id"] = client_id
+
+    return tags
+
+
+def _tag_current_ddtrace_span(tags: dict[str, str]) -> None:
+    """Attach user tags to the active Datadog span when ddtrace is installed."""
+    if not tags:
+        return
+
+    try:
+        tracer = import_module("ddtrace").tracer
+        span = tracer.current_span()
+    except Exception:
+        return
+
+    if span is None:
+        return
+
+    for key, value in tags.items():
+        try:
+            span.set_tag(key, value)
+        except Exception:
+            logger.debug("Failed to set Datadog span tag %s", key, exc_info=True)
+
+
+def _tag_current_otel_span(tags: dict[str, str]) -> None:
+    """Attach user tags to the active OpenTelemetry span when present."""
+    if not tags:
+        return
+
+    try:
+        span = import_module("opentelemetry.trace").get_current_span()
+    except Exception:
+        return
+
+    for key, value in tags.items():
+        try:
+            span.set_attribute(key, value)
+        except Exception:
+            logger.debug("Failed to set OpenTelemetry span attribute %s", key, exc_info=True)
+
+
+def attach_request_to_active_trace(
+    headers: dict[bytes, bytes],
+    scope: Scope,
+    user: dict[str, Any],
+    *,
+    user_identity_mode: str,
+    user_identity_secret: str | None,
+    client_id_mode: str,
+    client_id_secret: str | None,
+    client_ip_headers: list[str],
+) -> None:
+    """Attach request classification and optional pseudonymous identity to active trace spans."""
+    tags = _build_common_trace_tags(
+        headers,
+        scope,
+        user,
+        client_id_mode=client_id_mode,
+        client_id_secret=client_id_secret,
+        client_ip_headers=client_ip_headers,
+    )
+    tags.update(_build_trace_user_tags(user, user_identity_mode, user_identity_secret))
+
+    _tag_current_ddtrace_span(tags)
+    _tag_current_otel_span(tags)

--- a/frontends/aiq_api/tests/test_auth.py
+++ b/frontends/aiq_api/tests/test_auth.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import json
 import os
+import sys
+import types
 from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
@@ -463,6 +465,372 @@ class TestAuthMiddlewareInternal:
 
         assert state["user"]["type"] == "unverified_jwt"
         assert state["user"]["token"] == "badtoken"
+
+    @pytest.mark.asyncio
+    async def test_verified_user_tags_active_ddtrace_span(self, capture_asgi):
+        app, _state = capture_asgi
+        span_tags: dict[str, str] = {}
+
+        class FakeSpan:
+            def set_tag(self, key: str, value: str) -> None:
+                span_tags[key] = value
+
+        ddtrace_module = types.ModuleType("ddtrace")
+        ddtrace_module.tracer = types.SimpleNamespace(current_span=lambda: FakeSpan())
+
+        mock_v = MagicMock()
+        mock_v.can_handle.return_value = True
+        mock_v.validate = AsyncMock(
+            return_value={
+                "type": "starfleet",
+                "sub": "user-123",
+                "email": "alice@example.com",
+                "name": "Alice",
+                "token": "good",
+            }
+        )
+
+        async def send(msg):
+            pass
+
+        scope = _http_scope(
+            "/chat",
+            extra_headers=[(b"authorization", b"Bearer eyJhbGciOiJIUzI1NiJ9.x.y")],
+        )
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "AIQ_TRACE_USER_IDENTITY_MODE": "full",
+                    "AIQ_TRACE_USER_IDENTITY_HMAC_SECRET": "test-secret",
+                },
+                clear=False,
+            ),
+            patch.dict(sys.modules, {"ddtrace": ddtrace_module}, clear=False),
+        ):
+            mw = AuthMiddleware(app, validators=[mock_v], require_auth=True, external_hostnames=set())
+            await mw(scope, AsyncMock(), send)
+
+        expected_id = middleware_module._build_pseudonymous_trace_user_id("starfleet", "user-123", "test-secret")
+        assert span_tags == {
+            "enduser.id": expected_id,
+            "aiq.user.id": expected_id,
+            "aiq.auth.type": "starfleet",
+            "aiq.user.email": "alice@example.com",
+            "aiq.user.name": "Alice",
+            "aiq.caller.type": "starfleet",
+            "aiq.auth.transport": "bearer",
+            "aiq.auth.verified": "true",
+            "aiq.access.channel": "api",
+        }
+
+    @pytest.mark.asyncio
+    async def test_verified_user_tags_active_otel_span(self, capture_asgi):
+        app, _state = capture_asgi
+        span_attributes: dict[str, str] = {}
+
+        class FakeSpan:
+            def set_attribute(self, key: str, value: str) -> None:
+                span_attributes[key] = value
+
+        opentelemetry_module = types.ModuleType("opentelemetry")
+        trace_module = types.ModuleType("opentelemetry.trace")
+        trace_module.get_current_span = lambda: FakeSpan()
+
+        mock_v = MagicMock()
+        mock_v.can_handle.return_value = True
+        mock_v.validate = AsyncMock(return_value={"type": "nvauth", "sub": "svc-user", "token": "good"})
+
+        async def send(msg):
+            pass
+
+        scope = _http_scope(
+            "/chat",
+            extra_headers=[(b"authorization", b"Bearer eyJhbGciOiJIUzI1NiJ9.x.y")],
+        )
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "AIQ_TRACE_USER_IDENTITY_MODE": "id",
+                    "AIQ_TRACE_USER_IDENTITY_HMAC_SECRET": "test-secret",
+                },
+                clear=False,
+            ),
+            patch.dict(
+                sys.modules,
+                {"opentelemetry": opentelemetry_module, "opentelemetry.trace": trace_module},
+                clear=False,
+            ),
+        ):
+            mw = AuthMiddleware(app, validators=[mock_v], require_auth=True, external_hostnames=set())
+            await mw(scope, AsyncMock(), send)
+
+        expected_id = middleware_module._build_pseudonymous_trace_user_id("nvauth", "svc-user", "test-secret")
+        assert span_attributes == {
+            "enduser.id": expected_id,
+            "aiq.user.id": expected_id,
+            "aiq.auth.type": "nvauth",
+            "aiq.caller.type": "nvauth",
+            "aiq.auth.transport": "bearer",
+            "aiq.auth.verified": "true",
+            "aiq.access.channel": "api",
+        }
+
+    @pytest.mark.asyncio
+    async def test_none_mode_does_not_tag_verified_user(self, capture_asgi):
+        app, _state = capture_asgi
+        span_tags: dict[str, str] = {}
+
+        class FakeSpan:
+            def set_tag(self, key: str, value: str) -> None:
+                span_tags[key] = value
+
+        ddtrace_module = types.ModuleType("ddtrace")
+        ddtrace_module.tracer = types.SimpleNamespace(current_span=lambda: FakeSpan())
+
+        mock_v = MagicMock()
+        mock_v.can_handle.return_value = True
+        mock_v.validate = AsyncMock(return_value={"type": "starfleet", "sub": "user-123", "token": "good"})
+
+        async def send(msg):
+            pass
+
+        scope = _http_scope(
+            "/chat",
+            extra_headers=[(b"authorization", b"Bearer eyJhbGciOiJIUzI1NiJ9.x.y")],
+        )
+        with (
+            patch.dict(
+                os.environ,
+                {"AIQ_TRACE_USER_IDENTITY_MODE": "none"},
+                clear=False,
+            ),
+            patch.dict(sys.modules, {"ddtrace": ddtrace_module}, clear=False),
+        ):
+            mw = AuthMiddleware(app, validators=[mock_v], require_auth=True, external_hostnames=set())
+            await mw(scope, AsyncMock(), send)
+
+        assert span_tags == {
+            "aiq.caller.type": "starfleet",
+            "aiq.auth.transport": "bearer",
+            "aiq.auth.verified": "true",
+            "aiq.access.channel": "api",
+        }
+
+    @pytest.mark.asyncio
+    async def test_always_on_common_tags_present_without_user_identity(self, capture_asgi):
+        app, _state = capture_asgi
+        span_tags: dict[str, str] = {}
+
+        class FakeSpan:
+            def set_tag(self, key: str, value: str) -> None:
+                span_tags[key] = value
+
+        ddtrace_module = types.ModuleType("ddtrace")
+        ddtrace_module.tracer = types.SimpleNamespace(current_span=lambda: FakeSpan())
+
+        mock_v = MagicMock()
+        mock_v.can_handle.return_value = True
+        mock_v.validate = AsyncMock(return_value={"type": "starfleet", "sub": "user-123", "token": "good"})
+
+        async def send(msg):
+            pass
+
+        scope = _http_scope(
+            "/chat",
+            extra_headers=[(b"authorization", b"Bearer eyJhbGciOiJIUzI1NiJ9.x.y")],
+        )
+        with (
+            patch.dict(
+                os.environ,
+                {"AIQ_TRACE_USER_IDENTITY_MODE": "none", "AIQ_TRACE_CLIENT_ID_MODE": "none"},
+                clear=False,
+            ),
+            patch.dict(sys.modules, {"ddtrace": ddtrace_module}, clear=False),
+        ):
+            mw = AuthMiddleware(app, validators=[mock_v], require_auth=True, external_hostnames=set())
+            await mw(scope, AsyncMock(), send)
+
+        assert span_tags == {
+            "aiq.caller.type": "starfleet",
+            "aiq.auth.transport": "bearer",
+            "aiq.auth.verified": "true",
+            "aiq.access.channel": "api",
+        }
+
+    @pytest.mark.asyncio
+    async def test_missing_secret_does_not_tag_verified_user(self, capture_asgi):
+        app, _state = capture_asgi
+        span_tags: dict[str, str] = {}
+
+        class FakeSpan:
+            def set_tag(self, key: str, value: str) -> None:
+                span_tags[key] = value
+
+        ddtrace_module = types.ModuleType("ddtrace")
+        ddtrace_module.tracer = types.SimpleNamespace(current_span=lambda: FakeSpan())
+
+        mock_v = MagicMock()
+        mock_v.can_handle.return_value = True
+        mock_v.validate = AsyncMock(return_value={"type": "starfleet", "sub": "user-123", "token": "good"})
+
+        async def send(msg):
+            pass
+
+        scope = _http_scope(
+            "/chat",
+            extra_headers=[(b"authorization", b"Bearer eyJhbGciOiJIUzI1NiJ9.x.y")],
+        )
+        with (
+            patch.dict(
+                os.environ,
+                {"AIQ_TRACE_USER_IDENTITY_MODE": "id", "AIQ_TRACE_USER_IDENTITY_HMAC_SECRET": ""},
+                clear=False,
+            ),
+            patch.dict(sys.modules, {"ddtrace": ddtrace_module}, clear=False),
+        ):
+            mw = AuthMiddleware(app, validators=[mock_v], require_auth=True, external_hostnames=set())
+            await mw(scope, AsyncMock(), send)
+
+        assert span_tags == {
+            "aiq.caller.type": "starfleet",
+            "aiq.auth.transport": "bearer",
+            "aiq.auth.verified": "true",
+            "aiq.access.channel": "api",
+        }
+
+    @pytest.mark.asyncio
+    async def test_explicit_access_channel_override_wins(self, capture_asgi):
+        app, _state = capture_asgi
+        span_tags: dict[str, str] = {}
+
+        class FakeSpan:
+            def set_tag(self, key: str, value: str) -> None:
+                span_tags[key] = value
+
+        ddtrace_module = types.ModuleType("ddtrace")
+        ddtrace_module.tracer = types.SimpleNamespace(current_span=lambda: FakeSpan())
+
+        mock_v = MagicMock()
+        mock_v.can_handle.return_value = True
+        mock_v.validate = AsyncMock(return_value={"type": "starfleet", "sub": "user-123", "token": "good"})
+
+        async def send(msg):
+            pass
+
+        scope = _http_scope(
+            "/chat",
+            extra_headers=[
+                (b"authorization", b"Bearer eyJhbGciOiJIUzI1NiJ9.x.y"),
+                (b"x-aiq-access-channel", b"skill"),
+                (b"x-aiq-mode", b"headless"),
+            ],
+        )
+        with (
+            patch.dict(
+                os.environ,
+                {"AIQ_TRACE_USER_IDENTITY_MODE": "none", "AIQ_TRACE_CLIENT_ID_MODE": "none"},
+                clear=False,
+            ),
+            patch.dict(sys.modules, {"ddtrace": ddtrace_module}, clear=False),
+        ):
+            mw = AuthMiddleware(app, validators=[mock_v], require_auth=True, external_hostnames=set())
+            await mw(scope, AsyncMock(), send)
+
+        assert span_tags["aiq.access.channel"] == "skill"
+
+    @pytest.mark.asyncio
+    async def test_client_ip_mode_adds_pseudonymous_client_id(self, capture_asgi):
+        app, _state = capture_asgi
+        span_tags: dict[str, str] = {}
+
+        class FakeSpan:
+            def set_tag(self, key: str, value: str) -> None:
+                span_tags[key] = value
+
+        ddtrace_module = types.ModuleType("ddtrace")
+        ddtrace_module.tracer = types.SimpleNamespace(current_span=lambda: FakeSpan())
+
+        mock_v = MagicMock()
+        mock_v.can_handle.return_value = True
+        mock_v.validate = AsyncMock(return_value={"type": "anonymous", "skip_clarifier": True})
+
+        async def send(msg):
+            pass
+
+        scope = _http_scope(
+            "/health",
+            host=b"api.public.example",
+            extra_headers=[(b"x-forwarded-for", b"203.0.113.10, 10.0.0.1")],
+        )
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "AIQ_TRACE_USER_IDENTITY_MODE": "none",
+                    "AIQ_TRACE_CLIENT_ID_MODE": "ip",
+                    "AIQ_TRACE_CLIENT_ID_HMAC_SECRET": "client-secret",
+                },
+                clear=False,
+            ),
+            patch.dict(sys.modules, {"ddtrace": ddtrace_module}, clear=False),
+        ):
+            mw = AuthMiddleware(app, validators=[mock_v], require_auth=False, external_hostnames={"api.public.example"})
+            await mw(scope, AsyncMock(), send)
+
+        expected_client_id = middleware_module._build_pseudonymous_trace_client_id("203.0.113.10", "client-secret")
+        assert span_tags == {
+            "aiq.caller.type": "anonymous",
+            "aiq.auth.transport": "none",
+            "aiq.auth.verified": "false",
+            "aiq.access.channel": "anonymous",
+            "aiq.client.id": expected_client_id,
+        }
+
+    @pytest.mark.asyncio
+    async def test_unverified_internal_token_does_not_tag_active_span(self, capture_asgi):
+        app, _state = capture_asgi
+        span_tags: dict[str, str] = {}
+
+        class FakeSpan:
+            def set_tag(self, key: str, value: str) -> None:
+                span_tags[key] = value
+
+        ddtrace_module = types.ModuleType("ddtrace")
+        ddtrace_module.tracer = types.SimpleNamespace(current_span=lambda: FakeSpan())
+
+        mock_v = MagicMock()
+        mock_v.can_handle.return_value = True
+        mock_v.validate = AsyncMock(return_value=None)
+
+        async def send(msg):
+            pass
+
+        scope = _http_scope(
+            "/chat",
+            extra_headers=[(b"authorization", b"Bearer badtoken")],
+        )
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "AIQ_TRACE_USER_IDENTITY_MODE": "full",
+                    "AIQ_TRACE_USER_IDENTITY_HMAC_SECRET": "test-secret",
+                },
+                clear=False,
+            ),
+            patch.dict(sys.modules, {"ddtrace": ddtrace_module}, clear=False),
+        ):
+            mw = AuthMiddleware(app, validators=[mock_v], require_auth=False, external_hostnames=set())
+            await mw(scope, AsyncMock(), send)
+
+        assert span_tags == {
+            "aiq.caller.type": "unverified_jwt",
+            "aiq.auth.transport": "bearer",
+            "aiq.auth.verified": "false",
+            "aiq.access.channel": "api",
+        }
 
 
 class TestAuthMiddlewareHelpers:

--- a/frontends/aiq_api/tests/test_auth.py
+++ b/frontends/aiq_api/tests/test_auth.py
@@ -502,7 +502,7 @@ class TestAuthMiddlewareInternal:
                 os.environ,
                 {
                     "AIQ_TRACE_USER_IDENTITY_MODE": "full",
-                    "AIQ_TRACE_USER_IDENTITY_HMAC_SECRET": "test-secret",
+                    "AIQ_TRACE_USER_IDENTITY_HMAC_SECRET": "test-secret",  # pragma: allowlist secret
                 },
                 clear=False,
             ),
@@ -553,7 +553,7 @@ class TestAuthMiddlewareInternal:
                 os.environ,
                 {
                     "AIQ_TRACE_USER_IDENTITY_MODE": "id",
-                    "AIQ_TRACE_USER_IDENTITY_HMAC_SECRET": "test-secret",
+                    "AIQ_TRACE_USER_IDENTITY_HMAC_SECRET": "test-secret",  # pragma: allowlist secret
                 },
                 clear=False,
             ),
@@ -770,7 +770,7 @@ class TestAuthMiddlewareInternal:
                 {
                     "AIQ_TRACE_USER_IDENTITY_MODE": "none",
                     "AIQ_TRACE_CLIENT_ID_MODE": "ip",
-                    "AIQ_TRACE_CLIENT_ID_HMAC_SECRET": "client-secret",
+                    "AIQ_TRACE_CLIENT_ID_HMAC_SECRET": "client-secret",  # pragma: allowlist secret
                 },
                 clear=False,
             ),
@@ -816,7 +816,7 @@ class TestAuthMiddlewareInternal:
                 os.environ,
                 {
                     "AIQ_TRACE_USER_IDENTITY_MODE": "full",
-                    "AIQ_TRACE_USER_IDENTITY_HMAC_SECRET": "test-secret",
+                    "AIQ_TRACE_USER_IDENTITY_HMAC_SECRET": "test-secret",  # pragma: allowlist secret
                 },
                 clear=False,
             ),

--- a/frontends/aiq_api/tests/test_auth.py
+++ b/frontends/aiq_api/tests/test_auth.py
@@ -741,6 +741,39 @@ class TestAuthMiddlewareInternal:
         assert span_tags["aiq.access.channel"] == "skill"
 
     @pytest.mark.asyncio
+    async def test_explicit_access_channel_ignored_for_external_anonymous_request(self, capture_asgi, external_host):
+        app, _state = capture_asgi
+        span_tags: dict[str, str] = {}
+
+        class FakeSpan:
+            def set_tag(self, key: str, value: str) -> None:
+                span_tags[key] = value
+
+        ddtrace_module = types.ModuleType("ddtrace")
+        ddtrace_module.tracer = types.SimpleNamespace(current_span=lambda: FakeSpan())
+
+        async def send(msg):
+            pass
+
+        scope = _http_scope(
+            "/health",
+            host=external_host,
+            extra_headers=[(b"x-aiq-access-channel", b"internal")],
+        )
+        with (
+            patch.dict(
+                os.environ,
+                {"AIQ_TRACE_USER_IDENTITY_MODE": "none", "AIQ_TRACE_CLIENT_ID_MODE": "none"},
+                clear=False,
+            ),
+            patch.dict(sys.modules, {"ddtrace": ddtrace_module}, clear=False),
+        ):
+            mw = AuthMiddleware(app, validators=[], require_auth=False, external_hostnames={external_host.decode()})
+            await mw(scope, AsyncMock(), send)
+
+        assert span_tags["aiq.access.channel"] == "anonymous"
+
+    @pytest.mark.asyncio
     async def test_client_ip_mode_adds_pseudonymous_client_id(self, capture_asgi):
         app, _state = capture_asgi
         span_tags: dict[str, str] = {}

--- a/frontends/ui/src/adapters/auth/constants.ts
+++ b/frontends/ui/src/adapters/auth/constants.ts
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const ACCESS_CHANNEL_HEADER = 'X-AIQ-Access-Channel'

--- a/frontends/ui/src/app/api/chat/route.ts
+++ b/frontends/ui/src/app/api/chat/route.ts
@@ -16,6 +16,8 @@ import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { isAuthRequired } from '@/adapters/auth/config'
 
+const ACCESS_CHANNEL_HEADER = 'X-AIQ-Access-Channel'
+
 const getBackendUrl = (): string => {
   const url = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000'
   return url.replace(/\/$/, '')
@@ -48,6 +50,7 @@ export async function POST(req: Request): Promise<Response> {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        [ACCESS_CHANNEL_HEADER]: 'ui',
         ...(authToken ? { Authorization: authToken } : {}),
         // Forward the idToken cookie to the backend
         ...(idToken ? { Cookie: `idToken=${idToken}` } : {}),

--- a/frontends/ui/src/app/api/chat/route.ts
+++ b/frontends/ui/src/app/api/chat/route.ts
@@ -14,9 +14,8 @@
 
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
+import { ACCESS_CHANNEL_HEADER } from '@/adapters/auth/constants'
 import { isAuthRequired } from '@/adapters/auth/config'
-
-const ACCESS_CHANNEL_HEADER = 'X-AIQ-Access-Channel'
 
 const getBackendUrl = (): string => {
   const url = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000'

--- a/frontends/ui/src/app/api/jobs/async/[...path]/route.ts
+++ b/frontends/ui/src/app/api/jobs/async/[...path]/route.ts
@@ -28,6 +28,8 @@ import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { isAuthRequired } from '@/adapters/auth/config'
 
+const ACCESS_CHANNEL_HEADER = 'X-AIQ-Access-Channel'
+
 const getBackendUrl = (): string => {
   const url = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000'
   return url.replace(/\/$/, '')
@@ -52,7 +54,7 @@ const buildBackendUrl = (path: string[]): string => {
 const getAuthHeaders = async (req: Request, pathSegments: string[]): Promise<Record<string, string>> => {
   // Skip auth when REQUIRE_AUTH=false - don't forward any auth info to backend
   if (!isAuthRequired()) {
-    return {}
+    return { [ACCESS_CHANNEL_HEADER]: 'ui' }
   }
 
   // Only allow query token for stream paths (EventSource can't set headers).
@@ -73,6 +75,7 @@ const getAuthHeaders = async (req: Request, pathSegments: string[]): Promise<Rec
   const idToken = cookieIdToken || queryToken
 
   return {
+    [ACCESS_CHANNEL_HEADER]: 'ui',
     ...(authToken ? { Authorization: authToken } : {}),
     // Forward the idToken cookie to the backend
     ...(idToken ? { Cookie: `idToken=${idToken}` } : {}),

--- a/frontends/ui/src/app/api/jobs/async/[...path]/route.ts
+++ b/frontends/ui/src/app/api/jobs/async/[...path]/route.ts
@@ -26,9 +26,8 @@
 
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
+import { ACCESS_CHANNEL_HEADER } from '@/adapters/auth/constants'
 import { isAuthRequired } from '@/adapters/auth/config'
-
-const ACCESS_CHANNEL_HEADER = 'X-AIQ-Access-Channel'
 
 const getBackendUrl = (): string => {
   const url = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000'

--- a/frontends/ui/src/app/api/v1/[...path]/route.ts
+++ b/frontends/ui/src/app/api/v1/[...path]/route.ts
@@ -19,6 +19,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { isAuthRequired } from '@/adapters/auth/config'
 
+const ACCESS_CHANNEL_HEADER = 'X-AIQ-Access-Channel'
+
 const getBackendUrl = (): string => {
   const url = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000'
   return url.replace(/\/$/, '')
@@ -33,7 +35,7 @@ const buildBackendUrl = (path: string[]): string => {
 const getAuthHeaders = async (req: NextRequest): Promise<Record<string, string>> => {
   // Skip auth when REQUIRE_AUTH=false - don't forward any auth info to backend
   if (!isAuthRequired()) {
-    return {}
+    return { [ACCESS_CHANNEL_HEADER]: 'ui' }
   }
 
   const authToken = req.headers.get('Authorization')
@@ -41,6 +43,7 @@ const getAuthHeaders = async (req: NextRequest): Promise<Record<string, string>>
   const idToken = cookieStore.get('idToken')?.value
 
   return {
+    [ACCESS_CHANNEL_HEADER]: 'ui',
     ...(authToken ? { Authorization: authToken } : {}),
     ...(idToken ? { Cookie: `idToken=${idToken}` } : {}),
   }

--- a/frontends/ui/src/app/api/v1/[...path]/route.ts
+++ b/frontends/ui/src/app/api/v1/[...path]/route.ts
@@ -17,9 +17,8 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
+import { ACCESS_CHANNEL_HEADER } from '@/adapters/auth/constants'
 import { isAuthRequired } from '@/adapters/auth/config'
-
-const ACCESS_CHANNEL_HEADER = 'X-AIQ-Access-Channel'
 
 const getBackendUrl = (): string => {
   const url = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000'


### PR DESCRIPTION
## Summary
- add always-on request trace classification tags plus optional pseudonymous user and client ids in aiq_api auth middleware
- support explicit low-cardinality access channel tagging and have the public UI proxy routes send ui
- document the new env vars and observability contract and cover the middleware behavior with auth tests

## Testing
- uv run pytest frontends/aiq_api/tests/test_auth.py -k "tags_active or common_tags or missing_secret or explicit_access_channel or client_ip_mode or does_not_tag_active_span or none_mode"