### PR TITLE
Propagate AIQ request tags to NAT spans

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -128,10 +128,3 @@ FILE_EXPIRATION_CHECK_INTERVAL_HOURS=0
 # - /app/configs/config_web_default_llamaindex.yml
 # - /app/configs/config_web_frag.yml
 # BACKEND_CONFIG=
-#
-# Optional trace enrichment for aiq_api auth middleware:
-# AIQ_TRACE_USER_IDENTITY_MODE=none
-# AIQ_TRACE_USER_IDENTITY_HMAC_SECRET=
-# AIQ_TRACE_CLIENT_ID_MODE=none
-# AIQ_TRACE_CLIENT_ID_HMAC_SECRET=
-# AIQ_TRACE_CLIENT_IP_HEADERS=x-real-ip,x-forwarded-for

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -128,3 +128,10 @@ FILE_EXPIRATION_CHECK_INTERVAL_HOURS=0
 # - /app/configs/config_web_default_llamaindex.yml
 # - /app/configs/config_web_frag.yml
 # BACKEND_CONFIG=
+#
+# Optional NAT span request tag enrichment for aiq_api auth middleware:
+# AIQ_TRACE_USER_IDENTITY_MODE=none
+# AIQ_TRACE_USER_IDENTITY_HMAC_SECRET=
+# AIQ_TRACE_CLIENT_ID_MODE=none
+# AIQ_TRACE_CLIENT_ID_HMAC_SECRET=
+# AIQ_TRACE_CLIENT_IP_HEADERS=x-real-ip,x-forwarded-for

--- a/docs/source/customization/configuration-reference.md
+++ b/docs/source/customization/configuration-reference.md
@@ -78,6 +78,16 @@ general:
 | `front_end.expiry_seconds` | `int` | `86400` | How long completed jobs remain in the database (seconds). |
 | `front_end.cors` | `object` | -- | CORS settings for the API server. |
 
+For `aiq_api`, request tag enrichment for NAT-exported spans is configured via
+environment variables rather than YAML fields. See `frontends/aiq_api/README.md`
+and the [Observability](../deployment/observability.md) guide for:
+
+- `AIQ_TRACE_USER_IDENTITY_MODE`
+- `AIQ_TRACE_USER_IDENTITY_HMAC_SECRET`
+- `AIQ_TRACE_CLIENT_ID_MODE`
+- `AIQ_TRACE_CLIENT_ID_HMAC_SECRET`
+- `AIQ_TRACE_CLIENT_IP_HEADERS`
+
 ---
 
 ## `llms` Section

--- a/docs/source/customization/configuration-reference.md
+++ b/docs/source/customization/configuration-reference.md
@@ -78,16 +78,6 @@ general:
 | `front_end.expiry_seconds` | `int` | `86400` | How long completed jobs remain in the database (seconds). |
 | `front_end.cors` | `object` | -- | CORS settings for the API server. |
 
-For `aiq_api`, request-trace enrichment is configured via environment variables
-rather than YAML fields. See `frontends/aiq_api/README.md` and the
-[Observability](../deployment/observability.md) guide for:
-
-- `AIQ_TRACE_USER_IDENTITY_MODE`
-- `AIQ_TRACE_USER_IDENTITY_HMAC_SECRET`
-- `AIQ_TRACE_CLIENT_ID_MODE`
-- `AIQ_TRACE_CLIENT_ID_HMAC_SECRET`
-- `AIQ_TRACE_CLIENT_IP_HEADERS`
-
 ---
 
 ## `llms` Section

--- a/docs/source/deployment/observability.md
+++ b/docs/source/deployment/observability.md
@@ -206,6 +206,37 @@ general:
 | `redaction_headers` | Request headers checked to determine whether to redact. |
 | `resource_attributes` | Custom OTEL resource attributes attached to all spans. |
 
+### Request Tags on NAT Spans
+
+When the `aiq_api` auth middleware is enabled, NAT-exported workflow spans can
+include low-cardinality request tags plus optional pseudonymous identity tags.
+These tags are propagated across HTTP requests, WebSocket workflows, and async
+job execution.
+
+Always-on NAT span tags:
+
+- `nat.aiq.caller.type` -- resolved caller type from auth middleware
+- `nat.aiq.auth.transport` -- `bearer`, `cookie`, or `none`
+- `nat.aiq.auth.verified` -- whether the request resolved to a verified principal
+- `nat.aiq.access.channel` -- inferred request channel or trusted explicit access-channel header
+
+Optional pseudonymous tags:
+
+- `nat.enduser.id`, `nat.aiq.user.id`, `nat.aiq.auth.type` -- controlled by `AIQ_TRACE_USER_IDENTITY_MODE`
+- `nat.aiq.user.email`, `nat.aiq.user.name` -- added only in `full` mode
+- `nat.aiq.client.id` -- controlled by `AIQ_TRACE_CLIENT_ID_MODE=ip`
+
+Environment variables:
+
+- `AIQ_TRACE_USER_IDENTITY_MODE=none|id|full`
+- `AIQ_TRACE_USER_IDENTITY_HMAC_SECRET=<secret>`
+- `AIQ_TRACE_CLIENT_ID_MODE=none|ip`
+- `AIQ_TRACE_CLIENT_ID_HMAC_SECRET=<secret>`
+- `AIQ_TRACE_CLIENT_IP_HEADERS=x-real-ip,x-forwarded-for`
+
+The `id` and `ip` modes emit HMAC-derived pseudonymous identifiers rather than
+raw subjects or raw IP addresses.
+
 ### Batch Configuration
 
 The exporter supports standard OTEL batch settings:

--- a/docs/source/deployment/observability.md
+++ b/docs/source/deployment/observability.md
@@ -206,52 +206,6 @@ general:
 | `redaction_headers` | Request headers checked to determine whether to redact. |
 | `resource_attributes` | Custom OTEL resource attributes attached to all spans. |
 
-### Request Classification Tags
-
-When the `aiq_api` auth middleware is enabled, request spans can include a set
-of low-risk request tags plus optional pseudonymous identity tags.
-
-Always-on request tags:
-
-- `aiq.caller.type` -- resolved caller type from auth middleware
-- `aiq.auth.transport` -- `bearer`, `cookie`, or `none`
-- `aiq.auth.verified` -- whether the request resolved to a verified principal
-- `aiq.access.channel` -- inferred request channel or the explicit `X-AIQ-Access-Channel` header
-
-Optional pseudonymous tags:
-
-- `enduser.id`, `aiq.user.id`, `aiq.auth.type` -- controlled by `AIQ_TRACE_USER_IDENTITY_MODE`
-- `aiq.user.email`, `aiq.user.name` -- added only in `full` mode
-- `aiq.client.id` -- controlled by `AIQ_TRACE_CLIENT_ID_MODE=ip`
-
-Environment variables:
-
-- `AIQ_TRACE_USER_IDENTITY_MODE=none|id|full`
-- `AIQ_TRACE_USER_IDENTITY_HMAC_SECRET=<secret>`
-- `AIQ_TRACE_CLIENT_ID_MODE=none|ip`
-- `AIQ_TRACE_CLIENT_ID_HMAC_SECRET=<secret>`
-- `AIQ_TRACE_CLIENT_IP_HEADERS=x-real-ip,x-forwarded-for`
-
-The `id` and `ip` modes emit HMAC-derived pseudonymous identifiers rather than
-raw subjects or raw IP addresses.
-
-### Access Channel Header
-
-Deployment-specific wrappers can set the optional request header
-`X-AIQ-Access-Channel` to separate traffic sources without modifying public
-middleware. Supported values are:
-
-- `ui`
-- `skill`
-- `api`
-- `headless`
-- `anonymous`
-- `internal`
-- `unknown`
-
-When absent, the middleware falls back to generic inference from auth transport
-and request shape.
-
 ### Batch Configuration
 
 The exporter supports standard OTEL batch settings:

