### PR TITLE
Harden AIQ UI stream failure handling

### DIFF
--- a/frontends/ui/src/adapters/auth/config.spec.ts
+++ b/frontends/ui/src/adapters/auth/config.spec.ts
@@ -255,6 +255,7 @@ describe('provider lifecycle hooks', () => {
       token: {
         accessToken: 'at',
         idToken: 'it',
+        expiresAt: 9999999999,
         userId: 'u1',
         hasAccess: true,
         dlGroup: 'aiq-users',
@@ -271,6 +272,7 @@ describe('provider lifecycle hooks', () => {
     expect(sessionObj.hasAccess).toBe(true)
     expect(sessionObj.dlGroup).toBe('aiq-users')
     expect(sessionObj.idToken).toBe('it')
+    expect(sessionObj.idTokenExpiresAt).toBe(9999999999)
   })
 
   test('onSession hook cannot override core session fields', async () => {
@@ -291,6 +293,7 @@ describe('provider lifecycle hooks', () => {
       token: {
         accessToken: 'at',
         idToken: 'it',
+        expiresAt: 9999999999,
         userId: 'u1',
         error: undefined,
       },
@@ -302,6 +305,7 @@ describe('provider lifecycle hooks', () => {
     const sessionObj = result as unknown as Record<string, unknown>
     expect(sessionObj.accessToken).toBe('at')
     expect(sessionObj.idToken).toBe('it')
+    expect(sessionObj.idTokenExpiresAt).toBe(9999999999)
     expect(sessionObj.userId).toBe('u1')
     expect(sessionObj.error).toBeUndefined()
     expect(sessionObj.hasAccess).toBe(true)
@@ -335,13 +339,14 @@ describe('provider lifecycle hooks', () => {
     // Session without onSession hook
     const sessionResult = await authOptions.callbacks!.session!({
       session: { user: { name: 'Test' }, expires: '2099-01-01' },
-      token: { accessToken: 'at', idToken: 'it', userId: 'u1' },
+      token: { accessToken: 'at', idToken: 'it', expiresAt: 9999999999, userId: 'u1' },
       user: { id: 'u1', name: 'Test', email: 'test@example.com', emailVerified: null },
       trigger: 'update',
       newSession: undefined,
     }) as unknown as Record<string, unknown>
 
     expect(sessionResult.idToken).toBe('it')
+    expect(sessionResult.idTokenExpiresAt).toBe(9999999999)
     // No extra fields from hooks
     expect(sessionResult.hasAccess).toBeUndefined()
   })

--- a/frontends/ui/src/adapters/auth/config.ts
+++ b/frontends/ui/src/adapters/auth/config.ts
@@ -201,6 +201,7 @@ export const authOptions: AuthOptions = {
         ...session,
         accessToken: token.accessToken as string | undefined,
         idToken: token.idToken as string | undefined,
+        idTokenExpiresAt: token.expiresAt as number | undefined,
         userId: token.userId as string | undefined,
         error: token.error as string | undefined,
       }

--- a/frontends/ui/src/adapters/auth/id-token-cookie.spec.ts
+++ b/frontends/ui/src/adapters/auth/id-token-cookie.spec.ts
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  getIdTokenCookieDecision,
+  idTokenCookieMaxAgeSeconds,
+  isTokenExpired,
+} from './id-token-cookie'
+
+describe('idToken cookie decisions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-02T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('sets cookie when idToken exists and expires in the future', () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 3600
+
+    expect(
+      getIdTokenCookieDecision({
+        idToken: 'id-token',
+        expiresAt,
+      })
+    ).toBe('set')
+  })
+
+  test('deletes cookie when refresh has failed', () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 3600
+
+    expect(
+      getIdTokenCookieDecision({
+        tokenError: 'RefreshAccessTokenError',
+        idToken: 'stale-id-token',
+        expiresAt,
+      })
+    ).toBe('delete')
+  })
+
+  test('deletes cookie when dev token has expired', () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 3600
+
+    expect(
+      getIdTokenCookieDecision({
+        tokenError: 'DevTokenExpired',
+        idToken: 'stale-id-token',
+        expiresAt,
+      })
+    ).toBe('delete')
+  })
+
+  test('deletes cookie when idToken is missing', () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 3600
+
+    expect(getIdTokenCookieDecision({ expiresAt })).toBe('delete')
+  })
+
+  test('deletes cookie when token expiry is missing', () => {
+    expect(getIdTokenCookieDecision({ idToken: 'id-token' })).toBe('delete')
+  })
+
+  test('deletes cookie when token is expired by default', () => {
+    const expiresAt = Math.floor(Date.now() / 1000) - 10
+
+    expect(
+      getIdTokenCookieDecision({
+        idToken: 'expired-id-token',
+        expiresAt,
+      })
+    ).toBe('delete')
+  })
+
+  test('preserves cookie for expired request token during session refresh', () => {
+    const expiresAt = Math.floor(Date.now() / 1000) - 10
+
+    expect(
+      getIdTokenCookieDecision({
+        idToken: 'request-side-id-token',
+        expiresAt,
+        preserveExpiredRequestToken: true,
+      })
+    ).toBe('preserve')
+  })
+
+  test('checks real token expiry', () => {
+    const nowSec = Math.floor(Date.now() / 1000)
+
+    expect(isTokenExpired(nowSec + 1)).toBe(false)
+    expect(isTokenExpired(nowSec)).toBe(true)
+    expect(isTokenExpired(undefined)).toBe(true)
+  })
+
+  test('clamps cookie maxAge to session lifetime', () => {
+    const nowSec = Math.floor(Date.now() / 1000)
+
+    expect(idTokenCookieMaxAgeSeconds(nowSec + 3600, 86400)).toBe(3600)
+    expect(idTokenCookieMaxAgeSeconds(nowSec + 200000, 86400)).toBe(86400)
+    expect(idTokenCookieMaxAgeSeconds(nowSec - 10, 86400)).toBe(1)
+  })
+})

--- a/frontends/ui/src/adapters/auth/id-token-cookie.spec.ts
+++ b/frontends/ui/src/adapters/auth/id-token-cookie.spec.ts
@@ -63,6 +63,10 @@ describe('idToken cookie decisions', () => {
     expect(getIdTokenCookieDecision({ idToken: 'id-token' })).toBe('delete')
   })
 
+  test('deletes cookie when token expiry is zero', () => {
+    expect(getIdTokenCookieDecision({ idToken: 'id-token', expiresAt: 0 })).toBe('delete')
+  })
+
   test('deletes cookie when token is expired by default', () => {
     const expiresAt = Math.floor(Date.now() / 1000) - 10
 
@@ -91,6 +95,7 @@ describe('idToken cookie decisions', () => {
 
     expect(isTokenExpired(nowSec + 1)).toBe(false)
     expect(isTokenExpired(nowSec)).toBe(true)
+    expect(isTokenExpired(0)).toBe(true)
     expect(isTokenExpired(undefined)).toBe(true)
   })
 

--- a/frontends/ui/src/adapters/auth/id-token-cookie.ts
+++ b/frontends/ui/src/adapters/auth/id-token-cookie.ts
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const TOKEN_REFRESH_ERROR_CODES = new Set(['RefreshAccessTokenError', 'DevTokenExpired'])
+
+export type IdTokenCookieDecision = 'set' | 'delete' | 'preserve'
+
+interface IdTokenCookieDecisionInput {
+  tokenError?: unknown
+  idToken?: unknown
+  expiresAt?: number
+  preserveExpiredRequestToken?: boolean
+}
+
+/**
+ * Check if a token is actually expired (real expiry, not refresh buffer).
+ * The refresh buffer is for proactive token refresh in the NextAuth JWT
+ * callback; transport auth should remain usable until real token expiry.
+ */
+export const isTokenExpired = (expiresAt: number | undefined): boolean => {
+  if (!expiresAt) return true
+  return Date.now() >= expiresAt * 1000
+}
+
+/**
+ * Compute the cookie maxAge so it expires with the token rather than lasting a
+ * fixed session lifetime. Clamped to [1, sessionMaxAgeSeconds].
+ */
+export const idTokenCookieMaxAgeSeconds = (
+  expiresAt: number,
+  sessionMaxAgeSeconds: number
+): number => {
+  const nowSec = Math.floor(Date.now() / 1000)
+  return Math.min(sessionMaxAgeSeconds, Math.max(1, expiresAt - nowSec))
+}
+
+export const getIdTokenCookieDecision = ({
+  tokenError,
+  idToken,
+  expiresAt,
+  preserveExpiredRequestToken = false,
+}: IdTokenCookieDecisionInput): IdTokenCookieDecision => {
+  if (typeof tokenError === 'string' && TOKEN_REFRESH_ERROR_CODES.has(tokenError)) {
+    return 'delete'
+  }
+
+  if (typeof idToken !== 'string' || idToken.length === 0) {
+    return 'delete'
+  }
+
+  if (!expiresAt) {
+    return 'delete'
+  }
+
+  if (isTokenExpired(expiresAt)) {
+    return preserveExpiredRequestToken ? 'preserve' : 'delete'
+  }
+
+  return 'set'
+}

--- a/frontends/ui/src/adapters/auth/id-token-cookie.ts
+++ b/frontends/ui/src/adapters/auth/id-token-cookie.ts
@@ -18,7 +18,7 @@ interface IdTokenCookieDecisionInput {
  * callback; transport auth should remain usable until real token expiry.
  */
 export const isTokenExpired = (expiresAt: number | undefined): boolean => {
-  if (!expiresAt) return true
+  if (expiresAt === undefined) return true
   return Date.now() >= expiresAt * 1000
 }
 
@@ -48,7 +48,7 @@ export const getIdTokenCookieDecision = ({
     return 'delete'
   }
 
-  if (!expiresAt) {
+  if (expiresAt === undefined) {
     return 'delete'
   }
 

--- a/frontends/ui/src/adapters/auth/types.ts
+++ b/frontends/ui/src/adapters/auth/types.ts
@@ -20,6 +20,8 @@ declare module 'next-auth' {
     accessToken?: string
     /** The OIDC ID token (used for backend auth) */
     idToken?: string
+    /** Expiration timestamp for the OIDC ID token (seconds since epoch) */
+    idTokenExpiresAt?: number
     /** User ID from the OAuth provider */
     userId?: string
     /** Error state for token refresh failures */

--- a/frontends/ui/src/app/api/auth/[...nextauth]/route.ts
+++ b/frontends/ui/src/app/api/auth/[...nextauth]/route.ts
@@ -36,6 +36,56 @@ const clearAuthCookies = (response: NextResponse): void => {
   response.cookies.delete('__Secure-next-auth.callback-url')
 }
 
+const isTokenExpired = (expiresAt: number | undefined): boolean => {
+  if (!expiresAt) return true
+  return Date.now() >= expiresAt * 1000
+}
+
+const idTokenCookieMaxAgeSeconds = (expiresAt: number): number => {
+  const nowSec = Math.floor(Date.now() / 1000)
+  return Math.min(SESSION_MAX_AGE_SECONDS, Math.max(1, expiresAt - nowSec))
+}
+
+const cloneResponse = (response: Response): NextResponse =>
+  new NextResponse(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: new Headers(response.headers),
+  })
+
+const syncIdTokenCookie = async (
+  req: NextRequest,
+  response: Response
+): Promise<NextResponse> => {
+  const newResponse = cloneResponse(response)
+
+  try {
+    const token = await getToken({
+      req,
+      secret: process.env.NEXTAUTH_SECRET,
+      secureCookie: shouldUseSecureCookies(),
+    })
+
+    const expiresAt = token?.expiresAt as number | undefined
+    if (token?.error === 'RefreshAccessTokenError' || !token?.idToken || isTokenExpired(expiresAt)) {
+      newResponse.cookies.delete('idToken')
+      return newResponse
+    }
+
+    newResponse.cookies.set('idToken', token.idToken as string, {
+      httpOnly: true,
+      sameSite: 'lax',
+      path: '/',
+      secure: shouldUseSecureCookies(),
+      maxAge: idTokenCookieMaxAgeSeconds(expiresAt!),
+    })
+  } catch (error) {
+    console.error('[NextAuth] Error syncing idToken cookie:', error)
+  }
+
+  return newResponse
+}
+
 /**
  * Wrapper that sets idToken cookie after successful auth callback.
  * The middleware skips /api/auth/ routes, so we need to set the cookie here.
@@ -66,41 +116,17 @@ const withIdTokenCookie = async (
 
   // Run NextAuth handler first
   const response = await nextAuthHandler(req, context)
+  const action = params.nextauth?.[0]
 
   // Check if this is a callback (OAuth GET or Credentials POST)
   const isCallback = params.nextauth?.includes('callback')
+  if (action === 'session') {
+    return syncIdTokenCookie(req, response)
+  }
 
   if (isCallback) {
-    try {
-      const token = await getToken({
-        req,
-        secret: process.env.NEXTAUTH_SECRET,
-      })
-
-      if (token?.idToken) {
-        console.log('[NextAuth] Setting idToken cookie after callback')
-
-        // Clone the response to modify headers
-        const newResponse = new NextResponse(response.body, {
-          status: response.status,
-          statusText: response.statusText,
-          headers: new Headers(response.headers),
-        })
-
-        // Keep callback-set cookies aligned with the shared auth session lifetime.
-        newResponse.cookies.set('idToken', token.idToken as string, {
-          httpOnly: true,
-          sameSite: 'lax',
-          path: '/',
-          secure: shouldUseSecureCookies(),
-          maxAge: SESSION_MAX_AGE_SECONDS,
-        })
-
-        return newResponse
-      }
-    } catch (error) {
-      console.error('[NextAuth] Error setting idToken cookie:', error)
-    }
+    console.log('[NextAuth] Syncing idToken cookie after callback')
+    return syncIdTokenCookie(req, response)
   }
 
   return response

--- a/frontends/ui/src/app/api/auth/[...nextauth]/route.ts
+++ b/frontends/ui/src/app/api/auth/[...nextauth]/route.ts
@@ -98,10 +98,17 @@ const syncIdTokenCookie = async (
       secureCookie: shouldUseSecureCookies(),
     })
 
+    const hasResponseSessionCookieSource =
+      responseSession?.idToken !== undefined ||
+      responseSession?.expiresAt !== undefined ||
+      responseSession?.error !== undefined
     const expiresAt = responseSession?.expiresAt ?? (token?.expiresAt as number | undefined)
     const idToken = responseSession?.idToken ?? (token?.idToken as string | undefined)
     const cookieDecision = getIdTokenCookieDecision({
-      tokenError: responseSession?.error ?? token?.error,
+      // If the session response includes refreshed token fields, it is the
+      // authoritative state. Do not let a stale request-side refresh error
+      // shadow a successful recovery from the same /api/auth/session response.
+      tokenError: hasResponseSessionCookieSource ? responseSession?.error : token?.error,
       idToken,
       expiresAt,
       preserveExpiredRequestToken,

--- a/frontends/ui/src/app/api/auth/[...nextauth]/route.ts
+++ b/frontends/ui/src/app/api/auth/[...nextauth]/route.ts
@@ -47,11 +47,48 @@ const cloneResponse = (response: Response): NextResponse =>
     headers: new Headers(response.headers),
   })
 
+interface SessionCookieSource {
+  idToken?: string
+  expiresAt?: number
+  error?: string
+}
+
+const readSessionCookieSource = async (
+  response: Response
+): Promise<SessionCookieSource | undefined> => {
+  const contentType = response.headers.get('content-type') ?? ''
+  if (!contentType.includes('application/json')) {
+    return undefined
+  }
+
+  try {
+    const session = (await response.clone().json()) as {
+      idToken?: unknown
+      idTokenExpiresAt?: unknown
+      error?: unknown
+    }
+
+    return {
+      idToken: typeof session.idToken === 'string' ? session.idToken : undefined,
+      expiresAt: typeof session.idTokenExpiresAt === 'number' ? session.idTokenExpiresAt : undefined,
+      error: typeof session.error === 'string' ? session.error : undefined,
+    }
+  } catch {
+    return undefined
+  }
+}
+
 const syncIdTokenCookie = async (
   req: NextRequest,
   response: Response,
-  { preserveExpiredRequestToken = false }: { preserveExpiredRequestToken?: boolean } = {}
+  {
+    preserveExpiredRequestToken = false,
+    preferResponseSessionToken = false,
+  }: { preserveExpiredRequestToken?: boolean; preferResponseSessionToken?: boolean } = {}
 ): Promise<NextResponse> => {
+  const responseSession = preferResponseSessionToken
+    ? await readSessionCookieSource(response)
+    : undefined
   const newResponse = cloneResponse(response)
 
   try {
@@ -61,10 +98,10 @@ const syncIdTokenCookie = async (
       secureCookie: shouldUseSecureCookies(),
     })
 
-    const expiresAt = token?.expiresAt as number | undefined
-    const idToken = token?.idToken as string | undefined
+    const expiresAt = responseSession?.expiresAt ?? (token?.expiresAt as number | undefined)
+    const idToken = responseSession?.idToken ?? (token?.idToken as string | undefined)
     const cookieDecision = getIdTokenCookieDecision({
-      tokenError: token?.error,
+      tokenError: responseSession?.error ?? token?.error,
       idToken,
       expiresAt,
       preserveExpiredRequestToken,
@@ -129,9 +166,13 @@ const withIdTokenCookie = async (
   const isCallback = params.nextauth?.includes('callback')
   if (action === 'session') {
     // On session requests, NextAuth may refresh the JWT and write it only to
-    // the response Set-Cookie header. getToken(req) still sees the old request
-    // JWT, so expiry alone should not clear idToken in the same response.
-    return syncIdTokenCookie(req, response, { preserveExpiredRequestToken: true })
+    // the response. Prefer the session payload so idToken gets the refreshed
+    // token and TTL; fall back to preserving when only the old request JWT is
+    // visible.
+    return syncIdTokenCookie(req, response, {
+      preserveExpiredRequestToken: true,
+      preferResponseSessionToken: true,
+    })
   }
 
   if (isCallback) {

--- a/frontends/ui/src/app/api/auth/[...nextauth]/route.ts
+++ b/frontends/ui/src/app/api/auth/[...nextauth]/route.ts
@@ -23,6 +23,10 @@ import {
   SESSION_MAX_AGE_SECONDS,
   shouldUseSecureCookies,
 } from '@/adapters/auth/config'
+import {
+  getIdTokenCookieDecision,
+  idTokenCookieMaxAgeSeconds,
+} from '@/adapters/auth/id-token-cookie'
 
 const nextAuthHandler = NextAuth(authOptions)
 
@@ -36,16 +40,6 @@ const clearAuthCookies = (response: NextResponse): void => {
   response.cookies.delete('__Secure-next-auth.callback-url')
 }
 
-const isTokenExpired = (expiresAt: number | undefined): boolean => {
-  if (!expiresAt) return true
-  return Date.now() >= expiresAt * 1000
-}
-
-const idTokenCookieMaxAgeSeconds = (expiresAt: number): number => {
-  const nowSec = Math.floor(Date.now() / 1000)
-  return Math.min(SESSION_MAX_AGE_SECONDS, Math.max(1, expiresAt - nowSec))
-}
-
 const cloneResponse = (response: Response): NextResponse =>
   new NextResponse(response.body, {
     status: response.status,
@@ -55,7 +49,8 @@ const cloneResponse = (response: Response): NextResponse =>
 
 const syncIdTokenCookie = async (
   req: NextRequest,
-  response: Response
+  response: Response,
+  { preserveExpiredRequestToken = false }: { preserveExpiredRequestToken?: boolean } = {}
 ): Promise<NextResponse> => {
   const newResponse = cloneResponse(response)
 
@@ -67,17 +62,29 @@ const syncIdTokenCookie = async (
     })
 
     const expiresAt = token?.expiresAt as number | undefined
-    if (token?.error === 'RefreshAccessTokenError' || !token?.idToken || isTokenExpired(expiresAt)) {
+    const idToken = token?.idToken as string | undefined
+    const cookieDecision = getIdTokenCookieDecision({
+      tokenError: token?.error,
+      idToken,
+      expiresAt,
+      preserveExpiredRequestToken,
+    })
+
+    if (cookieDecision === 'delete') {
       newResponse.cookies.delete('idToken')
       return newResponse
     }
 
-    newResponse.cookies.set('idToken', token.idToken as string, {
+    if (cookieDecision === 'preserve') {
+      return newResponse
+    }
+
+    newResponse.cookies.set('idToken', idToken!, {
       httpOnly: true,
       sameSite: 'lax',
       path: '/',
       secure: shouldUseSecureCookies(),
-      maxAge: idTokenCookieMaxAgeSeconds(expiresAt!),
+      maxAge: idTokenCookieMaxAgeSeconds(expiresAt!, SESSION_MAX_AGE_SECONDS),
     })
   } catch (error) {
     console.error('[NextAuth] Error syncing idToken cookie:', error)
@@ -121,7 +128,10 @@ const withIdTokenCookie = async (
   // Check if this is a callback (OAuth GET or Credentials POST)
   const isCallback = params.nextauth?.includes('callback')
   if (action === 'session') {
-    return syncIdTokenCookie(req, response)
+    // On session requests, NextAuth may refresh the JWT and write it only to
+    // the response Set-Cookie header. getToken(req) still sees the old request
+    // JWT, so expiry alone should not clear idToken in the same response.
+    return syncIdTokenCookie(req, response, { preserveExpiredRequestToken: true })
   }
 
   if (isCallback) {

--- a/frontends/ui/src/app/api/jobs/async/[...path]/route.ts
+++ b/frontends/ui/src/app/api/jobs/async/[...path]/route.ts
@@ -62,15 +62,14 @@ const getAuthHeaders = async (req: Request, pathSegments: string[]): Promise<Rec
   const allowQueryToken = pathSegments.includes('stream')
   const rawQueryToken = new URL(req.url).searchParams.get('token')?.trim()
   const queryToken = allowQueryToken && rawQueryToken ? rawQueryToken : undefined
+  const cookieStore = await cookies()
+  const cookieIdToken = cookieStore.get('idToken')?.value?.trim()
+  const idToken = cookieIdToken || queryToken
+  const authToken = req.headers.get('Authorization') || (idToken ? `Bearer ${idToken}` : null)
 
-  if (queryToken) {
+  if (queryToken && !cookieIdToken) {
     console.warn('[Deep Research API] SSE stream using ?token= query fallback (idToken cookie missing)')
   }
-
-  const authToken = req.headers.get('Authorization') || (queryToken ? `Bearer ${queryToken}` : null)
-  const cookieStore = await cookies()
-  const cookieIdToken = cookieStore.get('idToken')?.value
-  const idToken = cookieIdToken || queryToken
 
   return {
     ...(authToken ? { Authorization: authToken } : {}),

--- a/frontends/ui/src/features/chat/hooks/use-deep-research.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-deep-research.spec.ts
@@ -617,6 +617,39 @@ describe('useDeepResearch', () => {
       )
     })
 
+    test('onJobStatus interrupted by user shows cancelled banner', async () => {
+      await setupConnectedHook()
+
+      act(() => {
+        mockClient?.callbacks.onJobStatus?.('interrupted', 'cancelled by user')
+      })
+
+      expect(mockAddDeepResearchBanner).toHaveBeenCalledWith(
+        'cancelled',
+        'job-456',
+        'test-conv-123'
+      )
+      expect(mockAddErrorCard).not.toHaveBeenCalled()
+    })
+
+    test('onJobStatus interrupted for non-user reason shows failure banner', async () => {
+      await setupConnectedHook()
+
+      act(() => {
+        mockClient?.callbacks.onJobStatus?.('interrupted', 'worker lost during reconnect')
+      })
+
+      expect(mockAddDeepResearchBanner).toHaveBeenCalledWith(
+        'failure',
+        'job-456',
+        'test-conv-123'
+      )
+      expect(mockAddErrorCard).toHaveBeenCalledWith(
+        'agent.deep_research_failed',
+        'worker lost during reconnect'
+      )
+    })
+
     test('onWorkflowStart adds thinking step and agent', async () => {
       await setupConnectedHook()
 

--- a/frontends/ui/src/features/chat/hooks/use-deep-research.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-deep-research.spec.ts
@@ -650,6 +650,26 @@ describe('useDeepResearch', () => {
       )
     })
 
+    test('onJobStatus interrupted without error shows fallback failure', async () => {
+      await setupConnectedHook()
+
+      expect(() => {
+        act(() => {
+          mockClient?.callbacks.onJobStatus?.('interrupted', undefined)
+        })
+      }).not.toThrow()
+
+      expect(mockAddDeepResearchBanner).toHaveBeenCalledWith(
+        'failure',
+        'job-456',
+        'test-conv-123'
+      )
+      expect(mockAddErrorCard).toHaveBeenCalledWith(
+        'agent.deep_research_failed',
+        'Research was interrupted before completion.'
+      )
+    })
+
     test('onWorkflowStart adds thinking step and agent', async () => {
       await setupConnectedHook()
 

--- a/frontends/ui/src/features/chat/hooks/use-deep-research.ts
+++ b/frontends/ui/src/features/chat/hooks/use-deep-research.ts
@@ -314,6 +314,8 @@ export const useDeepResearch = (): UseDeepResearchReturn => {
               setCurrentStatus('error')
               stopAllDeepResearchSpinners()
               const hasReport = Boolean(state.reportContent?.trim())
+              const isUserCancelled =
+                status === 'interrupted' && error?.toLowerCase().includes('cancelled by user')
 
               if (ownerConvId && messageId) {
                 patchConversationMessage(ownerConvId, messageId, {
@@ -323,7 +325,6 @@ export const useDeepResearch = (): UseDeepResearchReturn => {
                   showViewReport: hasReport,
                 })
               }
-              const isUserCancelled = status === 'interrupted'
               addDeepResearchBanner(isUserCancelled ? 'cancelled' : 'failure', jobId, ownerConvId || undefined)
               researchStartTimeRef.current = null
               clientRef.current?.disconnect()
@@ -333,6 +334,9 @@ export const useDeepResearch = (): UseDeepResearchReturn => {
               if (error && !isUserCancelled) {
                 const { addErrorCard } = useChatStore.getState()
                 addErrorCard('agent.deep_research_failed', error)
+              } else if (status === 'interrupted' && !isUserCancelled) {
+                const { addErrorCard } = useChatStore.getState()
+                addErrorCard('agent.deep_research_failed', 'Research was interrupted before completion.')
               }
             }
           },

--- a/frontends/ui/src/features/chat/hooks/use-deep-research.ts
+++ b/frontends/ui/src/features/chat/hooks/use-deep-research.ts
@@ -35,6 +35,15 @@ const TIMEOUT_CHECK_INTERVAL_MS = 10000
  *  job.status "interrupted" within this window, clean up locally so the
  *  UI never stays stuck in a streaming state. */
 const CANCEL_FALLBACK_TIMEOUT_MS = 5000
+const USER_CANCELLED_ERROR_MARKER = 'cancelled by user'
+
+const isUserCancelledStatus = (
+  status: DeepResearchJobStatus,
+  error?: string
+): boolean => (
+  status === 'interrupted' &&
+  error?.toLowerCase().includes(USER_CANCELLED_ERROR_MARKER) === true
+)
 
 interface UseDeepResearchReturn {
   /** Whether deep research is currently streaming */
@@ -314,8 +323,7 @@ export const useDeepResearch = (): UseDeepResearchReturn => {
               setCurrentStatus('error')
               stopAllDeepResearchSpinners()
               const hasReport = Boolean(state.reportContent?.trim())
-              const isUserCancelled =
-                status === 'interrupted' && error?.toLowerCase().includes('cancelled by user')
+              const isUserCancelled = isUserCancelledStatus(status, error)
 
               if (ownerConvId && messageId) {
                 patchConversationMessage(ownerConvId, messageId, {

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
@@ -460,6 +460,8 @@ describe('useWebSocketChat', () => {
   test('onResponse callback adds streaming content to chat', () => {
     renderWebSocketHook()
 
+    mockStoreState.isStreaming = true
+
     // Simulate streaming response (not final)
     act(() => {
       capturedCallbacks.onResponse?.('Partial content...', 'in_progress', false)
@@ -468,6 +470,23 @@ describe('useWebSocketChat', () => {
     // Non-final responses with content are now added to chat as AgentResponse
     // reportContent is only set by deep research SSE events
     expect(mockAddAgentResponse).toHaveBeenCalledWith('Partial content...')
+  })
+
+  test('onResponse drops stale content when not streaming', () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    renderWebSocketHook()
+
+    mockStoreState.isStreaming = false
+
+    act(() => {
+      capturedCallbacks.onResponse?.('Repeated stale response', 'complete', true)
+    })
+
+    expect(mockAddAgentResponse).not.toHaveBeenCalled()
+    expect(mockSetStreaming).not.toHaveBeenCalledWith(false)
+    expect(consoleWarnSpy).toHaveBeenCalledWith('Ignoring stale isFinal -- not currently streaming')
+
+    consoleWarnSpy.mockRestore()
   })
 
   test('onIntermediateStep callback creates thinking step if none exists', () => {
@@ -828,6 +847,7 @@ describe('useWebSocketChat', () => {
     })
 
     renderWebSocketHook()
+    mockStoreState.isStreaming = true
 
     // Simulate response with deep research escalation signal
     act(() => {

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -260,6 +260,19 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           return
         }
 
+        // If the UI is no longer streaming, this response belongs to a
+        // workflow that outlived its request lifecycle. Drop it before adding
+        // content; otherwise stale final responses can duplicate agent replies.
+        const { isStreaming: currentlyStreaming } = useChatStore.getState()
+        if (!currentlyStreaming) {
+          console.warn(
+            isFinal
+              ? 'Ignoring stale isFinal -- not currently streaming'
+              : 'Ignoring stale system_response -- not currently streaming'
+          )
+          return
+        }
+
         // Check for deep research escalation signal
         // Backend sends: "Deep research job submitted. Job ID: {uuid}"
         const deepResearchMatch = content?.match(
@@ -365,14 +378,6 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
 
         // status: "complete" with null text signals task completion
         if (isFinal) {
-          // Guard: if we're not streaming, this is a stale COMPLETE from a
-          // previous workflow that outlived its socket (e.g. after disconnect).
-          const { isStreaming: currentlyStreaming } = useChatStore.getState()
-          if (!currentlyStreaming) {
-            console.warn('Ignoring stale isFinal -- not currently streaming')
-            return
-          }
-
           // Complete any pending thinking step
           if (currentThinkingStepIdRef.current) {
             completeThinkingStep(currentThinkingStepIdRef.current)

--- a/frontends/ui/src/proxy.ts
+++ b/frontends/ui/src/proxy.ts
@@ -30,26 +30,10 @@ import {
   isAuthRequired,
   shouldUseSecureCookies,
 } from '@/adapters/auth/config'
-
-/**
- * Check if a token is actually expired (real expiry, not refresh buffer).
- * The refresh buffer is for proactive token refresh in the NextAuth JWT
- * callback — the cookie should remain valid until the token truly expires
- * so that WebSocket and SSE transports can still authenticate.
- */
-const isTokenExpired = (expiresAt: number | undefined): boolean => {
-  if (!expiresAt) return true
-  return Date.now() >= expiresAt * 1000
-}
-
-/**
- * Compute the cookie maxAge so it expires with the token rather than
- * lasting a fixed 24 hours. Clamped to [1, SESSION_MAX_AGE_SECONDS].
- */
-const idTokenCookieMaxAgeSeconds = (expiresAt: number): number => {
-  const nowSec = Math.floor(Date.now() / 1000)
-  return Math.min(SESSION_MAX_AGE_SECONDS, Math.max(1, expiresAt - nowSec))
-}
+import {
+  getIdTokenCookieDecision,
+  idTokenCookieMaxAgeSeconds,
+} from '@/adapters/auth/id-token-cookie'
 
 export default async function proxy(req: NextRequest) {
   if (!isAuthRequired()) {
@@ -84,25 +68,24 @@ export default async function proxy(req: NextRequest) {
     })
 
     if (token) {
-      // Check for refresh error from NextAuth JWT callback
-      if (token.error === 'RefreshAccessTokenError' || token.error === 'DevTokenExpired') {
-        response.cookies.delete('idToken')
-        return response
-      }
-
       const expiresAt = token.expiresAt as number | undefined
+      const cookieDecision = getIdTokenCookieDecision({
+        tokenError: token.error,
+        idToken: token.idToken,
+        expiresAt,
+      })
 
       // Set idToken cookie only if we have a valid, non-expired token.
       // Unlike the refresh buffer (which proactively refreshes tokens),
       // the cookie stays valid until real expiry so WebSocket/SSE
       // transports don't lose auth while NextAuth refreshes in the background.
-      if (token.idToken && !isTokenExpired(expiresAt)) {
+      if (cookieDecision === 'set') {
         response.cookies.set('idToken', token.idToken as string, {
           httpOnly: true,
           sameSite: 'lax',
           path: '/',
           secure: shouldUseSecureCookies(),
-          maxAge: idTokenCookieMaxAgeSeconds(expiresAt!),
+          maxAge: idTokenCookieMaxAgeSeconds(expiresAt!, SESSION_MAX_AGE_SECONDS),
         })
       } else {
         // Token expired or absent - clear the cookie


### PR DESCRIPTION
## Summary

This draft starts the stream failure hardening work for the AIQ UI.

The first commit focuses on deep research SSE auth recovery and terminal-state classification:

- keeps the backend-facing `idToken` cookie synchronized during NextAuth session refreshes
- prefers the refreshed `idToken` cookie over stale EventSource query tokens when proxying async job streams
- only renders the deep research `cancelled` banner for explicit user cancellation
- treats other `interrupted` terminal states as failures so transport or worker issues do not masquerade as user cancellation

## Why

Long-running deep research jobs can outlive a single browser stream connection. If the stream reconnects after auth refresh, the original EventSource URL may still contain a stale query token. That can break the stream while the backend job continues and the report remains recoverable after refresh.

The UI also previously mapped every `interrupted` status to “Research Cancelled,” which made non-user failures look like intentional user cancellation.

## Validation

- `node node_modules/vitest/vitest.mjs run src/features/chat/hooks/use-deep-research.spec.ts`
- `node node_modules/typescript/bin/tsc --noEmit`
- `git diff --check`

## Notes

This is intentionally a draft PR. Greptile should review this first commit before I continue with the next scoped commits for broader stream and WebSocket failure handling.