--- a/docs/source/deployment/production.md
+++ b/docs/source/deployment/production.md
@@ -120,6 +120,16 @@ Set `LOG_LEVEL=DEBUG` for verbose output during troubleshooting. Use `LOG_LEVEL=
 
 The backend supports OpenTelemetry-compatible tracing. See [Observability](./observability.md) for setup guides covering Phoenix, LangSmith, Weave, and the OTEL Collector with privacy redaction.
 
+If you are deploying the `aiq_api` front-end and want request correlation on
+NAT-exported spans, set the relevant environment variables at deploy time rather
+than hardcoding them in code:
+
+- `AIQ_TRACE_USER_IDENTITY_MODE`
+- `AIQ_TRACE_USER_IDENTITY_HMAC_SECRET`
+- `AIQ_TRACE_CLIENT_ID_MODE`
+- `AIQ_TRACE_CLIENT_ID_HMAC_SECRET`
+- `AIQ_TRACE_CLIENT_IP_HEADERS`
+
 ### Metrics to Watch
 
 | Metric | Source | What to look for |

--- a/docs/source/deployment/production.md
+++ b/docs/source/deployment/production.md
@@ -120,19 +120,6 @@ Set `LOG_LEVEL=DEBUG` for verbose output during troubleshooting. Use `LOG_LEVEL=
 
 The backend supports OpenTelemetry-compatible tracing. See [Observability](./observability.md) for setup guides covering Phoenix, LangSmith, Weave, and the OTEL Collector with privacy redaction.
 
-If you are deploying the `aiq_api` front-end and want request correlation in
-traces, set the relevant environment variables at deploy time rather than
-hardcoding them in code:
-
-- `AIQ_TRACE_USER_IDENTITY_MODE`
-- `AIQ_TRACE_USER_IDENTITY_HMAC_SECRET`
-- `AIQ_TRACE_CLIENT_ID_MODE`
-- `AIQ_TRACE_CLIENT_ID_HMAC_SECRET`
-- `AIQ_TRACE_CLIENT_IP_HEADERS`
-
-Deployment-specific wrappers may also set `X-AIQ-Access-Channel` to distinguish
-UI, skill, and API traffic at the request level.
-
 ### Metrics to Watch
 
 | Metric | Source | What to look for |

--- a/frontends/aiq_api/README.md
+++ b/frontends/aiq_api/README.md
@@ -198,6 +198,11 @@ is disabled by default and opt-in via the `REQUIRE_AUTH` environment variable.
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `REQUIRE_AUTH` | Enforce authentication on all non-exempt routes | `false` |
+| `AIQ_TRACE_USER_IDENTITY_MODE` | Control whether verified user identity is attached to NAT spans: `none`, `id`, or `full` | `none` |
+| `AIQ_TRACE_USER_IDENTITY_HMAC_SECRET` | Secret used to pseudonymize verified user IDs in traces when identity tagging is enabled | unset |
+| `AIQ_TRACE_CLIENT_ID_MODE` | Control whether a pseudonymous client identifier is attached to NAT spans: `none` or `ip` | `none` |
+| `AIQ_TRACE_CLIENT_ID_HMAC_SECRET` | Secret used to pseudonymize client IDs when client tagging is enabled; falls back to the user-identity secret | unset |
+| `AIQ_TRACE_CLIENT_IP_HEADERS` | Ordered comma-separated client IP headers to trust before falling back to the ASGI client address | `x-real-ip,x-forwarded-for` |
 
 ### Enabling authentication
 
@@ -206,6 +211,40 @@ starts.  The server raises a `RuntimeError` at startup if auth is required but
 no validators are registered.
 
 Two registration mechanisms are supported — pick whichever fits your deployment:
+
+### NAT span request tagging
+
+Auth middleware can enrich NAT-exported workflow spans with low-risk request
+tags and optional pseudonymous identity tags. The resolved tags are propagated
+through HTTP requests, WebSocket workflow execution, and async jobs.
+
+Always-on NAT span tags:
+
+- `nat.aiq.caller.type`: resolved caller type from the auth middleware
+- `nat.aiq.auth.transport`: `bearer`, `cookie`, or `none`
+- `nat.aiq.auth.verified`: whether the request resolved to a verified principal
+- `nat.aiq.access.channel`: inferred or explicitly supplied access channel
+
+Optional user identity tags are controlled by `AIQ_TRACE_USER_IDENTITY_MODE`:
+
+- `none`: disable user identity tagging entirely
+- `id`: tag only pseudonymous stable identifiers (`nat.enduser.id`, `nat.aiq.user.id`, `nat.aiq.auth.type`)
+- `full`: tag pseudonymous identifiers plus `nat.aiq.user.email` and `nat.aiq.user.name` when present
+
+Only verified principals are tagged. Anonymous, internal, and unverified JWT
+fallback callers are never attached to traces.
+Set `AIQ_TRACE_USER_IDENTITY_HMAC_SECRET` when using `id` or `full`; otherwise
+identity tagging is skipped.
+
+Optional client correlation is controlled by `AIQ_TRACE_CLIENT_ID_MODE`:
+
+- `none`: disable client correlation
+- `ip`: add `nat.aiq.client.id` as an HMAC-derived pseudonymous identifier from
+  the client IP
+
+Set `AIQ_TRACE_CLIENT_ID_HMAC_SECRET` when using `ip`. If unset, the middleware
+falls back to `AIQ_TRACE_USER_IDENTITY_HMAC_SECRET`. `AIQ_TRACE_CLIENT_IP_HEADERS`
+controls which ingress headers are consulted first.
 
 #### 1. Programmatic (`register_validator`)
 

--- a/frontends/aiq_api/README.md
+++ b/frontends/aiq_api/README.md
@@ -198,11 +198,6 @@ is disabled by default and opt-in via the `REQUIRE_AUTH` environment variable.
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `REQUIRE_AUTH` | Enforce authentication on all non-exempt routes | `false` |
-| `AIQ_TRACE_USER_IDENTITY_MODE` | Control whether verified user identity is attached to request traces: `none`, `id`, or `full` | `none` |
-| `AIQ_TRACE_USER_IDENTITY_HMAC_SECRET` | Secret used to pseudonymize verified user IDs in traces when identity tagging is enabled | unset |
-| `AIQ_TRACE_CLIENT_ID_MODE` | Control whether a pseudonymous client identifier is attached to request traces: `none` or `ip` | `none` |
-| `AIQ_TRACE_CLIENT_ID_HMAC_SECRET` | Secret used to pseudonymize client IDs when client tagging is enabled; falls back to the user-identity secret | unset |
-| `AIQ_TRACE_CLIENT_IP_HEADERS` | Ordered comma-separated client IP headers to trust before falling back to the ASGI client address | `x-real-ip,x-forwarded-for` |
 
 ### Enabling authentication
 
@@ -211,59 +206,6 @@ starts.  The server raises a `RuntimeError` at startup if auth is required but
 no validators are registered.
 
 Two registration mechanisms are supported — pick whichever fits your deployment:
-
-### Trace identity tagging
-
-Auth middleware can enrich active Datadog / OpenTelemetry request spans with
-low-risk request tags and optional pseudonymous identity tags.
-
-Always-on request tags:
-
-- `aiq.caller.type`: resolved caller type from the auth middleware
-- `aiq.auth.transport`: `bearer`, `cookie`, or `none`
-- `aiq.auth.verified`: whether the request resolved to a verified principal
-- `aiq.access.channel`: inferred or explicitly supplied access channel
-
-Optional user identity tags are controlled by `AIQ_TRACE_USER_IDENTITY_MODE`:
-
-- `none`: disable user identity tagging entirely
-- `id`: tag only pseudonymous stable identifiers (`enduser.id`, `aiq.user.id`, `aiq.auth.type`)
-- `full`: tag pseudonymous identifiers plus `aiq.user.email` and `aiq.user.name` when present
-
-Only verified principals are tagged. Anonymous, internal, and unverified JWT
-fallback callers are never attached to traces.
-Set `AIQ_TRACE_USER_IDENTITY_HMAC_SECRET` when using `id` or `full`; otherwise
-identity tagging is skipped.
-
-Optional client correlation is controlled by `AIQ_TRACE_CLIENT_ID_MODE`:
-
-- `none`: disable client correlation
-- `ip`: add `aiq.client.id` as an HMAC-derived pseudonymous identifier from the
-  client IP
-
-Set `AIQ_TRACE_CLIENT_ID_HMAC_SECRET` when using `ip`. If unset, the middleware
-falls back to `AIQ_TRACE_USER_IDENTITY_HMAC_SECRET`. `AIQ_TRACE_CLIENT_IP_HEADERS`
-controls which ingress headers are consulted first.
-
-### Access Channel Header
-
-Upstream middleware accepts an optional low-cardinality request header:
-
-- `X-AIQ-Access-Channel: <channel>`
-
-Supported values are:
-
-- `ui`
-- `skill`
-- `api`
-- `headless`
-- `anonymous`
-- `internal`
-- `unknown`
-
-When absent, the middleware falls back to generic inference from auth transport
-and request shape. Deployment-specific wrappers can set this header explicitly
-to separate UI, skill, and API traffic without modifying public middleware.
 
 #### 1. Programmatic (`register_validator`)
 

--- a/frontends/aiq_api/src/aiq_api/auth/__init__.py
+++ b/frontends/aiq_api/src/aiq_api/auth/__init__.py
@@ -19,6 +19,7 @@ from .base import TokenValidator
 from .errors import AuthError
 from .jwt_validator import JWTValidator
 from .middleware import AuthMiddleware
+from .middleware import get_current_trace_tags
 from .middleware import get_current_user
 
 __all__ = [
@@ -26,5 +27,6 @@ __all__ = [
     "AuthMiddleware",
     "JWTValidator",
     "TokenValidator",
+    "get_current_trace_tags",
     "get_current_user",
 ]

--- a/frontends/aiq_api/src/aiq_api/auth/middleware.py
+++ b/frontends/aiq_api/src/aiq_api/auth/middleware.py
@@ -99,6 +99,9 @@ from starlette.types import Receive
 from starlette.types import Scope
 from starlette.types import Send
 
+from aiq_agent.observability.request_trace_injector import get_request_trace_tags
+from aiq_agent.observability.request_trace_injector import request_trace_tag_context
+
 from . import utils as auth_utils
 from .utils import _load_trace_client_id_mode
 from .utils import _load_trace_client_id_secret
@@ -130,6 +133,11 @@ def get_current_user() -> dict[str, Any]:
     the middleware is not registered or when called outside a request context.
     """
     return _current_user.get()
+
+
+def get_current_trace_tags() -> dict[str, str]:
+    """Return request trace tags resolved by ``AuthMiddleware`` for this request."""
+    return get_request_trace_tags()
 
 
 @contextmanager
@@ -365,7 +373,7 @@ class AuthMiddleware:
         scope["state"]["user"] = user
         is_external = self._is_external(headers)
         trust_access_channel_override = (not is_external) or bool(user.get("sub"))
-        attach_request_to_active_trace(
+        request_trace_tags = attach_request_to_active_trace(
             headers,
             scope,
             user,
@@ -377,7 +385,7 @@ class AuthMiddleware:
             client_ip_headers=self._trace_client_ip_headers,
         )
 
-        with user_context(user):
+        with user_context(user), request_trace_tag_context(request_trace_tags):
             await self.app(scope, receive, send)
 
     def _is_external(self, headers: dict[bytes, bytes]) -> bool:

--- a/frontends/aiq_api/src/aiq_api/auth/middleware.py
+++ b/frontends/aiq_api/src/aiq_api/auth/middleware.py
@@ -99,16 +99,17 @@ from starlette.types import Receive
 from starlette.types import Scope
 from starlette.types import Send
 
-from aiq_agent.observability.request_trace_injector import get_request_trace_tags
-from aiq_agent.observability.request_trace_injector import request_trace_tag_context
-
 from . import utils as auth_utils
+from .request_trace import get_request_trace_tags
+from .request_trace import install_request_trace_span_injection
+from .request_trace import request_trace_tag_context
 from .utils import _load_trace_client_id_mode
 from .utils import _load_trace_client_id_secret
 from .utils import _load_trace_client_ip_headers
 from .utils import _load_trace_user_identity_mode
 from .utils import _load_trace_user_identity_secret
 from .utils import attach_request_to_active_trace
+from .utils import build_request_trace_tags as _build_request_trace_tags
 from .utils import is_headless_request
 
 logger = logging.getLogger(__name__)
@@ -148,6 +149,29 @@ def user_context(user: dict[str, Any]):
         yield
     finally:
         _current_user.reset(token)
+
+
+def build_request_trace_tags(
+    headers: dict[bytes, bytes],
+    scope: Scope,
+    user: dict[str, Any],
+    *,
+    external_hostnames: set[str] | None = None,
+) -> dict[str, str]:
+    """Build request trace tags using the same policy as ``AuthMiddleware``."""
+    is_external = is_external_request(headers, external_hostnames)
+    trust_access_channel_override = (not is_external) or bool(user.get("sub"))
+    return _build_request_trace_tags(
+        headers,
+        scope,
+        user,
+        trust_access_channel_override=trust_access_channel_override,
+        user_identity_mode=_load_trace_user_identity_mode(),
+        user_identity_secret=_load_trace_user_identity_secret(),
+        client_id_mode=_load_trace_client_id_mode(),
+        client_id_secret=_load_trace_client_id_secret(),
+        client_ip_headers=_load_trace_client_ip_headers(),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -296,6 +320,7 @@ class AuthMiddleware:
         self._trace_client_id_mode: str = _load_trace_client_id_mode()
         self._trace_client_id_secret: str | None = _load_trace_client_id_secret()
         self._trace_client_ip_headers: list[str] = _load_trace_client_ip_headers()
+        install_request_trace_span_injection()
 
         if require_auth and not self._validators:
             logger.warning(

--- a/frontends/aiq_api/src/aiq_api/auth/request_trace.py
+++ b/frontends/aiq_api/src/aiq_api/auth/request_trace.py
@@ -50,12 +50,20 @@ def install_request_trace_span_injection() -> None:
 
     def patched_process_start_event(self, event) -> None:
         process_start_event(self, event)
+        tags = get_request_trace_tags()
+        if not tags:
+            return
+
         try:
             span = self._outstanding_spans.get(event.UUID)
         except Exception:
-            span = None
-        if span is not None:
-            _inject_request_trace_attributes(span)
+            logger.debug("Failed to look up NAT span for request trace tags", exc_info=True)
+            return
+        if span is None:
+            logger.debug("No NAT span found for request trace tag injection: %s", event.UUID)
+            return
+
+        _inject_request_trace_attributes(span)
 
     patched_process_start_event.__aiq_request_trace_patched__ = True
     SpanExporter._process_start_event = patched_process_start_event

--- a/frontends/aiq_api/src/aiq_api/auth/utils.py
+++ b/frontends/aiq_api/src/aiq_api/auth/utils.py
@@ -330,7 +330,7 @@ def attach_request_to_active_trace(
     client_id_mode: str,
     client_id_secret: str | None,
     client_ip_headers: list[str],
-) -> None:
+) -> dict[str, str]:
     """Attach request classification and optional pseudonymous identity to active trace spans."""
     tags = _build_common_trace_tags(
         headers,
@@ -345,3 +345,4 @@ def attach_request_to_active_trace(
 
     _tag_current_ddtrace_span(tags)
     _tag_current_otel_span(tags)
+    return tags

--- a/frontends/aiq_api/src/aiq_api/auth/utils.py
+++ b/frontends/aiq_api/src/aiq_api/auth/utils.py
@@ -31,7 +31,6 @@ TRACE_CLIENT_ID_MODES = frozenset({"none", "ip"})
 TRACE_ACCESS_CHANNELS = frozenset(
     {
         "ui",
-        "skill",
         "api",
         "headless",
         "anonymous",

--- a/frontends/aiq_api/src/aiq_api/auth/utils.py
+++ b/frontends/aiq_api/src/aiq_api/auth/utils.py
@@ -319,6 +319,32 @@ def _tag_current_otel_span(tags: dict[str, str]) -> None:
             logger.debug("Failed to set OpenTelemetry span attribute %s", key, exc_info=True)
 
 
+def build_request_trace_tags(
+    headers: dict[bytes, bytes],
+    scope: Scope,
+    user: dict[str, Any],
+    *,
+    trust_access_channel_override: bool,
+    user_identity_mode: str,
+    user_identity_secret: str | None,
+    client_id_mode: str,
+    client_id_secret: str | None,
+    client_ip_headers: list[str],
+) -> dict[str, str]:
+    """Build request classification and optional pseudonymous identity trace tags."""
+    tags = _build_common_trace_tags(
+        headers,
+        scope,
+        user,
+        trust_access_channel_override=trust_access_channel_override,
+        client_id_mode=client_id_mode,
+        client_id_secret=client_id_secret,
+        client_ip_headers=client_ip_headers,
+    )
+    tags.update(_build_trace_user_tags(user, user_identity_mode, user_identity_secret))
+    return tags
+
+
 def attach_request_to_active_trace(
     headers: dict[bytes, bytes],
     scope: Scope,
@@ -332,16 +358,17 @@ def attach_request_to_active_trace(
     client_ip_headers: list[str],
 ) -> dict[str, str]:
     """Attach request classification and optional pseudonymous identity to active trace spans."""
-    tags = _build_common_trace_tags(
+    tags = build_request_trace_tags(
         headers,
         scope,
         user,
         trust_access_channel_override=trust_access_channel_override,
+        user_identity_mode=user_identity_mode,
+        user_identity_secret=user_identity_secret,
         client_id_mode=client_id_mode,
         client_id_secret=client_id_secret,
         client_ip_headers=client_ip_headers,
     )
-    tags.update(_build_trace_user_tags(user, user_identity_mode, user_identity_secret))
 
     _tag_current_ddtrace_span(tags)
     _tag_current_otel_span(tags)

--- a/frontends/aiq_api/src/aiq_api/jobs/runner.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/runner.py
@@ -251,8 +251,8 @@ async def run_agent_job(
 
         _auth_token_reset = job_auth_token.set(auth_token)
 
-    from aiq_agent.observability.request_trace_injector import install_request_trace_span_injection
-    from aiq_agent.observability.request_trace_injector import request_trace_tag_context
+    from aiq_api.auth.request_trace import install_request_trace_span_injection
+    from aiq_api.auth.request_trace import request_trace_tag_context
 
     install_request_trace_span_injection()
 

--- a/frontends/aiq_api/src/aiq_api/jobs/runner.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/runner.py
@@ -205,6 +205,7 @@ async def run_agent_job(
     parent_workflow_run_id: str | None = None,
     parent_workflow_trace_id: int | str | None = None,
     parent_conversation_id: str | None = None,
+    request_trace_tags: dict[str, str] | None = None,
     available_documents: list[dict] | None = None,
     data_sources: list[str] | None = None,
     auth_token: str | None = None,
@@ -234,6 +235,7 @@ async def run_agent_job(
         parent_workflow_run_id: Parent workflow run ID for trace grouping.
         parent_workflow_trace_id: Parent trace ID (int or hex string) for trace continuity.
         parent_conversation_id: Conversation ID for session grouping in Phoenix.
+        request_trace_tags: Request trace tags captured at async submission time.
         available_documents: Optional list of document dicts with file_name and summary.
         data_sources: Optional list of allowed data sources to enforce in the worker.
         auth_token: Optional auth token propagated from the HTTP request for
@@ -248,6 +250,11 @@ async def run_agent_job(
         from ._auth_context import job_auth_token
 
         _auth_token_reset = job_auth_token.set(auth_token)
+
+    from aiq_agent.observability.request_trace_injector import install_request_trace_span_injection
+    from aiq_agent.observability.request_trace_injector import request_trace_tag_context
+
+    install_request_trace_span_injection()
 
     from aiq_agent.common import LLMProvider
     from aiq_agent.common import LLMRole
@@ -394,113 +401,114 @@ async def run_agent_job(
             )
 
             # Run with telemetry - exporter must start before pushing events
-            async with exporter_manager.start(context_state=context_state):
-                # Link to parent span if provided (for nested trace continuity)
-                parent_metadata: TraceMetadata | None = None
-                if parent_span_id and parent_span_id != "root":
-                    parent_metadata = TraceMetadata(
-                        provided_metadata={
-                            "workflow_run_id": parent_workflow_run_id,
-                            "workflow_trace_id": f"{workflow_trace_id:032x}",
-                            "conversation_id": parent_conversation_id,
-                            "workflow_name": parent_function_name,
-                        }
-                    )
+            with request_trace_tag_context(request_trace_tags or {}):
+                async with exporter_manager.start(context_state=context_state):
+                    # Link to parent span if provided (for nested trace continuity)
+                    parent_metadata: TraceMetadata | None = None
+                    if parent_span_id and parent_span_id != "root":
+                        parent_metadata = TraceMetadata(
+                            provided_metadata={
+                                "workflow_run_id": parent_workflow_run_id,
+                                "workflow_trace_id": f"{workflow_trace_id:032x}",
+                                "conversation_id": parent_conversation_id,
+                                "workflow_name": parent_function_name,
+                            }
+                        )
+                        context.intermediate_step_manager.push_intermediate_step(
+                            IntermediateStepPayload(
+                                UUID=parent_span_id,
+                                event_type=IntermediateStepType.SPAN_START,
+                                name=parent_function_name or "parent_workflow",
+                                metadata=parent_metadata,
+                            )
+                        )
+
+                    # Push WORKFLOW_START first so LLM/tool events become children
                     context.intermediate_step_manager.push_intermediate_step(
                         IntermediateStepPayload(
-                            UUID=parent_span_id,
-                            event_type=IntermediateStepType.SPAN_START,
-                            name=parent_function_name or "parent_workflow",
-                            metadata=parent_metadata,
+                            UUID=job_id,
+                            event_type=IntermediateStepType.WORKFLOW_START,
+                            name=workflow_span_name,
+                            metadata=workflow_metadata,
+                            data=StreamEventData(input=input_text),
                         )
                     )
 
-                # Push WORKFLOW_START first so LLM/tool events become children
-                context.intermediate_step_manager.push_intermediate_step(
-                    IntermediateStepPayload(
-                        UUID=job_id,
-                        event_type=IntermediateStepType.WORKFLOW_START,
-                        name=workflow_span_name,
-                        metadata=workflow_metadata,
-                        data=StreamEventData(input=input_text),
+                    # Create profiler callback AFTER workflow starts (ensures correct parent)
+                    nat_profiler_callback = LangchainProfilerHandler()
+
+                    # Set up LLM provider
+                    provider = LLMProvider()
+                    provider.set_default(llm)
+                    if orchestrator_llm:
+                        provider.configure(LLMRole.ORCHESTRATOR, orchestrator_llm)
+                    if planner_llm:
+                        provider.configure(LLMRole.PLANNER, planner_llm)
+                    if researcher_llm:
+                        provider.configure(LLMRole.RESEARCHER, researcher_llm)
+
+                    verbose = is_verbose(getattr(fn_config, "verbose", False))
+                    callbacks = [VerboseTraceCallback()] if verbose else []
+
+                    raw_event_store = EventStore(db_url, job_id)
+                    event_store = BatchingEventStore(raw_event_store)
+                    callbacks.append(AgentEventCallback(event_store))
+                    callbacks.append(nat_profiler_callback)
+
+                    # Instantiate agent with callbacks
+                    agent = _create_agent_instance(
+                        agent_cls=agent_cls,
+                        llm_provider=provider,
+                        llm=llm,
+                        tools=tools,
+                        fn_config=fn_config,
+                        verbose=verbose,
+                        callbacks=callbacks,
                     )
-                )
 
-                # Create profiler callback AFTER workflow starts (ensures correct parent)
-                nat_profiler_callback = LangchainProfilerHandler()
-
-                # Set up LLM provider
-                provider = LLMProvider()
-                provider.set_default(llm)
-                if orchestrator_llm:
-                    provider.configure(LLMRole.ORCHESTRATOR, orchestrator_llm)
-                if planner_llm:
-                    provider.configure(LLMRole.PLANNER, planner_llm)
-                if researcher_llm:
-                    provider.configure(LLMRole.RESEARCHER, researcher_llm)
-
-                verbose = is_verbose(getattr(fn_config, "verbose", False))
-                callbacks = [VerboseTraceCallback()] if verbose else []
-
-                raw_event_store = EventStore(db_url, job_id)
-                event_store = BatchingEventStore(raw_event_store)
-                callbacks.append(AgentEventCallback(event_store))
-                callbacks.append(nat_profiler_callback)
-
-                # Instantiate agent with callbacks
-                agent = _create_agent_instance(
-                    agent_cls=agent_cls,
-                    llm_provider=provider,
-                    llm=llm,
-                    tools=tools,
-                    fn_config=fn_config,
-                    verbose=verbose,
-                    callbacks=callbacks,
-                )
-
-                # Run agent - LLM/tool events will be nested under workflow span
-                result = await _run_agent(
-                    agent=agent,
-                    input_text=input_text,
-                    monitor=cancellation_monitor,
-                    available_documents=available_documents,
-                    data_sources=data_sources,
-                    event_store=event_store,
-                )
-
-                # Emit WORKFLOW_END event for Phoenix
-                context.intermediate_step_manager.push_intermediate_step(
-                    IntermediateStepPayload(
-                        UUID=job_id,
-                        event_type=IntermediateStepType.WORKFLOW_END,
-                        name=workflow_span_name,
-                        metadata=workflow_metadata,
-                        data=StreamEventData(output=_extract_result(result)),
+                    # Run agent - LLM/tool events will be nested under workflow span
+                    result = await _run_agent(
+                        agent=agent,
+                        input_text=input_text,
+                        monitor=cancellation_monitor,
+                        available_documents=available_documents,
+                        data_sources=data_sources,
+                        event_store=event_store,
                     )
-                )
 
-                if parent_metadata:
+                    # Emit WORKFLOW_END event for Phoenix
                     context.intermediate_step_manager.push_intermediate_step(
                         IntermediateStepPayload(
-                            UUID=parent_span_id,
-                            event_type=IntermediateStepType.SPAN_END,
-                            name=parent_function_name or "parent_workflow",
-                            metadata=parent_metadata,
+                            UUID=job_id,
+                            event_type=IntermediateStepType.WORKFLOW_END,
+                            name=workflow_span_name,
+                            metadata=workflow_metadata,
+                            data=StreamEventData(output=_extract_result(result)),
                         )
                     )
 
-                # Signal event stream completion
-                event_stream.on_complete()
+                    if parent_metadata:
+                        context.intermediate_step_manager.push_intermediate_step(
+                            IntermediateStepPayload(
+                                UUID=parent_span_id,
+                                event_type=IntermediateStepType.SPAN_END,
+                                name=parent_function_name or "parent_workflow",
+                                metadata=parent_metadata,
+                            )
+                        )
 
-                # Flush any buffered events before updating status
-                if hasattr(event_store, "flush"):
-                    event_store.flush()
+                    # Signal event stream completion
+                    event_stream.on_complete()
 
-                # Extract report and update status inside the context manager
-                # so the UI sees completion before exporter flush and cleanup
-                report = _extract_result(result)
-                await job_store.update_status(job_id, JobStatus.SUCCESS, output={"report": report})
-                logger.info("Job %s completed (report: %d chars)", job_id, len(report))
+                    # Flush any buffered events before updating status
+                    if hasattr(event_store, "flush"):
+                        event_store.flush()
+
+                    # Extract report and update status inside the context manager
+                    # so the UI sees completion before exporter flush and cleanup
+                    report = _extract_result(result)
+                    await job_store.update_status(job_id, JobStatus.SUCCESS, output={"report": report})
+                    logger.info("Job %s completed (report: %d chars)", job_id, len(report))
 
     except asyncio.CancelledError:
         logger.info("Job %s cancelled", job_id)

--- a/frontends/aiq_api/src/aiq_api/jobs/submit.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/submit.py
@@ -27,6 +27,7 @@ import os
 
 from aiq_agent.auth import Principal
 from aiq_agent.auth import get_current_principal
+from aiq_api.auth import get_current_trace_tags
 
 from ..registry import get_agent_config
 from .access import _make_no_auth_principal
@@ -61,6 +62,7 @@ def _get_parent_trace_context() -> tuple[
     str | None,  # parent_workflow_run_id
     int | str | None,  # parent_workflow_trace_id
     str | None,  # parent_conversation_id
+    dict[str, str],  # request_trace_tags
 ]:
     """
     Extract trace context from current workflow for propagation to async jobs.
@@ -70,12 +72,12 @@ def _get_parent_trace_context() -> tuple[
 
     Returns:
         Tuple of (parent_span_id, parent_function_id, parent_function_name,
-                  parent_workflow_run_id, parent_workflow_trace_id, parent_conversation_id)
+                  parent_workflow_run_id, parent_workflow_trace_id, parent_conversation_id, request_trace_tags)
     """
     try:
         from nat.builder.context import ContextState
     except ImportError:
-        return (None, None, None, None, None, None)
+        return (None, None, None, None, None, None, {})
 
     context_state = ContextState.get()
 
@@ -104,6 +106,7 @@ def _get_parent_trace_context() -> tuple[
         parent_workflow_run_id,
         parent_workflow_trace_id,
         parent_conversation_id,
+        get_current_trace_tags(),
     )
 
 

--- a/frontends/aiq_api/src/aiq_api/websocket_reconnect.py
+++ b/frontends/aiq_api/src/aiq_api/websocket_reconnect.py
@@ -27,6 +27,8 @@ from pydantic import BaseModel
 from pydantic import ValidationError
 from starlette.websockets import WebSocketDisconnect
 
+from aiq_agent.observability.request_trace_injector import request_trace_tag_context
+from aiq_api.auth.middleware import build_request_trace_tags
 from aiq_api.auth.middleware import detect_internal_caller
 from aiq_api.auth.middleware import resolve_request_user
 from aiq_api.auth.middleware import user_context
@@ -262,8 +264,10 @@ class ReconnectableWebSocketMessageHandler(WebSocketMessageHandler):
     async def process_workflow_request(self, user_message_as_validated_type: WebSocketUserMessage) -> None:
         """Process user messages and register sockets for reconnect."""
         await _registry.set_socket(user_message_as_validated_type.conversation_id, self._socket)
-        current_user = self._authenticated_user or detect_internal_caller(dict(self._socket.scope.get("headers", [])))
-        with user_context(current_user):
+        headers = dict(self._socket.scope.get("headers", []))
+        current_user = self._authenticated_user or detect_internal_caller(headers)
+        request_trace_tags = build_request_trace_tags(headers, self._socket.scope, current_user)
+        with user_context(current_user), request_trace_tag_context(request_trace_tags):
             await super().process_workflow_request(user_message_as_validated_type)
         # TODO(NAT-upstream): _running_workflow_task is currently always None
         # because NAT's message_handler.py assigns via method chaining:

--- a/frontends/aiq_api/src/aiq_api/websocket_reconnect.py
+++ b/frontends/aiq_api/src/aiq_api/websocket_reconnect.py
@@ -27,11 +27,11 @@ from pydantic import BaseModel
 from pydantic import ValidationError
 from starlette.websockets import WebSocketDisconnect
 
-from aiq_agent.observability.request_trace_injector import request_trace_tag_context
 from aiq_api.auth.middleware import build_request_trace_tags
 from aiq_api.auth.middleware import detect_internal_caller
 from aiq_api.auth.middleware import resolve_request_user
 from aiq_api.auth.middleware import user_context
+from aiq_api.auth.request_trace import request_trace_tag_context
 from nat.data_models.api_server import Error
 from nat.data_models.api_server import ErrorTypes
 from nat.data_models.api_server import ResponseObservabilityTrace
@@ -266,7 +266,12 @@ class ReconnectableWebSocketMessageHandler(WebSocketMessageHandler):
         await _registry.set_socket(user_message_as_validated_type.conversation_id, self._socket)
         headers = dict(self._socket.scope.get("headers", []))
         current_user = self._authenticated_user or detect_internal_caller(headers)
-        request_trace_tags = build_request_trace_tags(headers, self._socket.scope, current_user)
+        request_trace_tags = build_request_trace_tags(
+            headers,
+            self._socket.scope,
+            current_user,
+            external_hostnames=_external_hostnames,
+        )
         with user_context(current_user), request_trace_tag_context(request_trace_tags):
             await super().process_workflow_request(user_message_as_validated_type)
         # TODO(NAT-upstream): _running_workflow_task is currently always None

--- a/frontends/aiq_api/tests/test_auth.py
+++ b/frontends/aiq_api/tests/test_auth.py
@@ -411,7 +411,7 @@ class TestAuthMiddlewareInternal:
         app, state = capture_asgi
         mock_v = MagicMock()
         mock_v.can_handle.return_value = True
-        mock_v.validate = AsyncMock(return_value={"type": "starfleet", "sub": "user-1", "token": "good"})
+        mock_v.validate = AsyncMock(return_value={"type": "oidc", "sub": "user-1", "token": "good"})
         mw = AuthMiddleware(app, validators=[mock_v], require_auth=True, external_hostnames=set())
 
         async def send(msg):
@@ -423,7 +423,7 @@ class TestAuthMiddlewareInternal:
         )
         await mw(scope, AsyncMock(), send)
 
-        assert state["user"]["type"] == "starfleet"
+        assert state["user"]["type"] == "oidc"
         assert state["user"]["sub"] == "user-1"
 
     @pytest.mark.asyncio
@@ -482,7 +482,7 @@ class TestAuthMiddlewareInternal:
         mock_v.can_handle.return_value = True
         mock_v.validate = AsyncMock(
             return_value={
-                "type": "starfleet",
+                "type": "oidc",
                 "sub": "user-123",
                 "email": "alice@example.com",
                 "name": "Alice",
@@ -511,14 +511,14 @@ class TestAuthMiddlewareInternal:
             mw = AuthMiddleware(app, validators=[mock_v], require_auth=True, external_hostnames=set())
             await mw(scope, AsyncMock(), send)
 
-        expected_id = middleware_module._build_pseudonymous_trace_user_id("starfleet", "user-123", "test-secret")
+        expected_id = middleware_module._build_pseudonymous_trace_user_id("oidc", "user-123", "test-secret")
         assert span_tags == {
             "enduser.id": expected_id,
             "aiq.user.id": expected_id,
-            "aiq.auth.type": "starfleet",
+            "aiq.auth.type": "oidc",
             "aiq.user.email": "alice@example.com",
             "aiq.user.name": "Alice",
-            "aiq.caller.type": "starfleet",
+            "aiq.caller.type": "oidc",
             "aiq.auth.transport": "bearer",
             "aiq.auth.verified": "true",
             "aiq.access.channel": "api",
@@ -539,7 +539,7 @@ class TestAuthMiddlewareInternal:
 
         mock_v = MagicMock()
         mock_v.can_handle.return_value = True
-        mock_v.validate = AsyncMock(return_value={"type": "nvauth", "sub": "svc-user", "token": "good"})
+        mock_v.validate = AsyncMock(return_value={"type": "service", "sub": "svc-user", "token": "good"})
 
         async def send(msg):
             pass
@@ -566,12 +566,12 @@ class TestAuthMiddlewareInternal:
             mw = AuthMiddleware(app, validators=[mock_v], require_auth=True, external_hostnames=set())
             await mw(scope, AsyncMock(), send)
 
-        expected_id = middleware_module._build_pseudonymous_trace_user_id("nvauth", "svc-user", "test-secret")
+        expected_id = middleware_module._build_pseudonymous_trace_user_id("service", "svc-user", "test-secret")
         assert span_attributes == {
             "enduser.id": expected_id,
             "aiq.user.id": expected_id,
-            "aiq.auth.type": "nvauth",
-            "aiq.caller.type": "nvauth",
+            "aiq.auth.type": "service",
+            "aiq.caller.type": "service",
             "aiq.auth.transport": "bearer",
             "aiq.auth.verified": "true",
             "aiq.access.channel": "api",
@@ -591,7 +591,7 @@ class TestAuthMiddlewareInternal:
 
         mock_v = MagicMock()
         mock_v.can_handle.return_value = True
-        mock_v.validate = AsyncMock(return_value={"type": "starfleet", "sub": "user-123", "token": "good"})
+        mock_v.validate = AsyncMock(return_value={"type": "oidc", "sub": "user-123", "token": "good"})
 
         async def send(msg):
             pass
@@ -612,7 +612,7 @@ class TestAuthMiddlewareInternal:
             await mw(scope, AsyncMock(), send)
 
         assert span_tags == {
-            "aiq.caller.type": "starfleet",
+            "aiq.caller.type": "oidc",
             "aiq.auth.transport": "bearer",
             "aiq.auth.verified": "true",
             "aiq.access.channel": "api",
@@ -632,7 +632,7 @@ class TestAuthMiddlewareInternal:
 
         mock_v = MagicMock()
         mock_v.can_handle.return_value = True
-        mock_v.validate = AsyncMock(return_value={"type": "starfleet", "sub": "user-123", "token": "good"})
+        mock_v.validate = AsyncMock(return_value={"type": "oidc", "sub": "user-123", "token": "good"})
 
         async def send(msg):
             pass
@@ -653,7 +653,7 @@ class TestAuthMiddlewareInternal:
             await mw(scope, AsyncMock(), send)
 
         assert span_tags == {
-            "aiq.caller.type": "starfleet",
+            "aiq.caller.type": "oidc",
             "aiq.auth.transport": "bearer",
             "aiq.auth.verified": "true",
             "aiq.access.channel": "api",
@@ -673,7 +673,7 @@ class TestAuthMiddlewareInternal:
 
         mock_v = MagicMock()
         mock_v.can_handle.return_value = True
-        mock_v.validate = AsyncMock(return_value={"type": "starfleet", "sub": "user-123", "token": "good"})
+        mock_v.validate = AsyncMock(return_value={"type": "oidc", "sub": "user-123", "token": "good"})
 
         async def send(msg):
             pass
@@ -694,7 +694,7 @@ class TestAuthMiddlewareInternal:
             await mw(scope, AsyncMock(), send)
 
         assert span_tags == {
-            "aiq.caller.type": "starfleet",
+            "aiq.caller.type": "oidc",
             "aiq.auth.transport": "bearer",
             "aiq.auth.verified": "true",
             "aiq.access.channel": "api",
@@ -714,7 +714,7 @@ class TestAuthMiddlewareInternal:
 
         mock_v = MagicMock()
         mock_v.can_handle.return_value = True
-        mock_v.validate = AsyncMock(return_value={"type": "starfleet", "sub": "user-123", "token": "good"})
+        mock_v.validate = AsyncMock(return_value={"type": "oidc", "sub": "user-123", "token": "good"})
 
         async def send(msg):
             pass
@@ -723,7 +723,7 @@ class TestAuthMiddlewareInternal:
             "/chat",
             extra_headers=[
                 (b"authorization", b"Bearer eyJhbGciOiJIUzI1NiJ9.x.y"),
-                (b"x-aiq-access-channel", b"skill"),
+                (b"x-aiq-access-channel", b"headless"),
                 (b"x-aiq-mode", b"headless"),
             ],
         )
@@ -738,7 +738,7 @@ class TestAuthMiddlewareInternal:
             mw = AuthMiddleware(app, validators=[mock_v], require_auth=True, external_hostnames=set())
             await mw(scope, AsyncMock(), send)
 
-        assert span_tags["aiq.access.channel"] == "skill"
+        assert span_tags["aiq.access.channel"] == "headless"
 
     @pytest.mark.asyncio
     async def test_explicit_access_channel_ignored_for_external_anonymous_request(self, capture_asgi, external_host):

--- a/frontends/ui/src/adapters/auth/constants.ts
+++ b/frontends/ui/src/adapters/auth/constants.ts
@@ -1,4 +1,0 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-export const ACCESS_CHANNEL_HEADER = 'X-AIQ-Access-Channel'

--- a/frontends/ui/src/app/api/chat/route.ts
+++ b/frontends/ui/src/app/api/chat/route.ts
@@ -14,7 +14,6 @@
 
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
-import { ACCESS_CHANNEL_HEADER } from '@/adapters/auth/constants'
 import { isAuthRequired } from '@/adapters/auth/config'
 
 const getBackendUrl = (): string => {
@@ -49,7 +48,6 @@ export async function POST(req: Request): Promise<Response> {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        [ACCESS_CHANNEL_HEADER]: 'ui',
         ...(authToken ? { Authorization: authToken } : {}),
         // Forward the idToken cookie to the backend
         ...(idToken ? { Cookie: `idToken=${idToken}` } : {}),

--- a/frontends/ui/src/app/api/jobs/async/[...path]/route.ts
+++ b/frontends/ui/src/app/api/jobs/async/[...path]/route.ts
@@ -26,7 +26,6 @@
 
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
-import { ACCESS_CHANNEL_HEADER } from '@/adapters/auth/constants'
 import { isAuthRequired } from '@/adapters/auth/config'
 
 const getBackendUrl = (): string => {
@@ -53,7 +52,7 @@ const buildBackendUrl = (path: string[]): string => {
 const getAuthHeaders = async (req: Request, pathSegments: string[]): Promise<Record<string, string>> => {
   // Skip auth when REQUIRE_AUTH=false - don't forward any auth info to backend
   if (!isAuthRequired()) {
-    return { [ACCESS_CHANNEL_HEADER]: 'ui' }
+    return {}
   }
 
   // Only allow query token for stream paths (EventSource can't set headers).
@@ -74,7 +73,6 @@ const getAuthHeaders = async (req: Request, pathSegments: string[]): Promise<Rec
   const idToken = cookieIdToken || queryToken
 
   return {
-    [ACCESS_CHANNEL_HEADER]: 'ui',
     ...(authToken ? { Authorization: authToken } : {}),
     // Forward the idToken cookie to the backend
     ...(idToken ? { Cookie: `idToken=${idToken}` } : {}),

--- a/frontends/ui/src/app/api/v1/[...path]/route.ts
+++ b/frontends/ui/src/app/api/v1/[...path]/route.ts
@@ -17,7 +17,6 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
-import { ACCESS_CHANNEL_HEADER } from '@/adapters/auth/constants'
 import { isAuthRequired } from '@/adapters/auth/config'
 
 const getBackendUrl = (): string => {
@@ -34,7 +33,7 @@ const buildBackendUrl = (path: string[]): string => {
 const getAuthHeaders = async (req: NextRequest): Promise<Record<string, string>> => {
   // Skip auth when REQUIRE_AUTH=false - don't forward any auth info to backend
   if (!isAuthRequired()) {
-    return { [ACCESS_CHANNEL_HEADER]: 'ui' }
+    return {}
   }
 
   const authToken = req.headers.get('Authorization')
@@ -42,7 +41,6 @@ const getAuthHeaders = async (req: NextRequest): Promise<Record<string, string>>
   const idToken = cookieStore.get('idToken')?.value
 
   return {
-    [ACCESS_CHANNEL_HEADER]: 'ui',
     ...(authToken ? { Authorization: authToken } : {}),
     ...(idToken ? { Cookie: `idToken=${idToken}` } : {}),
   }

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -357,7 +357,7 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
         # Decide whether to skip the clarifier for this request.
         # 1. Config (enable_clarifier=false) — operator disabled it entirely.
         # 2. aiq_api.auth.middleware ContextVar — covers X-AIQ-Mode: headless,
-        #    NVAuth/anonymous callers, and unauthenticated internal callers.
+        #    anonymous callers, and unauthenticated internal callers.
         skip_clarifier = not config.enable_clarifier
         if not skip_clarifier:
             try:

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -33,7 +33,6 @@ from aiq_agent.common.citation_verification import set_session_registry
 from aiq_agent.observability.otel_header_redaction_exporter import (
     ensure_registered as _ensure_otel_redaction_registered,
 )
-from aiq_agent.observability.request_trace_injector import install_request_trace_span_injection
 from nat.builder.builder import Builder
 from nat.builder.context import Context
 from nat.builder.framework_enum import LLMFrameworkEnum
@@ -51,7 +50,6 @@ from .utils import _extract_query_and_sources
 logger = logging.getLogger(__name__)
 
 _ensure_otel_redaction_registered()
-install_request_trace_span_injection()
 
 
 ########################################################

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -33,6 +33,7 @@ from aiq_agent.common.citation_verification import set_session_registry
 from aiq_agent.observability.otel_header_redaction_exporter import (
     ensure_registered as _ensure_otel_redaction_registered,
 )
+from aiq_agent.observability.request_trace_injector import install_request_trace_span_injection
 from nat.builder.builder import Builder
 from nat.builder.context import Context
 from nat.builder.framework_enum import LLMFrameworkEnum
@@ -50,6 +51,7 @@ from .utils import _extract_query_and_sources
 logger = logging.getLogger(__name__)
 
 _ensure_otel_redaction_registered()
+install_request_trace_span_injection()
 
 
 ########################################################

--- a/src/aiq_agent/observability/request_trace_injector.py
+++ b/src/aiq_agent/observability/request_trace_injector.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+logger = logging.getLogger(__name__)
+
+_current_request_trace_tags: ContextVar[dict[str, str]] = ContextVar("_current_request_trace_tags", default={})
+
+
+def get_request_trace_tags() -> dict[str, str]:
+    """Return the trace tags resolved for the current request."""
+    return _current_request_trace_tags.get()
+
+
+@contextmanager
+def request_trace_tag_context(tags: dict[str, str]):
+    """Bind request trace tags while NAT emits spans for this request."""
+    token = _current_request_trace_tags.set(dict(tags))
+    try:
+        yield
+    finally:
+        _current_request_trace_tags.reset(token)
+
+
+def _inject_request_trace_attributes(span) -> None:
+    tags = get_request_trace_tags()
+    if not tags:
+        return
+
+    for key, value in tags.items():
+        prefixed_key = key if key.startswith("nat.") else f"nat.{key}"
+        try:
+            span.set_attribute(prefixed_key, value)
+        except Exception:
+            logger.debug("Failed to inject request trace tag %s onto NAT span", prefixed_key, exc_info=True)
+
+
+def install_request_trace_span_injection() -> None:
+    """Patch NAT's span exporter so exported spans inherit request trace attributes."""
+    from nat.observability.exporter.span_exporter import SpanExporter
+
+    process_start_event = SpanExporter._process_start_event
+    if getattr(process_start_event, "__aiq_request_trace_patched__", False):
+        return
+
+    def patched_process_start_event(self, event) -> None:
+        process_start_event(self, event)
+        try:
+            span = self._outstanding_spans.get(event.UUID)
+        except Exception:
+            span = None
+        if span is not None:
+            _inject_request_trace_attributes(span)
+
+    patched_process_start_event.__aiq_request_trace_patched__ = True
+    SpanExporter._process_start_event = patched_process_start_event
+    logger.info("Installed NAT request trace span attribute injection")

--- a/tests/aiq_agent/async_api/test_websocket_reconnect.py
+++ b/tests/aiq_agent/async_api/test_websocket_reconnect.py
@@ -29,6 +29,7 @@ from starlette.websockets import WebSocketDisconnect
 
 from aiq_api import websocket_reconnect
 from aiq_api.auth.middleware import get_current_user
+from aiq_api.auth.request_trace import get_request_trace_tags
 from aiq_api.websocket_reconnect import ReconnectableWebSocketMessageHandler
 from aiq_api.websocket_reconnect import WebSocketSessionRegistry
 from aiq_api.websocket_reconnect import authenticate_websocket_connection
@@ -748,3 +749,51 @@ async def test_run_workflow_binds_authenticated_user_context(monkeypatch) -> Non
     await handler._run_workflow(payload="hello", conversation_id="conv-1")
 
     assert seen_users == [{"type": "starfleet", "sub": "user-1", "skip_clarifier": False}]
+
+
+@pytest.mark.asyncio
+async def test_process_workflow_request_binds_request_trace_tags(monkeypatch) -> None:
+    configure_websocket_auth(validators=[], require_auth=False, external_hostnames={"localhost"})
+    socket = DummySocket(headers=[(b"host", b"localhost"), (b"cookie", b"idToken=test-token")])
+    handler = ReconnectableWebSocketMessageHandler(
+        socket=socket,
+        session_manager=DummySessionManager(),
+        step_adaptor=DummyStepAdaptor(),
+        worker=DummyWorker(),
+    )
+    handler._authenticated_user = {"type": "starfleet", "sub": "user-1", "skip_clarifier": False}
+    user_message = WebSocketUserMessage(
+        type=WebSocketMessageType.USER_MESSAGE,
+        schema_type=WorkflowSchemaType.CHAT_STREAM,
+        id="msg-1",
+        conversation_id="conv-1",
+        content=UserMessageContent(
+            messages=[
+                UserMessages(
+                    role=UserMessageContentRoleType.USER,
+                    content=[TextContent(text="hello")],
+                )
+            ]
+        ),
+    )
+    seen_tags: list[dict[str, str]] = []
+
+    async def fake_process_workflow_request(_self, _message):
+        seen_tags.append(get_request_trace_tags())
+
+    monkeypatch.setattr(
+        websocket_reconnect.WebSocketMessageHandler,
+        "process_workflow_request",
+        fake_process_workflow_request,
+    )
+
+    await handler.process_workflow_request(user_message)
+
+    assert seen_tags == [
+        {
+            "aiq.caller.type": "starfleet",
+            "aiq.auth.transport": "cookie",
+            "aiq.auth.verified": "true",
+            "aiq.access.channel": "ui",
+        }
+    ]

--- a/tests/aiq_agent/async_api/test_websocket_reconnect.py
+++ b/tests/aiq_agent/async_api/test_websocket_reconnect.py
@@ -675,14 +675,14 @@ def test_install_reconnectable_handler(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_authenticate_websocket_connection_validates_external_token() -> None:
-    validator = DummyValidator(user={"type": "starfleet", "sub": "user-1", "skip_clarifier": False})
+    validator = DummyValidator(user={"type": "oidc", "sub": "user-1", "skip_clarifier": False})
     configure_websocket_auth(validators=[validator], require_auth=True, external_hostnames={"localhost"})
     socket = DummySocket(headers=[(b"host", b"localhost"), (b"cookie", b"idToken=test-token")])
 
     user, close_code = await authenticate_websocket_connection(socket)
 
     assert close_code is None
-    assert user == {"type": "starfleet", "sub": "user-1", "skip_clarifier": False}
+    assert user == {"type": "oidc", "sub": "user-1", "skip_clarifier": False}
     assert validator.tokens == ["test-token", "test-token"]
 
 
@@ -699,14 +699,14 @@ async def test_authenticate_websocket_connection_rejects_missing_external_token(
 
 @pytest.mark.asyncio
 async def test_authenticate_websocket_connection_validates_internal_token_when_present() -> None:
-    validator = DummyValidator(user={"type": "starfleet", "sub": "user-1", "skip_clarifier": False})
+    validator = DummyValidator(user={"type": "oidc", "sub": "user-1", "skip_clarifier": False})
     configure_websocket_auth(validators=[validator], require_auth=True, external_hostnames={"localhost"})
     socket = DummySocket(headers=[(b"host", b"aiq-agent"), (b"cookie", b"idToken=test-token")])
 
     user, close_code = await authenticate_websocket_connection(socket)
 
     assert close_code is None
-    assert user == {"type": "starfleet", "sub": "user-1", "skip_clarifier": False}
+    assert user == {"type": "oidc", "sub": "user-1", "skip_clarifier": False}
 
 
 @pytest.mark.asyncio
@@ -735,7 +735,7 @@ async def test_run_workflow_binds_authenticated_user_context(monkeypatch) -> Non
         step_adaptor=DummyStepAdaptor(),
         worker=DummyWorker(),
     )
-    handler._authenticated_user = {"type": "starfleet", "sub": "user-1", "skip_clarifier": False}
+    handler._authenticated_user = {"type": "oidc", "sub": "user-1", "skip_clarifier": False}
 
     seen_users: list[dict] = []
 
@@ -748,7 +748,7 @@ async def test_run_workflow_binds_authenticated_user_context(monkeypatch) -> Non
 
     await handler._run_workflow(payload="hello", conversation_id="conv-1")
 
-    assert seen_users == [{"type": "starfleet", "sub": "user-1", "skip_clarifier": False}]
+    assert seen_users == [{"type": "oidc", "sub": "user-1", "skip_clarifier": False}]
 
 
 @pytest.mark.asyncio
@@ -761,7 +761,7 @@ async def test_process_workflow_request_binds_request_trace_tags(monkeypatch) ->
         step_adaptor=DummyStepAdaptor(),
         worker=DummyWorker(),
     )
-    handler._authenticated_user = {"type": "starfleet", "sub": "user-1", "skip_clarifier": False}
+    handler._authenticated_user = {"type": "oidc", "sub": "user-1", "skip_clarifier": False}
     user_message = WebSocketUserMessage(
         type=WebSocketMessageType.USER_MESSAGE,
         schema_type=WorkflowSchemaType.CHAT_STREAM,
@@ -791,7 +791,7 @@ async def test_process_workflow_request_binds_request_trace_tags(monkeypatch) ->
 
     assert seen_tags == [
         {
-            "aiq.caller.type": "starfleet",
+            "aiq.caller.type": "oidc",
             "aiq.auth.transport": "cookie",
             "aiq.auth.verified": "true",
             "aiq.access.channel": "ui",


### PR DESCRIPTION
## Summary
- propagate resolved AIQ request tags into NAT-exported spans for HTTP, WebSocket, and async job workflows
- carry request tags into async Dask jobs so child workflow spans retain caller and access-channel context
- keep public channel tagging generic: ui, api, headless, internal, anonymous, unknown
- move request trace span injection into the API auth layer and document nat.aiq.* / nat.enduser.id span attributes

## Validation
- ruff check <changed python files and tests>
- ruff format --check <changed python files and tests>
- python -m py_compile <changed python files and tests>
- uv run pytest tests/ -q (881 passed, 2 skipped)
- uv run pytest tests/aiq_agent/async_api/test_websocket_reconnect.py -q (22 passed)

## Local E2E
- verified curl /chat traces include nat.aiq.* and nat.enduser.id attributes
- verified UI websocket traces include NAT request tags after binding websocket request context