### PR TITLE
feat: add support for skills and sandbox along with example

### DIFF
--- a/.claude/skills/aiq-research/SKILL.md
+++ b/.claude/skills/aiq-research/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: aiq-research
+description: Use when deep research should call a locally running AIQ Blueprint server for routed chat, async deep research jobs, status checks, reports, or event-store artifacts.
+version: "1.0.0"
+---
+
+# AIQ Research Skill
+
+Use this skill to call a locally running AIQ Blueprint server through the helper script at `scripts/aiq.py`.
+
+## Assumptions
+
+- The AIQ server is running locally at `http://localhost:8000`.
+- Override the base URL only for another local deployment by setting `AIQ_SERVER_URL`.
+
+## Use Cases
+
+- Submit a routed `/chat` request to the local AIQ server.
+- Poll an async deep research job to completion.
+- Fetch job status, final reports, or event-store artifacts.
+- Cancel a local async job.
+
+## Available Script Commands
+
+| Command | Purpose |
+|---|---|
+| `python3 scripts/aiq.py health` | Check whether the local server responds |
+| `python3 scripts/aiq.py chat "<query>"` | POST `/chat`; may return inline output or a deep-research job ID |
+| `python3 scripts/aiq.py agents` | List available async agent types |
+| `python3 scripts/aiq.py submit "<query>" [agent_type]` | Submit an explicit async job |
+| `python3 scripts/aiq.py research "<query>" [agent_type]` | Submit an async job, poll, and print the final report JSON |
+| `python3 scripts/aiq.py research_poll <job_id>` | Resume polling an existing async job |
+| `python3 scripts/aiq.py status <job_id>` | Fetch job status plus `/state` artifacts |
+| `python3 scripts/aiq.py state <job_id>` | Fetch event-store artifacts only |
+| `python3 scripts/aiq.py report <job_id>` | Fetch the final report for a completed job |
+| `python3 scripts/aiq.py stream <job_id>` | Stream SSE events from a job |
+| `python3 scripts/aiq.py cancel <job_id>` | Cancel a running job |
+
+## Usage
+
+### Research flow
+
+Run:
+
+```bash
+python3 $SKILL_DIR/scripts/aiq.py chat "USER QUESTION"
+```
+
+- The `/chat` endpoint routes the request to the right AIQ path.
+- For shallow queries it returns a normal JSON response inline.
+- For deep research it returns structured JSON containing `{"status": "deep_research_running", "job_id": "..."}`.
+
+If the response is normal JSON:
+- Present the result immediately.
+- Do not force polling when there is no `job_id`.
+
+If the response includes `deep_research_running`:
+- Extract the `job_id`.
+- Launch polling with the same absolute script path:
+
+```bash
+python3 $SKILL_DIR/scripts/aiq.py research_poll <job_id>
+```
+
+- Use the runtime's non-blocking/background execution mechanism when available.
+- If the chosen execution method requires escalated permissions, request explicit user approval first and explain why.
+- Tell the user that deep research is running in the background.
+
+## Workflow
+
+1. Run `health` first if you are unsure whether the local AIQ server is running.
+2. Run `chat "<query>"` by passing the user's exact query for routed chat/research.
+3. If the response contains `{"status": "deep_research_running", "job_id": "..."}`, run `research_poll <job_id>`.
+4. If polling is interrupted, resume with `status <job_id>`, `report <job_id>`, or `research_poll <job_id>`.
+5. Present returned reports with citations intact. Do not truncate source URLs.
+
+### Presenting the report
+
+- When `research_poll` completes successfully, fetch and present the full report.
+- Do not truncate citations or source URLs from the returned report.
+
+### Handling interruptions and timeouts
+
+If polling is interrupted, the job continues server-side. Resume with:
+
+```bash
+python3 $SKILL_DIR/scripts/aiq.py status <job_id>
+python3 $SKILL_DIR/scripts/aiq.py report <job_id>
+python3 $SKILL_DIR/scripts/aiq.py research_poll <job_id>
+```
+
+- Use `status` to inspect job status and saved artifacts.
+- Use `report` when the job has already finished and you only need the final output.
+- Use `research_poll` to keep waiting for completion.
+
+### Checking job progress and state
+
+Async jobs expose two useful progress views:
+
+- `status <job_id>` returns top-level job status and also fetches `/state` artifacts.
+- `state <job_id>` returns the event-store artifacts only, without refetching the outer status wrapper.
+
+Run:
+
+```bash
+python3 $SKILL_DIR/scripts/aiq.py status <job_id>
+python3 $SKILL_DIR/scripts/aiq.py state <job_id>
+```
+
+Treat the responses as follows:
+- If `job_status.status` is `completed` or `success`, fetch or present the report.
+- If status is `failed`, `failure`, or `cancelled`, show the error and do not silently retry.
+- If status is still running, queued, or another non-terminal state, continue polling.
+
+### Failure handling
+
+If the job status is `failed` or `failure`:
+- Show the user the error from the status response.
+- Ask whether they want to retry with a narrower query or different approach.
+- Do not retry automatically.
+
+### Cancelling a job
+
+```bash
+python3 $SKILL_DIR/scripts/aiq.py cancel <job_id>
+```
+
+## Examples
+
+```bash
+python3 /skills/aiq/aiq-research/scripts/aiq.py health
+python3 /skills/aiq/aiq-research/scripts/aiq.py chat "Compare local AIQ deep research with a standard web search workflow"
+python3 /skills/aiq/aiq-research/scripts/aiq.py research_poll 12345678-1234-1234-1234-123456789abc
+```
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|---|---:|---|---|
+| `AIQ_SERVER_URL` | No | `http://localhost:8000` | Local AIQ server base URL |
+
+## Troubleshooting
+
+| Error | Likely Cause | Action |
+|---|---|---|
+| Connection refused | Local server is not running | Start the AIQ API server locally |
+| HTTP 401 or 403 | Local server rejected the request | Restart local server with `REQUIRE_AUTH=false` |
+| Job remains running | Deep research is asynchronous | Continue with `research_poll <job_id>` |
+| Job failed | Server-side workflow failed | Show the returned status/error; do not retry automatically |

--- a/.claude/skills/aiq-research/scripts/aiq.py
+++ b/.claude/skills/aiq-research/scripts/aiq.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Local AIQ Research API client.
+
+This helper assumes a local AIQ server running with REQUIRE_AUTH=false.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Iterator
+from typing import Any
+
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
+_JOB_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+_AGENT_TYPE_RE = re.compile(r"^[a-zA-Z0-9_.-]{1,128}$")
+_ALLOWED_METHODS = frozenset({"GET", "POST"})
+
+DEFAULT_SERVER_URL = "http://localhost:8000"
+AIQ_SERVER_URL = os.environ.get("AIQ_SERVER_URL", DEFAULT_SERVER_URL)
+DEFAULT_AGENT_TYPE = "shallow_researcher"
+
+DEFAULT_API_TIMEOUT_SECONDS = 120
+DEFAULT_LONG_HTTP_TIMEOUT_SECONDS = 3600
+JOB_POLL_INTERVAL_SECONDS = 15
+STATUS_CHECK_MAX_ATTEMPTS = 3
+POLL_MAX_CONSECUTIVE_ERRORS = 3
+
+_DONE_JOB_STATES = frozenset({"completed", "success", "failed", "cancelled", "failure"})
+_SUCCESS_JOB_STATES = frozenset({"completed", "success"})
+_FAILED_JOB_STATES = frozenset({"failed", "failure", "cancelled"})
+_STREAM_TERMINAL_EVENTS = frozenset({"complete", "error", "done"})
+
+
+def _validate_base_url(url: str) -> str:
+    raw = (url or "").strip()
+    if not raw:
+        raise RuntimeError("AIQ_SERVER_URL is empty")
+    if len(raw) > 2048 or _CONTROL_CHAR_RE.search(raw):
+        raise RuntimeError("AIQ_SERVER_URL is invalid")
+    parsed = urllib.parse.urlparse(raw)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise RuntimeError("AIQ_SERVER_URL must be an http or https URL with a host")
+    if parsed.username is not None or parsed.password is not None:
+        raise RuntimeError("AIQ_SERVER_URL must not include user:password@")
+    return raw.rstrip("/")
+
+
+def _validate_api_path(path: str) -> None:
+    if not path.startswith("/") or path.startswith("//"):
+        raise RuntimeError("Invalid API path")
+    if len(path) > 4096 or ".." in path or _CONTROL_CHAR_RE.search(path):
+        raise RuntimeError("Invalid API path")
+
+
+def _validate_job_id(job_id: str) -> str:
+    value = job_id.strip()
+    if not _JOB_UUID_RE.fullmatch(value):
+        raise RuntimeError("job_id must be a UUID")
+    return value
+
+
+def _validate_agent_type(agent_type: str) -> str:
+    value = agent_type.strip()
+    if not _AGENT_TYPE_RE.fullmatch(value):
+        raise RuntimeError("Invalid agent_type")
+    return value
+
+
+def _api_request(
+    method: str,
+    path: str,
+    body: dict[str, Any] | None = None,
+    *,
+    timeout: int = DEFAULT_API_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    if method not in _ALLOWED_METHODS:
+        raise RuntimeError(f"Unsupported HTTP method: {method!r}")
+    _validate_api_path(path)
+
+    url = f"{_validate_base_url(AIQ_SERVER_URL)}{path}"
+    data = None if body is None else json.dumps(body).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        error_body = exc.read().decode("utf-8", errors="replace")
+        print(f"HTTP {exc.code}: {error_body[:1000]}", file=sys.stderr)
+        raise RuntimeError(f"HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        print(f"Connection failed for {url}: {exc.reason}", file=sys.stderr)
+        raise RuntimeError(f"Connection failed: {exc.reason}") from exc
+
+    if not payload:
+        return {}
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as exc:
+        print(f"Invalid JSON in API response: {payload[:1000]!r}", file=sys.stderr)
+        raise RuntimeError(f"Invalid JSON in API response: {exc}") from exc
+
+
+def _stream_request(path: str, *, timeout: int = DEFAULT_LONG_HTTP_TIMEOUT_SECONDS) -> Iterator[str]:
+    _validate_api_path(path)
+    url = f"{_validate_base_url(AIQ_SERVER_URL)}{path}"
+    req = urllib.request.Request(url, method="GET")
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            for raw_line in resp:
+                yield raw_line.decode("utf-8", errors="replace").strip()
+    except urllib.error.HTTPError as exc:
+        error_body = exc.read().decode("utf-8", errors="replace")
+        print(f"HTTP {exc.code}: {error_body[:1000]}", file=sys.stderr)
+        raise RuntimeError(f"HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        print(f"Connection failed for {url}: {exc.reason}", file=sys.stderr)
+        raise RuntimeError(f"Connection failed: {exc.reason}") from exc
+
+
+def health() -> dict[str, Any]:
+    for path in ("/health", "/v1/health"):
+        try:
+            return _api_request("GET", path, timeout=10)
+        except RuntimeError:
+            continue
+    return _api_request("GET", "/", timeout=10)
+
+
+def list_agents() -> dict[str, Any]:
+    return _api_request("GET", "/v1/jobs/async/agents")
+
+
+def submit_job(query: str, agent_type: str = DEFAULT_AGENT_TYPE) -> dict[str, Any]:
+    body = {"agent_type": _validate_agent_type(agent_type), "input": query}
+    return _api_request("POST", "/v1/jobs/async/submit", body=body, timeout=DEFAULT_LONG_HTTP_TIMEOUT_SECONDS)
+
+
+def get_job_status(job_id: str) -> dict[str, Any]:
+    return _api_request("GET", f"/v1/jobs/async/job/{_validate_job_id(job_id)}")
+
+
+def get_job_state(job_id: str) -> dict[str, Any]:
+    return _api_request("GET", f"/v1/jobs/async/job/{_validate_job_id(job_id)}/state")
+
+
+def get_report(job_id: str) -> dict[str, Any]:
+    return _api_request("GET", f"/v1/jobs/async/job/{_validate_job_id(job_id)}/report")
+
+
+def cancel_job(job_id: str) -> dict[str, Any]:
+    return _api_request("POST", f"/v1/jobs/async/job/{_validate_job_id(job_id)}/cancel")
+
+
+def stream_job(job_id: str) -> None:
+    for line in _stream_request(f"/v1/jobs/async/job/{_validate_job_id(job_id)}/stream"):
+        if line.startswith("data:"):
+            data = line[5:].strip()
+            if data:
+                print(data, flush=True)
+        elif line.startswith("event:") and line[6:].strip() in _STREAM_TERMINAL_EVENTS:
+            break
+
+
+def chat_request(query: str) -> dict[str, Any]:
+    body = {"messages": [{"role": "user", "content": query}]}
+    print(f"Sending request to: {_validate_base_url(AIQ_SERVER_URL)}/chat", file=sys.stderr)
+    return _api_request("POST", "/chat", body=body, timeout=DEFAULT_LONG_HTTP_TIMEOUT_SECONDS)
+
+
+def poll_until_complete(
+    job_id: str,
+    *,
+    timeout: int = DEFAULT_LONG_HTTP_TIMEOUT_SECONDS,
+    max_consecutive_errors: int = POLL_MAX_CONSECUTIVE_ERRORS,
+) -> dict[str, Any]:
+    deadline = time.time() + timeout
+    consecutive_errors = 0
+    while time.time() < deadline:
+        try:
+            status = get_job_status(job_id)
+            consecutive_errors = 0
+        except RuntimeError as exc:
+            consecutive_errors += 1
+            if consecutive_errors >= max_consecutive_errors:
+                print(f"  Status check failed {consecutive_errors} times in a row: {exc}", file=sys.stderr)
+                raise
+            print(
+                f"  Status check failed ({exc}), retrying... ({consecutive_errors}/{max_consecutive_errors})",
+                file=sys.stderr,
+                flush=True,
+            )
+            time.sleep(JOB_POLL_INTERVAL_SECONDS)
+            continue
+
+        state = status.get("status", "UNKNOWN").lower()
+        if state in _DONE_JOB_STATES:
+            return status
+        print(f"  Status: {state}", file=sys.stderr, flush=True)
+        time.sleep(JOB_POLL_INTERVAL_SECONDS)
+
+    print("  Timed out waiting for job.", file=sys.stderr)
+    return {"status": "TIMEOUT"}
+
+
+def _poll_until_success_or_exit(job_id: str) -> None:
+    try:
+        final = poll_until_complete(job_id)
+    except KeyboardInterrupt:
+        print(f"\nInterrupted. Job {job_id} is still running server-side.", file=sys.stderr)
+        print(f"Resume later: aiq.py research_poll {job_id}", file=sys.stderr)
+        sys.exit(1)
+
+    if final.get("status", "").lower() not in _SUCCESS_JOB_STATES:
+        print(f"Job did not complete: {final.get('status')}", file=sys.stderr)
+        print(json.dumps(final, indent=2))
+        sys.exit(1)
+
+    print(json.dumps(get_report(job_id), indent=2))
+
+
+def _print_usage() -> None:
+    print("Usage: aiq.py <command> [args]")
+    print()
+    print("Commands:")
+    print("  health                        Check the local AIQ server")
+    print("  chat <query>                  POST /chat, returns routed response")
+    print("  agents                        List available async agent types")
+    print("  submit <query> [agent_type]   Submit an async job")
+    print("  status <job_id>               Job status plus /state artifacts")
+    print("  state <job_id>                Event-store artifacts for one async job")
+    print("  stream <job_id>               Stream SSE events from an async job")
+    print("  report <job_id>               Get final report from an async job")
+    print("  research <query> [agent_type] Submit async job, poll, and return report")
+    print("  research_poll <job_id>        Resume polling an existing async job")
+    print("  cancel <job_id>               Cancel a running async job")
+    print()
+    print(f"Environment: AIQ_SERVER_URL defaults to {DEFAULT_SERVER_URL}")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        _print_usage()
+        sys.exit(1)
+
+    cmd = sys.argv[1]
+
+    if cmd == "health":
+        print(json.dumps(health(), indent=2))
+
+    elif cmd == "chat":
+        if len(sys.argv) < 3:
+            print("Usage: aiq.py chat <query>", file=sys.stderr)
+            sys.exit(1)
+        result = chat_request(sys.argv[2])
+
+        content = ""
+        try:
+            content = result["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError):
+            pass
+
+        match = re.search(r"Job ID:\s*([0-9a-f-]{36})", content, re.IGNORECASE)
+        if match:
+            print(json.dumps({"status": "deep_research_running", "job_id": match.group(1)}))
+        else:
+            print(json.dumps(result, indent=2))
+
+    elif cmd == "agents":
+        print(json.dumps(list_agents(), indent=2))
+
+    elif cmd == "submit":
+        if len(sys.argv) < 3:
+            print("Usage: aiq.py submit <query> [agent_type]", file=sys.stderr)
+            sys.exit(1)
+        agent_type = sys.argv[3] if len(sys.argv) > 3 else DEFAULT_AGENT_TYPE
+        print(json.dumps(submit_job(sys.argv[2], agent_type=agent_type), indent=2))
+
+    elif cmd == "status":
+        if len(sys.argv) < 3:
+            print("Usage: aiq.py status <job_id>", file=sys.stderr)
+            sys.exit(1)
+        job_id = sys.argv[2]
+        job_status = get_job_status(job_id)
+        try:
+            job_state = get_job_state(job_id)
+        except RuntimeError as exc:
+            job_state = {"_fetch_error": str(exc)}
+        print(json.dumps({"job_status": job_status, "job_state": job_state}, indent=2))
+
+    elif cmd == "state":
+        if len(sys.argv) < 3:
+            print("Usage: aiq.py state <job_id>", file=sys.stderr)
+            sys.exit(1)
+        print(json.dumps(get_job_state(sys.argv[2]), indent=2))
+
+    elif cmd == "stream":
+        if len(sys.argv) < 3:
+            print("Usage: aiq.py stream <job_id>", file=sys.stderr)
+            sys.exit(1)
+        stream_job(sys.argv[2])
+
+    elif cmd == "report":
+        if len(sys.argv) < 3:
+            print("Usage: aiq.py report <job_id>", file=sys.stderr)
+            sys.exit(1)
+        print(json.dumps(get_report(sys.argv[2]), indent=2))
+
+    elif cmd == "research":
+        if len(sys.argv) < 3:
+            print("Usage: aiq.py research <query> [agent_type]", file=sys.stderr)
+            sys.exit(1)
+        agent_type = sys.argv[3] if len(sys.argv) > 3 else DEFAULT_AGENT_TYPE
+        print(f"Submitting {agent_type} job...", file=sys.stderr)
+        result = submit_job(sys.argv[2], agent_type=agent_type)
+        job_id = result.get("job_id")
+        if not job_id:
+            print(f"ERROR: No job_id in response: {result}", file=sys.stderr)
+            sys.exit(1)
+        print(f"Job submitted: {job_id}", file=sys.stderr)
+        _poll_until_success_or_exit(job_id)
+
+    elif cmd == "research_poll":
+        if len(sys.argv) < 3:
+            print("Usage: aiq.py research_poll <job_id>", file=sys.stderr)
+            sys.exit(1)
+        job_id = sys.argv[2]
+        state = "UNKNOWN"
+        status: dict[str, Any] = {}
+        for attempt in range(1, STATUS_CHECK_MAX_ATTEMPTS + 1):
+            try:
+                status = get_job_status(job_id)
+                state = status.get("status", "UNKNOWN").lower()
+                break
+            except RuntimeError as exc:
+                if attempt == STATUS_CHECK_MAX_ATTEMPTS:
+                    print(f"Status check failed after {STATUS_CHECK_MAX_ATTEMPTS} attempts: {exc}", file=sys.stderr)
+                    sys.exit(1)
+                print(
+                    f"Status check failed ({exc}), retrying in {JOB_POLL_INTERVAL_SECONDS}s... "
+                    f"({attempt}/{STATUS_CHECK_MAX_ATTEMPTS})",
+                    file=sys.stderr,
+                )
+                time.sleep(JOB_POLL_INTERVAL_SECONDS)
+
+        print(f"Current status: {state}", file=sys.stderr)
+        if state in _SUCCESS_JOB_STATES:
+            print(json.dumps(get_report(job_id), indent=2))
+        elif state in _FAILED_JOB_STATES:
+            print(f"Job {job_id} ended with status: {state}", file=sys.stderr)
+            print(json.dumps(status, indent=2))
+            sys.exit(1)
+        else:
+            print("Job still running, polling...", file=sys.stderr)
+            _poll_until_success_or_exit(job_id)
+
+    elif cmd == "cancel":
+        if len(sys.argv) < 3:
+            print("Usage: aiq.py cancel <job_id>", file=sys.stderr)
+            sys.exit(1)
+        print(json.dumps(cancel_job(sys.argv[2]), indent=2))
+
+    else:
+        print(f"Unknown command: {cmd}", file=sys.stderr)
+        _print_usage()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/configs/config_skills.yml
+++ b/configs/config_skills.yml
@@ -235,6 +235,7 @@ functions:
         - numpy
         - pandas
         - pillow
+        - tabulate  # required by pandas.DataFrame.to_markdown(), used by data-table-analysis skill
       block_network: true
 
 workflow:

--- a/configs/config_skills.yml
+++ b/configs/config_skills.yml
@@ -1,0 +1,246 @@
+# This is the default configuration for the Web mode.
+# It has the following features:
+# - Knowledge retrieval using LlamaIndex
+# - Web search and Paper search tools by default
+
+general:
+  use_uvloop: true
+  telemetry:
+    logging:
+      console:
+        _type: console
+        level: INFO
+    # tracing:
+    #   langsmith: # Optional: LangSmith tracing - requires langsmith API key. Set using `export LANGSMITH_API_KEY=<your-langsmith-api-key>`
+    #     _type: langsmith
+    #     project: nvidia-aiq
+
+  front_end:
+    _type: aiq_api
+    runner_class: aiq_api.plugin.AIQAPIWorker
+    # =========================================================================
+    # Knowledge API is automatically enabled when knowledge_retrieval function
+    # is configured
+    # =========================================================================
+    # Async Job API Settings
+    # =========================================================================
+    # Async job infrastructure database (NAT JobStore + EventStore)
+    # Used by: /v1/jobs/async routes, SSE streaming, job status persistence
+    # Requires async driver for SQLite (aiosqlite) or PostgreSQL (asyncpg)
+    # Environment overrides:
+    # - NAT_JOB_STORE_DB_URL (direct override)
+    # - NAT_JOB_STORE_DB_URL_DEV / NAT_JOB_STORE_DB_URL_PROD (via NAT_ENV)
+    db_url: ${NAT_JOB_STORE_DB_URL:-sqlite+aiosqlite:///./jobs.db}
+    # Job expiry - how long completed jobs stay in database before cleanup
+    expiry_seconds: 86400  # 24 hours (min: 600, max: 604800/7 days)
+    cors:
+      allow_origin_regex: 'http://localhost(:\d+)?|http://127.0.0.1(:\d+)?'
+      allow_methods:
+        - GET
+        - POST
+        - DELETE
+        - OPTIONS
+      allow_headers:
+        - "*"
+      allow_credentials: true
+      expose_headers:
+        - "*"
+
+llms:
+  nemotron_llm_intent:
+    _type: nim
+    model_name: nvidia/nemotron-3-nano-30b-a3b
+    base_url: "https://integrate.api.nvidia.com/v1"
+    temperature: 0.5
+    top_p: 0.9
+    max_tokens: 4096
+    num_retries: 5
+    chat_template_kwargs:
+      enable_thinking: true
+
+  nemotron_nano_llm:
+    _type: nim
+    model_name: nvidia/nemotron-3-nano-30b-a3b
+    base_url: "https://integrate.api.nvidia.com/v1"
+    temperature: 0.1
+    top_p: 0.3
+    max_tokens: 16384
+    num_retries: 5
+    chat_template_kwargs:
+      enable_thinking: true
+
+  gpt_oss_llm:
+    _type: nim
+    model_name: openai/gpt-oss-120b
+    base_url: https://integrate.api.nvidia.com/v1
+    temperature: 1.0
+    top_p: 1.0
+    max_tokens: 256000
+    api_key: ${NVIDIA_API_KEY}
+    max_retries: 10
+
+  # Nemotron Super is compatible and tested with AIQ but has limited availability
+  # on the Build API due to high demand.
+  # Uncomment nemotron_super_llm below if the endpoint is accessible.
+  # nemotron_super_llm:
+  #   _type: nim
+  #   model_name: nvidia/nemotron-3-super-120b-a12b
+  #   base_url: "https://integrate.api.nvidia.com/v1"
+  #   temperature: 1.0
+  #   top_p: 1.0
+  #   max_tokens: 128000
+  #   num_retries: 5
+  #   chat_template_kwargs:
+  #     enable_thinking: true
+
+  # LLM for document summaries (required when generate_summary: true)
+  summary_llm:
+    _type: nim
+    model_name: nvidia/nemotron-mini-4b-instruct
+    base_url: "https://integrate.api.nvidia.com/v1"
+    api_key: ${NVIDIA_API_KEY}
+    temperature: 0.3
+    max_tokens: 100
+
+functions:
+  # =========================================================================
+  # Data Source Registry
+  # =========================================================================
+  # Central registry that controls:
+  #   1. UI toggles — each source appears as an on/off switch in the frontend
+  #   2. Per-message filtering — users can select active sources per request
+  #   3. Tool auto-inheritance — agents with no explicit `tools` list receive
+  #      every tool listed here (use `exclude_tools` on agents to specialize)
+  #
+  # Adding a new tool or MCP function group? Just add it here — all agents
+  # pick it up automatically. No per-agent config changes needed.
+  #
+  # Source entry fields:
+  #   id            — Unique key used in API payloads and filtering
+  #   name          — Display name shown in the UI
+  #   description   — Human-readable description shown in the UI
+  #   tools         — List of NAT function names or function group names
+  #   requires_auth — (default: false) If true, the UI greys out this source
+  #                   until the user signs in. Use for sources that need
+  #                   user-level OAuth tokens (e.g., enterprise SSO).
+  #                   Sources using backend API keys (Tavily, Serper) should
+  #                   leave this false.
+  #   default_enabled — (default: true) Whether enabled by default
+  #
+  # See docs/source/customization/tools-and-sources.md for full details.
+  # =========================================================================
+  data_sources:
+    _type: data_source_registry
+    sources:
+      - id: web_search
+        name: "Web Search"
+        description: "Search the web for real-time information."
+        tools:
+          - web_search_tool
+          - advanced_web_search_tool
+      - id: knowledge_layer
+        name: "Knowledge Base"
+        description: "Search uploaded documents and files."
+        tools:
+          - knowledge_search
+      # Uncomment when paper_search_tool is enabled (requires SERPER_API_KEY)
+      # - id: paper_search
+      #   name: "Academic Papers"
+      #   description: "Search academic papers and scientific publications."
+      #   tools:
+      #     - paper_search_tool
+
+  web_search_tool:
+    _type: tavily_web_search
+    max_results: 5
+    max_content_length: 1000
+
+  advanced_web_search_tool:
+    _type: tavily_web_search
+    max_results: 2
+    advanced_search: true
+
+  # Knowledge Retrieval (see sources/knowledge_layer/KNOWLEDGE-LAYER-SETUP.md)
+  knowledge_search:
+    _type: knowledge_retrieval
+    backend: llamaindex
+    collection_name: ${COLLECTION_NAME:-test_collection}
+    generate_summary: true
+    summary_model: summary_llm                     # Required when generate_summary: true
+    summary_db: ${AIQ_SUMMARY_DB:-sqlite+aiosqlite:///./summaries.db}
+    top_k: 5
+    chroma_dir: ${AIQ_CHROMA_DIR:-/tmp/chroma_data}
+
+  # Paper Search (optional - requires SERPER_API_KEY)
+  # Uncomment the block below and set SERPER_API_KEY to enable academic paper search.
+  # paper_search_tool:
+  #   _type: paper_search
+  #   max_results: 5
+  #   serper_api_key: ${SERPER_API_KEY}
+
+  # =========================================================================
+  # Agents
+  # =========================================================================
+  # Tool inheritance: agents with no `tools` list inherit ALL tools from the
+  # data_source_registry above. Use `exclude_tools` to remove specific tools
+  # from an agent (e.g., give shallow the basic search, deep the advanced).
+  # To bypass auto-inherit entirely, set an explicit `tools` list.
+  # =========================================================================
+  intent_classifier:
+    _type: intent_classifier
+    llm: nemotron_llm_intent
+    # tools: omitted -> inherits all from data_source_registry
+    # exclude_tools: []
+    verbose: true
+
+  clarifier_agent:
+    _type: clarifier_agent
+    llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
+    planner_llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
+    # tools: omitted -> inherits all from data_source_registry
+    # exclude_tools: []
+    max_turns: 3
+    enable_plan_approval: true
+    log_response_max_chars: 2000
+    verbose: true
+
+  shallow_research_agent:
+    _type: shallow_research_agent
+    llm: nemotron_nano_llm
+    # tools: omitted -> inherits all from data_source_registry
+    exclude_tools:                     # Remove advanced variant; shallow uses web_search_tool
+      - advanced_web_search_tool
+    verbose: true
+    max_llm_turns: 10
+    max_tool_iterations: 5
+
+  deep_research_agent:
+    _type: deep_research_agent
+    orchestrator_llm: gpt_oss_llm
+    researcher_llm: nemotron_nano_llm  # replace with nemotron_super_llm if available
+    planner_llm: gpt_oss_llm
+    # tools: omitted -> inherits all from data_source_registry
+    exclude_tools:                     # Remove basic variant; deep uses advanced_web_search_tool
+      - web_search_tool
+    max_loops: 2
+    verbose: true
+    skills:
+      enabled: true
+    sandbox:
+      provider: modal
+      app_name: aiq-deep-research
+      image: python:3.12-slim
+      python_packages:
+        - matplotlib
+        - numpy
+        - pandas
+        - pillow
+      block_network: true
+
+workflow:
+  _type: chat_deepresearcher_agent
+  verbose: true
+  enable_escalation: true
+  enable_clarifier: true
+  use_async_deep_research: true
+  checkpoint_db: ${AIQ_CHECKPOINT_DB:-./checkpoints.db}

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -48,11 +48,6 @@ DASK_DISTRIBUTED__LOGGING__DISTRIBUTED=warning
 # AIQ_SUMMARY_DB=
 
 # -----------------------------------------------------------------------------
-# NVIDIA API Key (required for skills sandbox)
-# -----------------------------------------------------------------------------
-NVIDIA_API_KEY=
-
-# -----------------------------------------------------------------------------
 # Environment Variables for Modal Sandbox for Skills Execution (optional)
 # -----------------------------------------------------------------------------
 # MODAL_TOKEN_ID=

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -48,6 +48,17 @@ DASK_DISTRIBUTED__LOGGING__DISTRIBUTED=warning
 # AIQ_SUMMARY_DB=
 
 # -----------------------------------------------------------------------------
+# NVIDIA API Key (required for skills sandbox)
+# -----------------------------------------------------------------------------
+NVIDIA_API_KEY=
+
+# -----------------------------------------------------------------------------
+# Environment Variables for Modal Sandbox for Skills Execution (optional)
+# -----------------------------------------------------------------------------
+# MODAL_TOKEN_ID=
+# MODAL_TOKEN_SECRET=
+
+# -----------------------------------------------------------------------------
 # Observability / Tracing (optional)
 # See docs/source/deployment/observability.md for setup guides.
 # -----------------------------------------------------------------------------

--- a/docs/source/architecture/agents/deep-researcher.md
+++ b/docs/source/architecture/agents/deep-researcher.md
@@ -11,6 +11,9 @@ an orchestrator using the [`deepagents`](https://docs.langchain.com/oss/python/d
 
 **Location:** `src/aiq_agent/agents/deep_researcher/agent.py`
 
+For optional DeepAgents sandbox execution (Modal) and operational notes, see
+[Deep Research Sandbox](./sandbox.md).
+
 ## Purpose
 
 The deep path handles queries that require comprehensive investigation:

--- a/docs/source/architecture/agents/index.md
+++ b/docs/source/architecture/agents/index.md
@@ -21,4 +21,5 @@ intent-classifier.md
 clarifier.md
 shallow-researcher.md
 deep-researcher.md
+sandbox.md
 ```

--- a/docs/source/architecture/agents/sandbox.md
+++ b/docs/source/architecture/agents/sandbox.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Deep Research Sandbox Notes
 
 Deep research can optionally run DeepAgents `execute` calls in a Modal sandbox.

--- a/docs/source/architecture/index.md
+++ b/docs/source/architecture/index.md
@@ -10,3 +10,4 @@ Understand how AI-Q processes queries, routes between agents, and produces resea
 - **[Overview](./overview.md)** — End-to-end system flow with diagrams
 - **[Agents](./agents/index.md)** — Individual agent architectures and internals
 - **[Data Flow](./data-flow.md)** — Request lifecycle, async jobs, SSE streaming
+- **[Deep Research Sandbox](./agents/sandbox.md)** — Modal sandbox behavior and operational notes

--- a/docs/source/examples/index.md
+++ b/docs/source/examples/index.md
@@ -14,3 +14,4 @@ Complete, annotated configuration examples for common use cases.
 | [Full Pipeline -- Foundational RAG](./full-pipeline-web.md) | Complete production setup with hosted RAG | `config_web_frag.yml` |
 | [CLI with Local NIMs](./cli-with-local-nims.md) | Interactive CLI mode with self-hosted NIM models | `config_cli_default.yml` |
 | [Hybrid Frontier Model](./hybrid-frontier-model.md) | NIM for shallow + frontier model for deep research | Custom hybrid |
+| [Deep Research Skills and Sandbox](./skills-sandbox/index.md) | DeepAgents skills with Modal sandbox execution for quantitative research workflows | `config_skills.yml` |

--- a/docs/source/examples/skills-sandbox/index.md
+++ b/docs/source/examples/skills-sandbox/index.md
@@ -1,0 +1,176 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Example: Deep Research Skills and Sandbox
+
+This example shows how to run AI-Q deep research with DeepAgents skills and a Modal-backed sandbox.
+
+Skills let a research agent discover task-specific instructions only when they are relevant. A skill can teach the agent a repeatable workflow, such as extracting numeric facts, normalizing a table, running calculations, and producing reusable text artifacts. The sandbox gives the agent an isolated execution environment for code-based work, such as Python/pandas calculations, without running that code in the AI-Q process.
+
+For more background, see the LangChain DeepAgents docs:
+
+- [Deep Agents overview](https://docs.langchain.com/oss/python/deepagents/overview)
+- [DeepAgents skills](https://docs.langchain.com/oss/python/deepagents/skills)
+
+## What This Example Enables
+
+The example config enables:
+
+- built-in DeepAgents skills from `src/aiq_agent/agents/deep_researcher/skills/`
+- a Modal sandbox for job-scoped Python execution
+- Python packages useful for analysis, including `pandas`, `numpy`, `matplotlib`, and `pillow`
+- virtual `/shared/` files for text artifacts that the orchestrator and subagents can read during the report workflow
+
+The current built-in example skill is `data-table-analysis`. It is intended for quantitative research tasks where the agent must normalize researched facts and compute tabular outputs such as growth rates, rankings, summary statistics, CSV, JSON, or markdown tables.
+
+## Prerequisites
+
+Install and configure AI-Q as usual, then make sure these credentials are available to the process running AI-Q:
+
+```bash
+export NVIDIA_API_KEY="nvapi-..."              # pragma: allowlist secret
+export TAVILY_API_KEY="tvly-..."               # pragma: allowlist secret
+```
+
+For sandbox execution, create a Modal account and configure Modal credentials. Modal uses a token ID and token secret:
+
+```bash
+export MODAL_TOKEN_ID="ak-..."                 # pragma: allowlist secret
+export MODAL_TOKEN_SECRET="as-..."             # pragma: allowlist secret
+```
+
+You can also configure Modal locally with:
+
+```bash
+modal token set --token-id "$MODAL_TOKEN_ID" --token-secret "$MODAL_TOKEN_SECRET"
+```
+
+See Modal's token configuration docs for details: [modal.config](https://modal.com/docs/reference/modal.config).
+
+## Configuration
+
+Use `configs/config_skills.yml`. The relevant section is:
+
+```yaml
+functions:
+  deep_research_agent:
+    _type: deep_research_agent
+    skills:
+      enabled: true
+    sandbox:
+      provider: modal
+      app_name: aiq-deep-research
+      image: python:3.12-slim
+      python_packages:
+        - matplotlib
+        - numpy
+        - pandas
+        - pillow
+      block_network: true
+```
+
+When `skills.enabled` is true, AI-Q preloads the built-in skill files into the DeepAgents virtual filesystem and passes `/skills/` as the skill source. When the sandbox block is present, DeepAgents `execute` calls run inside a job-scoped Modal sandbox.
+
+## Run AI-Q
+
+```bash
+dotenv -f deploy/.env run .venv/bin/nat run \
+  --config_file configs/config_skills.yml \
+  --input "Compare AI infrastructure capex for Microsoft, Google, and Meta over the last 8 quarters. Include QoQ and YoY growth."
+```
+
+For API or UI testing:
+
+```bash
+dotenv -f deploy/.env run .venv/bin/nat serve \
+  --config_file configs/config_skills.yml \
+  --host 0.0.0.0 \
+  --port 8000
+```
+
+Then submit a deep research request through the AI-Q API or UI.
+
+## Example Queries
+
+Use queries that require researched numeric facts plus computed tabular analysis:
+
+```text
+Compare AI infrastructure capex for Microsoft, Google, Meta, and Amazon over the last 8 quarters. Include QoQ and YoY growth.
+```
+
+```text
+Compare R&D spend across the top 10 semiconductor companies and compute R&D as a percent of revenue.
+```
+
+Expected behavior:
+
+1. The planner identifies that a skill should be used for structured quantitative analysis.
+2. Researchers gather source-grounded input figures.
+3. During synthesis, the orchestrator reads the relevant `SKILL.md`.
+4. The agent calls `execute` to run Python/pandas in the Modal sandbox.
+5. The agent writes markdown, CSV, or JSON text artifacts to `/shared/...` with `write_file`.
+6. The final report cites the original sources for input figures and labels computed columns as calculations.
+
+## Skill Files
+
+Built-in deep research skills live under:
+
+```text
+src/aiq_agent/agents/deep_researcher/skills/
+```
+
+Each skill should be a directory with a `SKILL.md` file:
+
+```text
+src/aiq_agent/agents/deep_researcher/skills/
+`-- my-skill/
+    `-- SKILL.md
+```
+
+At minimum, `SKILL.md` needs frontmatter with a stable `name` and a clear `description`:
+
+```markdown
+---
+name: my-skill
+description: >
+  Use this skill when the research task requires a specific repeatable workflow.
+  Include trigger phrases and expected outputs so the agent can decide when to
+  read this skill.
+---
+
+# My Skill
+
+## When to Use
+
+Use this skill for ...
+
+## Execution Flow
+
+1. Gather the required inputs.
+2. Use the appropriate tools.
+3. Write reusable outputs to `/shared/...` when another agent or the final report needs them.
+```
+
+Skill descriptions matter because DeepAgents uses the frontmatter description to decide whether the skill applies before reading the full file. Keep descriptions specific, list representative trigger phrases, and explicitly name required tools such as `execute`, `read_file`, or `write_file` when the workflow depends on them.
+
+## Adding More Skills
+
+To add a built-in AI-Q deep research skill:
+
+1. Create a new directory under `src/aiq_agent/agents/deep_researcher/skills/`.
+2. Add a `SKILL.md` file with frontmatter and workflow instructions.
+3. Put optional helper scripts, references, or templates inside the same skill directory.
+4. Reference any helper files from `SKILL.md` so the agent knows when to read or run them.
+5. Keep workflow instructions generic enough to handle variations of the task, but concrete enough to force required tool calls.
+6. Run with `configs/config_skills.yml` and test a query that should trigger the new skill.
+
+No config change is required for additional built-in skills in this directory when `skills.enabled: true` is set. AI-Q collects available skill directories at runtime and exposes them through the `/skills/` source.
+
+## Notes and Limitations
+
+- The Modal sandbox is used for code execution. Text artifacts that need to survive for the report should be written through DeepAgents filesystem tools to `/shared/...`.
+- `/shared/` is a virtual DeepAgents filesystem path. Use `ls`, `read_file`, `write_file`, and `edit_file` for `/shared/`; do not inspect `/shared/` with shell commands through `execute`.
+- The sandbox is configured with `block_network: true`, so research should happen through AI-Q search tools, not from sandbox code.
+- For the first release, sandbox lifecycle cleanup, persistence policy, quotas, and production capacity controls are tracked as follow-up work.

--- a/docs/source/examples/skills-sandbox/index.md
+++ b/docs/source/examples/skills-sandbox/index.md
@@ -25,6 +25,8 @@ The example config enables:
 
 The current built-in example skill is `data-table-analysis`. It is intended for quantitative research tasks where the agent must normalize researched facts and compute tabular outputs such as growth rates, rankings, summary statistics, CSV, JSON, or markdown tables.
 
+**Models and report quality:** For clearer tables, stronger reasoning over numbers, and more reliable use of the data-table-analysis skill end-to-end, prefer **frontier-class models** for the orchestrator, planner, and researcher in your config ([Swapping models](../../customization/swapping-models.md)). Smaller or faster models may complete runs but often produce weaker structured outputs and more formatting mistakes in long reports.
+
 ## Prerequisites
 
 Install and configure AI-Q as usual, then make sure these credentials are available to the process running AI-Q:
@@ -78,7 +80,7 @@ When `skills.enabled` is true, AI-Q preloads the built-in skill files into the D
 ```bash
 dotenv -f deploy/.env run .venv/bin/nat run \
   --config_file configs/config_skills.yml \
-  --input "Compare AI infrastructure capex for Microsoft, Google, and Meta over the last 8 quarters. Include QoQ and YoY growth."
+  --input "Compare the top 10 publicly traded semiconductor companies by 2024 revenue. Build a markdown table with revenue, YoY growth, market cap, and gross margin. Then rank them and compute summary statistics. Use the data analysis tool for all calculations."
 ```
 
 For API or UI testing:
@@ -94,7 +96,15 @@ Then submit a deep research request through the AI-Q API or UI.
 
 ## Example Queries
 
-Use queries that require researched numeric facts plus computed tabular analysis:
+Use queries that require researched numeric facts plus computed tabular analysis.
+
+**Example prompt:**
+
+```text
+Compare the top 10 publicly traded semiconductor companies by 2024 revenue. Build a markdown table with revenue, YoY growth, market cap, and gross margin. Then rank them and compute summary statistics. Use the data analysis tool for all calculations.
+```
+
+Additional prompts that exercise the same pattern:
 
 ```text
 Compare AI infrastructure capex for Microsoft, Google, Meta, and Amazon over the last 8 quarters. Include QoQ and YoY growth.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -137,4 +137,5 @@ FAQ <./resources/faq.md>
 ./examples/full-pipeline-web.md
 ./examples/cli-with-local-nims.md
 ./examples/hybrid-frontier-model.md
+./examples/skills-sandbox/index.md
 ```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -39,6 +39,7 @@ Overview <./architecture/index.md>
 Architecture <./architecture/overview.md>
 Agents <./architecture/agents/index.md>
 Data Flow <./architecture/data-flow.md>
+Deep Research Sandbox <./architecture/agents/sandbox.md>
 ```
 
 ```{toctree}

--- a/frontends/aiq_api/src/aiq_api/jobs/runner.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/runner.py
@@ -464,6 +464,7 @@ async def run_agent_job(
                         fn_config=fn_config,
                         verbose=verbose,
                         callbacks=callbacks,
+                        job_id=job_id,
                     )
 
                     # Run agent - LLM/tool events will be nested under workflow span
@@ -573,6 +574,7 @@ def _create_agent_instance(
     fn_config,
     verbose: bool,
     callbacks: list,
+    job_id: str | None = None,
 ):
     """
     Create an agent instance, supporting different constructor patterns.
@@ -581,7 +583,22 @@ def _create_agent_instance(
     1. llm_provider + tools pattern (DeepResearcherAgent style)
     2. llm + tools pattern (simpler agents)
     """
-    # Try deep_researcher pattern (llm_provider + tools + max_loops + verbose)
+    # Try async deep_researcher pattern with generic function config and job-scoped runtime state.
+    try:
+        return agent_cls(
+            llm_provider=llm_provider,
+            tools=tools,
+            max_loops=getattr(fn_config, "max_loops", 3),
+            verbose=verbose,
+            callbacks=callbacks,
+            config=fn_config,
+            job_id=job_id,
+        )
+    except TypeError as exc:
+        if "unexpected keyword argument" not in str(exc):
+            raise
+
+    # Try original deep_researcher pattern (llm_provider + tools + max_loops + verbose)
     try:
         return agent_cls(
             llm_provider=llm_provider,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ requires = ["setuptools >= 64", "setuptools-scm>=8"]
 [tool.setuptools]
 package-dir = {"" = "src"}
 
+[tool.setuptools.package-data]
+"aiq_agent.agents.deep_researcher" = ["skills/**/*"]
+
 [project]
 name = "aiq-agent"
 version = "2.0.0"
@@ -31,7 +34,8 @@ dependencies = [
     "nvidia-nat-core==1.5.0",
     "nvidia-nat[langchain,weave,async_endpoints,phoenix]==1.5.0",
     "nvidia-nat-eval==1.5.0",
-    "deepagents>=0.3.0",
+    "deepagents==0.5.0",
+    "langchain-modal==0.0.3",
     "langgraph-checkpoint-postgres>=3.0.0",
     "langgraph-checkpoint-sqlite>=2.0.0",
     "psycopg[binary]>=3.0.0",

--- a/src/aiq_agent/agents/deep_researcher/README.md
+++ b/src/aiq_agent/agents/deep_researcher/README.md
@@ -109,6 +109,9 @@ The core deep research agent using the DeepAgents library.
 
 **Location**: `src/aiq_agent/agents/deep_researcher/`
 
+For optional DeepAgents sandbox behavior and v1 operational notes, see
+[`SANDBOX.md`](SANDBOX.md).
+
 **Configuration:**
 
 ```yaml

--- a/src/aiq_agent/agents/deep_researcher/README.md
+++ b/src/aiq_agent/agents/deep_researcher/README.md
@@ -110,7 +110,7 @@ The core deep research agent using the DeepAgents library.
 **Location**: `src/aiq_agent/agents/deep_researcher/`
 
 For optional DeepAgents sandbox behavior and v1 operational notes, see
-[`SANDBOX.md`](SANDBOX.md).
+[`docs/source/architecture/agents/sandbox.md`](../../../../docs/source/architecture/agents/sandbox.md).
 
 **Configuration:**
 

--- a/src/aiq_agent/agents/deep_researcher/SANDBOX.md
+++ b/src/aiq_agent/agents/deep_researcher/SANDBOX.md
@@ -1,0 +1,42 @@
+# Deep Research Sandbox Notes
+
+Deep research can optionally run DeepAgents `execute` calls in a Modal sandbox.
+In this release, sandboxes are scoped to a single async job: the Modal sandbox
+name is the resolved job ID. This prevents unrelated jobs from sharing sandbox
+filesystem state when each request receives a unique job ID.
+
+The sandbox is an internal execution detail. There are no sandbox-specific API
+endpoints, and job-level auth remains responsible for submit, stream, status,
+cancel, state, and report access.
+
+## Current Behavior
+
+- One sandbox name is used per deep research job when sandboxing is enabled.
+- The sandbox name is the resolved job ID.
+- Different jobs produce different sandbox names.
+- Synchronous sandbox-enabled runs use an internal per-agent runtime ID.
+- Job IDs must be valid Modal object names: 64 characters or fewer, using only
+  alphanumeric characters, dashes, periods, and underscores.
+- Modal `timeout` and `idle_timeout` control sandbox lifetime.
+- Files written inside the Modal workdir are temporary scratch state.
+- Durable results should be returned by the agent or written through DeepAgents
+  virtual filesystem paths such as `/shared/`.
+
+## Operational Notes
+
+- High concurrency creates one Modal sandbox per concurrent sandbox-enabled job.
+- If clients provide custom job IDs, they must not reuse a job ID for a new job.
+  Reuse can attach the job to an existing Modal sandbox until Modal terminates it.
+- Cancelled or failed jobs may leave sandbox scratch files until Modal terminates
+  the sandbox according to timeout settings.
+- If Modal removes a container mid-job, the job may fail and should be retried.
+
+## Deferred Hardening
+
+Planned follow-up work for production deployments:
+
+- Explicit sandbox cleanup on job success, failure, cancellation, and timeout.
+- Retry-on-stale-container handling for Modal `NotFoundError`.
+- Artifact capture rules for generated charts and binary outputs before cleanup.
+- Sandbox quota and concurrency controls.
+- Metrics and structured logs for sandbox create, reuse, failure, and cleanup.

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -12,8 +12,6 @@ from pathlib import Path
 from typing import Any
 
 from deepagents import create_deep_agent
-from deepagents.backends import CompositeBackend
-from deepagents.backends import StateBackend
 from langchain.agents.middleware import ModelRetryMiddleware
 from langchain_core.messages import AIMessage
 from langchain_core.messages import HumanMessage
@@ -34,6 +32,9 @@ from .custom_middleware import SourceRegistryMiddleware
 from .custom_middleware import ToolNameSanitizationMiddleware
 from .custom_middleware import ToolResultPruningMiddleware
 from .custom_middleware import ToolRetryMiddleware
+from .deepagents_runtime import DeepAgentsRuntime
+from .deepagents_runtime import SandboxConfig
+from .deepagents_runtime import SkillsConfig
 from .models import DeepResearchAgentState
 
 try:
@@ -113,6 +114,10 @@ class DeepResearcherAgent:
         max_loops: int = 2,
         verbose: bool = True,
         callbacks: list[Any] | None = None,
+        skills: SkillsConfig | None = None,
+        sandbox: SandboxConfig | None = None,
+        config: Any | None = None,
+        job_id: str | None = None,
     ) -> None:
         """
         Initialize the deep researcher subagent.
@@ -123,6 +128,10 @@ class DeepResearcherAgent:
             max_loops: Maximum number of research loops (default 2).
             verbose: Enable detailed logging.
             callbacks: Optional list of callbacks.
+            skills: Optional DeepAgents skills config.
+            sandbox: Optional DeepAgents sandbox config.
+            config: Optional agent config. Used by async workers to pass function config generically.
+            job_id: Optional async job identifier used to scope sandbox backends.
         """
         self.llm_provider = llm_provider
         self.tools = list(tools) if tools else []
@@ -132,6 +141,10 @@ class DeepResearcherAgent:
 
         if self.verbose:
             logger.info("Tools configured: %d", len(self.tools))
+        if config is not None:
+            skills = skills or getattr(config, "skills", None)
+            sandbox = sandbox if sandbox is not None else getattr(config, "sandbox", None)
+        self.deepagents_runtime = DeepAgentsRuntime(skills=skills, sandbox=sandbox, job_id=job_id)
 
         self._prompts = self._load_prompts()
         self.tools_info = []
@@ -198,58 +211,68 @@ class DeepResearcherAgent:
         }
         return defaults.get(name, f"You are a {name} agent.")
 
+    def _deepagents_prompt_context(self) -> dict[str, Any]:
+        """Return prompt variables for optional DeepAgents skills and sandbox support."""
+        skill_sources = self.deepagents_runtime.skill_sources
+        sandbox = self.deepagents_runtime.sandbox
+        return {
+            "skills_enabled": skill_sources is not None,
+            "skill_sources": skill_sources or [],
+            "sandbox_enabled": sandbox is not None,
+            "sandbox_python_packages": tuple(sandbox.python_packages) if sandbox is not None else (),
+        }
+
     def _get_subagents(self, state: DeepResearchAgentState) -> list[dict[str, Any]]:
         """Build subagent configs with state-dependent prompts (e.g. available_documents)."""
         available_docs = [doc.model_dump() for doc in (state.available_documents or [])]
-        return [
-            {
-                "name": "planner-agent",
-                "description": (
-                    "Content-driven research planning - iteratively builds evidence-grounded "
-                    "outlines through interleaved search and outline optimization"
-                ),
-                "system_prompt": render_prompt_template(
-                    self._prompts["planner"],
-                    current_datetime=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-                    user_info=state.user_info,
-                    tools=self.tools_info,
-                    available_documents=available_docs,
-                ),
-                "tools": self.all_tools,
-                "model": self.llm_provider.get(LLMRole.PLANNER),
-                "middleware": self.middleware,
-            },
-            {
-                "name": "researcher-agent",
-                "description": (
-                    "Information gathering - executes search queries and synthesizes "
-                    "relevant content from available sources"
-                ),
-                "system_prompt": render_prompt_template(
-                    self._prompts["researcher"],
-                    current_datetime=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-                    user_info=state.user_info,
-                    tools=self.tools_info,
-                    available_documents=available_docs,
-                ),
-                "tools": self.all_tools,
-                "model": self.llm_provider.get(LLMRole.RESEARCHER),
-                "middleware": self.middleware,
-            },
-        ]
+        deepagents_prompt_context = self._deepagents_prompt_context()
+        skill_sources = self.deepagents_runtime.skill_sources
+        planner_agent: dict[str, Any] = {
+            "name": "planner-agent",
+            "description": (
+                "Content-driven research planning - iteratively builds evidence-grounded "
+                "outlines through interleaved search and outline optimization"
+            ),
+            "system_prompt": render_prompt_template(
+                self._prompts["planner"],
+                current_datetime=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                user_info=state.user_info,
+                tools=self.tools_info,
+                available_documents=available_docs,
+                **deepagents_prompt_context,
+            ),
+            "tools": self.all_tools,
+            "model": self.llm_provider.get(LLMRole.PLANNER),
+            "middleware": self.middleware,
+        }
+        researcher_agent: dict[str, Any] = {
+            "name": "researcher-agent",
+            "description": (
+                "Information gathering - executes search queries and synthesizes "
+                "relevant content from available sources"
+            ),
+            "system_prompt": render_prompt_template(
+                self._prompts["researcher"],
+                current_datetime=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                user_info=state.user_info,
+                tools=self.tools_info,
+                available_documents=available_docs,
+                **deepagents_prompt_context,
+            ),
+            "tools": self.all_tools,
+            "model": self.llm_provider.get(LLMRole.RESEARCHER),
+            "middleware": self.middleware,
+        }
+        if skill_sources is not None:
+            planner_agent["skills"] = skill_sources
+            researcher_agent["skills"] = skill_sources
+        return [planner_agent, researcher_agent]
 
     def _build_orchestrator_agent(self, state: DeepResearchAgentState) -> str:
         """Get the orchestrator instructions for the deep research agent."""
 
-        def backend(runtime):
-            return CompositeBackend(
-                default=StateBackend(runtime),
-                routes={
-                    "/shared/": StateBackend(runtime),
-                },
-            )
-
         available_docs = [doc.model_dump() for doc in (state.available_documents or [])]
+        deepagents_prompt_context = self._deepagents_prompt_context()
         orchestrator_instructions = render_prompt_template(
             self._prompts["orchestrator"],
             current_datetime=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
@@ -257,17 +280,20 @@ class DeepResearcherAgent:
             clarifier_result=state.clarifier_result,
             available_documents=available_docs,
             tools=self.tools_info,
+            **deepagents_prompt_context,
         )
+
+        deepagents_kwargs = self.deepagents_runtime.create_agent_kwargs
 
         agent = create_deep_agent(
             model=self.llm_provider.get(LLMRole.ORCHESTRATOR),
             tools=self.all_tools,
-            backend=backend,
             system_prompt=orchestrator_instructions,
             subagents=self._get_subagents(state),
             store=InMemoryStore(),
             context_schema=DeepResearchAgentState,
             middleware=self.middleware,
+            **deepagents_kwargs,
         )
         return agent.with_config({"recursion_limit": 1000})
 
@@ -373,7 +399,7 @@ class DeepResearcherAgent:
         """
         Execute deep research with multi-phase workflow.
         """
-
+        state = self.deepagents_runtime.prepare_state(state)
         agent = self._build_orchestrator_agent(state)
 
         messages = state.messages

--- a/src/aiq_agent/agents/deep_researcher/deepagents_runtime.py
+++ b/src/aiq_agent/agents/deep_researcher/deepagents_runtime.py
@@ -1,5 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """DeepAgents skills and sandbox runtime support for deep research."""
 
 from __future__ import annotations

--- a/src/aiq_agent/agents/deep_researcher/deepagents_runtime.py
+++ b/src/aiq_agent/agents/deep_researcher/deepagents_runtime.py
@@ -32,6 +32,7 @@ from deepagents.backends.protocol import EditResult
 from deepagents.backends.protocol import ExecuteResponse
 from deepagents.backends.protocol import FileDownloadResponse
 from deepagents.backends.protocol import FileUploadResponse
+from deepagents.backends.protocol import ReadResult
 from deepagents.backends.protocol import WriteResult
 from deepagents.backends.sandbox import BaseSandbox
 from pydantic import BaseModel
@@ -86,6 +87,12 @@ class _PrefixedStateBackend(StateBackend):
         result = super().edit(file_path, old_string, new_string, replace_all=replace_all)
         if result.error and file_path in result.error:
             return EditResult(error=self._rewrite_error(result.error, file_path))
+        return result
+
+    def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
+        result = super().read(file_path, offset=offset, limit=limit)
+        if result.error and file_path in result.error:
+            return ReadResult(error=self._rewrite_error(result.error, file_path))
         return result
 
 
@@ -330,11 +337,22 @@ class _LazyModalSandboxBackend(BaseSandbox):
 
         with self._lock:
             if self._backend is None:
+                logger.info(
+                    "Modal sandbox backend init: sandbox_name=%s app=%s",
+                    self.sandbox_name,
+                    self.config.app_name,
+                )
                 self._backend = _create_modal_backend_now(self.config, self.sandbox_name)
             return self._backend
 
     def _reset_backend(self) -> None:
         with self._lock:
+            logger.warning(
+                "Modal sandbox backend RESET: sandbox_name=%s app=%s "
+                "(any uploaded files in the previous sandbox are now lost)",
+                self.sandbox_name,
+                self.config.app_name,
+            )
             self._backend = _create_modal_backend_now(self.config, self.sandbox_name, force_new=True)
 
 
@@ -351,9 +369,11 @@ def _create_modal_backend_now(config: SandboxConfig, sandbox_name: str, *, force
     app = modal.App.lookup(name=config.app_name, create_if_missing=True)
     if not force_new:
         try:
-            return ModalSandbox(sandbox=modal.Sandbox.from_name(config.app_name, sandbox_name))
+            sandbox = modal.Sandbox.from_name(config.app_name, sandbox_name)
+            logger.info("Modal sandbox attached to existing instance: name=%s", sandbox_name)
+            return ModalSandbox(sandbox=sandbox)
         except modal.exception.NotFoundError:
-            pass
+            logger.info("Modal sandbox not found, creating fresh instance: name=%s", sandbox_name)
 
     image = modal.Image.from_registry(config.image)
     if config.python_packages:
@@ -371,8 +391,16 @@ def _create_modal_backend_now(config: SandboxConfig, sandbox_name: str, *, force
             idle_timeout=config.idle_timeout,
             block_network=config.block_network,
         )
+        logger.info(
+            "Modal sandbox CREATED: name=%s image=%s workdir=%s timeout=%ds",
+            sandbox_name,
+            config.image,
+            config.workdir,
+            config.timeout,
+        )
     except modal.exception.AlreadyExistsError:
         sandbox = modal.Sandbox.from_name(config.app_name, sandbox_name)
+        logger.info("Modal sandbox attached after AlreadyExistsError: name=%s", sandbox_name)
     return ModalSandbox(sandbox=sandbox)
 
 

--- a/src/aiq_agent/agents/deep_researcher/deepagents_runtime.py
+++ b/src/aiq_agent/agents/deep_researcher/deepagents_runtime.py
@@ -1,0 +1,325 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""DeepAgents skills and sandbox runtime support for deep research."""
+
+from __future__ import annotations
+
+import logging
+import re
+import shlex
+import threading
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from deepagents.backends import CompositeBackend
+from deepagents.backends import StateBackend
+from deepagents.backends.protocol import ExecuteResponse
+from deepagents.backends.protocol import FileDownloadResponse
+from deepagents.backends.protocol import FileUploadResponse
+from deepagents.backends.sandbox import BaseSandbox
+from pydantic import BaseModel
+from pydantic import Field
+
+logger = logging.getLogger(__name__)
+
+AGENT_DIR = Path(__file__).parent
+BUILTIN_SKILLS_DIR = AGENT_DIR / "skills"
+BUILTIN_SKILL_SOURCE = "/skills/"
+
+
+class SkillsConfig(BaseModel):
+    """Configuration for built-in DeepAgents skills."""
+
+    enabled: bool = Field(default=False, description="Enable DeepAgents skills for the orchestrator")
+    sources: tuple[str, ...] = Field(
+        default=(BUILTIN_SKILL_SOURCE,),
+        description="DeepAgents skill source paths. Defaults to the built-in deep researcher skills directory.",
+    )
+
+    @classmethod
+    def enabled_builtin(cls) -> SkillsConfig:
+        return cls(enabled=True)
+
+
+class SandboxConfig(BaseModel):
+    """Configuration for a DeepAgents sandbox backend."""
+
+    provider: str = Field(default="modal", description="Sandbox backend provider. Supported value: modal.")
+    app_name: str = Field(default="aiq-deep-research", description="Modal app name for deep research sandboxes")
+    image: str = Field(default="python:3.12-slim", description="Container image for Modal sandboxes")
+    python_packages: tuple[str, ...] = Field(
+        default=(),
+        description="Python packages to install into the Modal sandbox image, such as matplotlib or pillow.",
+    )
+    workdir: str = Field(default="/workspace", description="Working directory inside Modal sandboxes")
+    timeout: int = Field(default=1200, description="Maximum Modal sandbox lifetime in seconds")
+    idle_timeout: int = Field(default=1800, description="Modal sandbox idle timeout in seconds")
+    block_network: bool = Field(default=True, description="Block outbound network access from Modal sandboxes")
+
+    def __init__(self, **data: Any) -> None:
+        super().__init__(**data)
+        provider = self.provider.lower()
+        if provider not in {"modal"}:
+            raise ValueError(f"Unsupported sandbox provider: {self.provider}. Supported providers: modal")
+        self.provider = provider
+
+
+class DeepAgentsRuntime:
+    """Builds DeepAgents backend kwargs and prepares built-in skill files."""
+
+    def __init__(
+        self,
+        *,
+        skills: SkillsConfig | None = None,
+        sandbox: SandboxConfig | None = None,
+        job_id: str | None = None,
+    ) -> None:
+        self.skills = skills or SkillsConfig()
+        self.sandbox = sandbox
+        self.job_id = str(job_id) if job_id is not None else str(uuid4())
+        self._backend: Any | None = None
+
+    @property
+    def skill_sources(self) -> list[str] | None:
+        if not self.skills.enabled:
+            return None
+        return list(self.skills.sources)
+
+    @property
+    def builtin_skills_dir(self) -> Path:
+        return BUILTIN_SKILLS_DIR
+
+    @property
+    def create_agent_kwargs(self) -> dict[str, Any]:
+        backend = self.backend
+        kwargs: dict[str, Any] = {"backend": backend}
+        if self.skill_sources is not None:
+            kwargs["skills"] = self.skill_sources
+        return kwargs
+
+    @property
+    def backend(self) -> Any:
+        """Return the concrete backend instance passed to DeepAgents."""
+        if self._backend is not None:
+            return self._backend
+
+        sandbox = self.sandbox
+        if sandbox is not None:
+            sandbox_backend = _create_sandbox_backend(sandbox, self.job_id)
+            self._backend = CompositeBackend(
+                default=sandbox_backend,
+                routes={
+                    BUILTIN_SKILL_SOURCE: StateBackend(),
+                    "/shared/": StateBackend(),
+                },
+            )
+            return self._backend
+
+        self._backend = CompositeBackend(
+            default=StateBackend(),
+            routes={
+                BUILTIN_SKILL_SOURCE: StateBackend(),
+                "/shared/": StateBackend(),
+            },
+        )
+        return self._backend
+
+    def prepare_state(self, state: Any) -> Any:
+        """Preload built-in skills into state when using the StateBackend."""
+        if not self.skills.enabled:
+            return state
+
+        files = dict(getattr(state, "files", None) or {})
+        skill_files = _builtin_skill_state_files()
+        for file_path, file_data in skill_files.items():
+            files.setdefault(file_path, file_data)
+        return state.model_copy(update={"files": files})
+
+
+def _collect_builtin_skill_files() -> list[tuple[str, bytes]]:
+    files: list[tuple[str, bytes]] = []
+    if not BUILTIN_SKILLS_DIR.exists():
+        return files
+
+    for skill_dir in sorted(BUILTIN_SKILLS_DIR.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        if skill_dir.name.startswith(".") or skill_dir.name == "__pycache__":
+            continue
+        skill_md = skill_dir / "SKILL.md"
+        if not skill_md.exists():
+            continue
+        files.append((f"{BUILTIN_SKILL_SOURCE}{skill_dir.name}/SKILL.md", skill_md.read_bytes()))
+    return files
+
+
+def _builtin_skill_state_files() -> dict[str, dict[str, str]]:
+    timestamp = datetime.now().isoformat()
+    return {
+        _strip_builtin_skill_source(file_path): {
+            "content": content.decode("utf-8"),
+            "encoding": "utf-8",
+            "created_at": timestamp,
+            "modified_at": timestamp,
+        }
+        for file_path, content in _collect_builtin_skill_files()
+    }
+
+
+def _strip_builtin_skill_source(file_path: str) -> str:
+    if file_path.startswith(BUILTIN_SKILL_SOURCE):
+        return "/" + file_path[len(BUILTIN_SKILL_SOURCE) :].lstrip("/")
+    return file_path
+
+
+def _validate_modal_sandbox_name(job_id: str) -> str:
+    if len(job_id) > 64 or re.match(r"^[a-zA-Z0-9-_.]+$", job_id) is None or re.match(r"^ap-[a-zA-Z0-9]{22}$", job_id):
+        raise ValueError(
+            "Deep research job_id must be a valid Modal sandbox name: "
+            "64 characters or fewer, using only alphanumeric characters, dashes, periods, and underscores."
+        )
+    return job_id
+
+
+def _create_sandbox_backend(config: SandboxConfig, job_id: str) -> Any:
+    if config.provider == "modal":
+        return _create_modal_backend(config, job_id)
+    raise ValueError(f"Unsupported sandbox provider: {config.provider}. Supported providers: modal")
+
+
+def _create_modal_backend(config: SandboxConfig, job_id: str) -> Any:
+    return _LazyModalSandboxBackend(config, job_id)
+
+
+class _LazyModalSandboxBackend(BaseSandbox):
+    """Job-scoped Modal backend that creates and recreates the sandbox on demand."""
+
+    def __init__(self, config: SandboxConfig, job_id: str) -> None:
+        self.config = config
+        self.sandbox_name = _validate_modal_sandbox_name(job_id)
+        self._backend: Any | None = None
+        self._lock = threading.Lock()
+
+        try:
+            import langchain_modal  # noqa: F401
+            import modal  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "The Modal sandbox backend requires the `langchain-modal` and `modal` packages. "
+                "Install the updated AIQ dependencies and run `modal setup` before enabling a Modal sandbox."
+            ) from exc
+
+    @property
+    def id(self) -> str:
+        backend = self._backend
+        if backend is None:
+            return self.sandbox_name
+        return backend.id
+
+    def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
+        for attempt in range(2):
+            try:
+                return self._get_backend().execute(command, timeout=timeout)
+            except Exception as exc:
+                if attempt == 0 and _is_modal_not_found_error(exc):
+                    logger.warning(
+                        "Modal sandbox %s disappeared during execute; recreating and retrying once",
+                        self.sandbox_name,
+                    )
+                    self._reset_backend()
+                    continue
+                raise
+        raise RuntimeError("unreachable")
+
+    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        for attempt in range(2):
+            try:
+                return self._get_backend().upload_files(files)
+            except Exception as exc:
+                if attempt == 0 and _is_modal_not_found_error(exc):
+                    logger.warning(
+                        "Modal sandbox %s disappeared during file upload; recreating and retrying once",
+                        self.sandbox_name,
+                    )
+                    self._reset_backend()
+                    continue
+                raise
+        raise RuntimeError("unreachable")
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        for attempt in range(2):
+            try:
+                return self._get_backend().download_files(paths)
+            except Exception as exc:
+                if attempt == 0 and _is_modal_not_found_error(exc):
+                    logger.warning(
+                        "Modal sandbox %s disappeared during file download; recreating and retrying once",
+                        self.sandbox_name,
+                    )
+                    self._reset_backend()
+                    continue
+                raise
+        raise RuntimeError("unreachable")
+
+    def _get_backend(self) -> Any:
+        backend = self._backend
+        if backend is not None:
+            return backend
+
+        with self._lock:
+            if self._backend is None:
+                self._backend = _create_modal_backend_now(self.config, self.sandbox_name)
+            return self._backend
+
+    def _reset_backend(self) -> None:
+        with self._lock:
+            self._backend = _create_modal_backend_now(self.config, self.sandbox_name, force_new=True)
+
+
+def _create_modal_backend_now(config: SandboxConfig, sandbox_name: str, *, force_new: bool = False) -> Any:
+    try:
+        import modal
+        from langchain_modal import ModalSandbox
+    except ImportError as exc:
+        raise ImportError(
+            "The Modal sandbox backend requires the `langchain-modal` and `modal` packages. "
+            "Install the updated AIQ dependencies and run `modal setup` before enabling a Modal sandbox."
+        ) from exc
+
+    app = modal.App.lookup(name=config.app_name, create_if_missing=True)
+    if not force_new:
+        try:
+            return ModalSandbox(sandbox=modal.Sandbox.from_name(config.app_name, sandbox_name))
+        except modal.exception.NotFoundError:
+            pass
+
+    image = modal.Image.from_registry(config.image)
+    if config.python_packages:
+        image = image.pip_install(*config.python_packages)
+    if config.workdir:
+        image = image.run_commands(f"mkdir -p {shlex.quote(config.workdir)}")
+
+    try:
+        sandbox = modal.Sandbox.create(
+            app=app,
+            image=image,
+            workdir=config.workdir,
+            name=sandbox_name,
+            timeout=config.timeout,
+            idle_timeout=config.idle_timeout,
+            block_network=config.block_network,
+        )
+    except modal.exception.AlreadyExistsError:
+        sandbox = modal.Sandbox.from_name(config.app_name, sandbox_name)
+    return ModalSandbox(sandbox=sandbox)
+
+
+def _is_modal_not_found_error(exc: Exception) -> bool:
+    try:
+        import modal
+
+        return isinstance(exc, modal.exception.NotFoundError)
+    except ImportError:
+        return exc.__class__.__name__ == "NotFoundError" and exc.__class__.__module__.startswith("modal")

--- a/src/aiq_agent/agents/deep_researcher/deepagents_runtime.py
+++ b/src/aiq_agent/agents/deep_researcher/deepagents_runtime.py
@@ -28,9 +28,11 @@ from uuid import uuid4
 
 from deepagents.backends import CompositeBackend
 from deepagents.backends import StateBackend
+from deepagents.backends.protocol import EditResult
 from deepagents.backends.protocol import ExecuteResponse
 from deepagents.backends.protocol import FileDownloadResponse
 from deepagents.backends.protocol import FileUploadResponse
+from deepagents.backends.protocol import WriteResult
 from deepagents.backends.sandbox import BaseSandbox
 from pydantic import BaseModel
 from pydantic import Field
@@ -40,6 +42,51 @@ logger = logging.getLogger(__name__)
 AGENT_DIR = Path(__file__).parent
 BUILTIN_SKILLS_DIR = AGENT_DIR / "skills"
 BUILTIN_SKILL_SOURCE = "/skills/"
+SHARED_ROUTE = "/shared/"
+
+
+class _PrefixedStateBackend(StateBackend):
+    """StateBackend that re-prepends a route prefix on error messages.
+
+    Why: deepagents' CompositeBackend strips the route prefix before delegating
+    to the routed backend, then rewrites WriteResult.path back to the full path
+    on success — but does NOT rewrite the path embedded in WriteResult.error /
+    EditResult.error. The agent then sees an error referencing a path it never
+    wrote to (e.g. ``/0_weather_data.txt`` instead of ``/shared/0_weather_data.txt``)
+    and chases the phantom path via shell, which routes to a different backend.
+    Restore the user-visible path here so error messages are consistent with
+    what the agent actually invoked.
+    """
+
+    def __init__(self, route_prefix: str) -> None:
+        super().__init__()
+        self._prefix = route_prefix.rstrip("/")
+
+    def _restore(self, key: str) -> str:
+        if key.startswith("/"):
+            return f"{self._prefix}{key}"
+        return f"{self._prefix}/{key}"
+
+    def _rewrite_error(self, error: str, file_path: str) -> str:
+        return error.replace(file_path, self._restore(file_path))
+
+    def write(self, file_path: str, content: str) -> WriteResult:
+        result = super().write(file_path, content)
+        if result.error and file_path in result.error:
+            return WriteResult(error=self._rewrite_error(result.error, file_path))
+        return result
+
+    def edit(
+        self,
+        file_path: str,
+        old_string: str,
+        new_string: str,
+        replace_all: bool = False,
+    ) -> EditResult:
+        result = super().edit(file_path, old_string, new_string, replace_all=replace_all)
+        if result.error and file_path in result.error:
+            return EditResult(error=self._rewrite_error(result.error, file_path))
+        return result
 
 
 class SkillsConfig(BaseModel):
@@ -124,8 +171,8 @@ class DeepAgentsRuntime:
             self._backend = CompositeBackend(
                 default=sandbox_backend,
                 routes={
-                    BUILTIN_SKILL_SOURCE: StateBackend(),
-                    "/shared/": StateBackend(),
+                    BUILTIN_SKILL_SOURCE: _PrefixedStateBackend(BUILTIN_SKILL_SOURCE),
+                    SHARED_ROUTE: _PrefixedStateBackend(SHARED_ROUTE),
                 },
             )
             return self._backend
@@ -133,8 +180,8 @@ class DeepAgentsRuntime:
         self._backend = CompositeBackend(
             default=StateBackend(),
             routes={
-                BUILTIN_SKILL_SOURCE: StateBackend(),
-                "/shared/": StateBackend(),
+                BUILTIN_SKILL_SOURCE: _PrefixedStateBackend(BUILTIN_SKILL_SOURCE),
+                SHARED_ROUTE: _PrefixedStateBackend(SHARED_ROUTE),
             },
         )
         return self._backend

--- a/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
@@ -11,7 +11,12 @@ You are a Deep Research agent that coordinates the production of a publication-r
 3. **Execute**: Use the execute tool to run the script: `execute("python /workspace/[name].py")`
 4. **Review output**: Check the execution output for results or errors
 5. **Iterate if needed**: Fix errors and re-run (max 2 retries)
-6. **Write findings**: Summarize results to /shared/[task_topic].txt{% endif %}
+6. **Write findings**: Summarize results to /shared/[task_topic].txt
+
+Filesystem rules for skills:
+- `/workspace/` is the sandbox real filesystem — used for scripts and intermediate files; reachable via `execute`/shell.
+- `/shared/` is a virtual path managed by the runtime — reachable ONLY via `read_file`/`write_file`/`ls`/`glob`. Sandbox `execute` calls cannot see `/shared/` (and shell `ls /shared` will fail). Do not write `/shared/` paths from inside Python scripts in `/workspace/`.
+- `write_file` cannot overwrite an existing file. To revise, use `edit_file` or write to a new path.{% endif %}
 
 ## Workflow
 
@@ -36,7 +41,7 @@ Step 7. **Final verification**: Use `think` tool to review constraints, note any
    - Every claim has a citation
    - Sources section is well-formatted and includes all referenced URLs
    - Report meets length requirement
-Step 8. **Return report**: Return the final report to the user in your final message and also call the `write_file` filesystem tool with `file_path="/report.md"`.
+Step 8. **Return report**: Return the final report to the user in your final message and also call the `write_file` filesystem tool with `file_path="/report.md"`. If `write_file` returns "File already exists" (a prior attempt wrote `/report.md`), do NOT abandon the file write — use `edit_file` against `/report.md` to apply the corrections, so the on-disk report stays in sync with what is returned to the user.
 
 ## Progress Tracking (REQUIRED)
 You MUST invoke the write_todos tool to update your progress after completing each workflow step. Use status values: "pending", "in_progress", or "completed".

--- a/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
@@ -5,21 +5,30 @@ You are a Deep Research agent that coordinates the production of a publication-r
 1. **planner-agent**: Content-driven research planning - generates task analysis, TOC (Table of Contents), constraints (acceptance criteria), and queries
 2. **researcher-agent**: Gathers and synthesizes information using available search tools
 
+{% if skills_enabled %}Available Skills:
+1. **Read skills (REQUIRED)**: Use read_file to load the relevant SKILL.md BEFORE writing any code. Copy initialization boilerplate and API patterns directly from the skill.
+2. **Write script**: Use write_file to create a Python script at /workspace/[name].py. Base your code on the patterns from the skill — do not write from scratch.
+3. **Execute**: Use the execute tool to run the script: `execute("python /workspace/[name].py")`
+4. **Review output**: Check the execution output for results or errors
+5. **Iterate if needed**: Fix errors and re-run (max 2 retries)
+6. **Write findings**: Summarize results to /shared/[task_topic].txt{% endif %}
+
 ## Workflow
-Step 1. **Task Decomposition and Progress Tracking**: Use `write_todos` to track research tasks, updating as planning completes and work progresses. Follow instructions in `## Progress Tracking` section.
-Step 2. **Planning**: Delegate research planning to the planner-agent using the task() tool to generate task analysis, TOC, constraints, and queries.
-Step 3. **Research**: Read the generated plan using read_file /shared/plan.json, then delegate up to 6 researcher-agent calls for the queries from the plan using the task() tool. ALWAYS use the researcher-agent for research; never conduct search yourself and never re-delegate to the planner-agent.
+
+{% if skills_enabled %}Note: Make sure to use skills following the skill instructions.{% endif %}Step 1. **Task Decomposition and Progress Tracking**: Use `write_todos` to track research tasks, updating as planning completes and work progresses. Follow instructions in `## Progress Tracking` section.
+Step 2. **Planning**: Delegate research planning to the planner-agent using the task() tool to generate task analysis, TOC, constraints, and queries.{% if skills_enabled %} Tell the planner to account for available skills and to identify where a relevant skill should be used instead of ad hoc specialized work.{% endif %}
+Step 3. **Research**: Read the generated plan by calling the `read_file` tool with `file_path="/shared/plan.json"`, then delegate up to 6 researcher-agent calls for the queries from the plan using the task() tool. ALWAYS use the researcher-agent for research; never conduct search yourself and never re-delegate to the planner-agent.{% if skills_enabled %} Include any applicable skill-use requirements from the plan in researcher-agent requests; researchers should use search tools for evidence gathering and relevant skills for covered specialized work.{% endif %}
 Step 4. **Verify after each researcher**: Use `think` tool to check and note down if findings satisfy constraints.
 Step 5. **Synthesize** (CRITICAL — follow this exact sequence):
-   a. Call `ls /shared/` to discover all research note files.
-   b. Call `read_file` on EACH file. Read ALL files before proceeding — do not start writing until you have read every researcher output.
-   c. After reading all files, call `think` to create a consolidated outline:
+   a. Call the `ls` filesystem tool with `path="/shared/"` to discover all research note files. Do not use `execute` or shell commands to inspect `/shared/`.
+   b. Call the `read_file` filesystem tool on EACH file. Read ALL files before proceeding — do not start writing until you have read every researcher output.
+   c. {% if skills_enabled %}Before doing synthesis work yourself, review the Skills System section. If an available skill applies to the required analysis, calculations, transformations, visualizations, file generation, or structured outputs, use it following the skill workflow instructions. Then call `think` to create a consolidated outline:{% else %}After reading all files, call `think` to create a consolidated outline:{% endif %}
       - List every concrete fact, name, date, number, project, ticket, and URL found across ALL files
       - Group findings by topic/section
       - Note which findings appear in multiple sources (high confidence)
       - Note genuine gaps (topics with zero findings)
    d. Call `get_verified_sources` to get the authoritative URL list — use ONLY these URLs in your report.
-   e. Write a consolidated findings summary using `write_file /shared/consolidated_findings.md`. Include every key fact, figure, name, date, URL, and quote from all researcher files. This file serves as your reference during report writing — if older tool results are pruned from context, you can re-read this file.
+   e. Write a consolidated findings summary using the `write_file` filesystem tool with `file_path="/shared/consolidated_findings.md"`. Include every key fact, figure, name, date, URL, and quote from all researcher files. This file serves as your reference during report writing — if older tool results are pruned from context, you can re-read this file.
    **WARNING**: If you skip reading any /shared/ file, your report will be incomplete. If you skip writing consolidated_findings.md, you risk losing earlier findings during report writing.
 Step 6. **Write report**: Write a comprehensive, in-depth, long-form report following the TOC and satisfying constraints. If you need to recall researcher findings during writing, re-read `/shared/consolidated_findings.md`.
 Step 7. **Final verification**: Use `think` tool to review constraints, note any gaps, proceed with best-effort report. Make sure that:
@@ -27,7 +36,7 @@ Step 7. **Final verification**: Use `think` tool to review constraints, note any
    - Every claim has a citation
    - Sources section is well-formatted and includes all referenced URLs
    - Report meets length requirement
-Step 8. **Return report**: Return the final report to the user in your final message also use write_file to write to /report.md.
+Step 8. **Return report**: Return the final report to the user in your final message and also call the `write_file` filesystem tool with `file_path="/report.md"`.
 
 ## Progress Tracking (REQUIRED)
 You MUST invoke the write_todos tool to update your progress after completing each workflow step. Use status values: "pending", "in_progress", or "completed".
@@ -66,6 +75,7 @@ The planner will use search tools to discover internal vs external and what info
 Use `think` tool to verify constraints after each researcher call and before finalizing. If gaps exist, try once to fix, then proceed. Avoid retry loops.
 
 ## Critical Rules
+{% if skills_enabled %}- When available skills apply, read and follow the relevant `SKILL.md` before doing specialized work yourself. If the next step is a specialized `execute` call, load the applicable skill first.{% endif %}
 - You MUST ALWAYS produce a complete report. NEVER ask the user for permission, clarification, or additional input.
 - If search tools fail or return insufficient data:
   1. Use available information to provide best-effort analysis

--- a/src/aiq_agent/agents/deep_researcher/prompts/planner.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/planner.j2
@@ -4,9 +4,10 @@ Return the final plan to the orchestrator in your final message.
 
 ## Other Tools
 - `think`: record your thoughts for downstream steps
-- `ls`: to see if /shared/plan.json exists
-- `write_file`: to write plan to /shared/plan.json if it doesn't exist
-- `edit_file`: to edit the plan at /shared/plan.json if it exists
+- `ls`: filesystem tool to see if `/shared/plan.json` exists
+- `write_file`: filesystem tool to write plan to `/shared/plan.json` if it doesn't exist
+- `edit_file`: filesystem tool to edit the plan at `/shared/plan.json` if it exists
+
 
 ## Task Analysis
 Before generating the research plan, deeply analyze the user's request:
@@ -19,6 +20,7 @@ Before generating the research plan, deeply analyze the user's request:
 
 ## Workflow
 - **Task Decomposition**: Use a todo list with write_todos to break down the research into focused tasks and update this todo list based on progress.
+{% if skills_enabled %}- **Skill-aware planning**: Review the Skills System section and available skill sources ({% for source in skill_sources %}`{{ source }}`{% if not loop.last %}, {% endif %}{% endfor %}). If a skill could apply to specialized analysis, calculations, transformations, visualizations, file generation, sandbox execution, or structured outputs, read its `SKILL.md` and include that skill-use requirement in the plan. Do not plan for downstream agents to perform covered specialized work ad hoc when an available skill applies.{% endif %}
 - **Internal vs external (you must use tools)**: If a knowledge_search or document tool is available, call it first to see if the topic or named entities are covered in the uploaded documents. If they are, treat them as internal and do not add web/paper queries for those. If not found internally, treat as external and use web/paper search.
 - **Discover what exists (you must use tools)**: Call available search tools to discover what information exists for the task. Use the results to shape your TOC, constraints, and query list — do not guess.
 - **Think**: After each search, use `think` to reason through:
@@ -27,7 +29,7 @@ Before generating the research plan, deeply analyze the user's request:
    - What gaps remain?
    - What constraints should I add based on these findings?
 - **Evolve**: Refine TOC and constraints based on findings.
-- **Output**: Write to /shared/plan.json and return the plan.
+- **Output**: Write to `/shared/plan.json` with the `write_file` filesystem tool and return the plan.
 
 ## TOC Structure
 The final TOC must be hierarchical with 2 levels (sections and subsections). Guidelines:
@@ -42,6 +44,7 @@ Generate that the final report must satisfy. Constraints are acceptance criteria
 - Deep understanding of the user's request
 - Search tool findings
 - Your reasoning about what is relevant vs tangential, what adds value, and what degrades quality
+{% if skills_enabled %}- Applicable skill instructions, when a skill covers part of the requested work{% endif %}
 
 ### Constraint Principles
 1. **Maximize Specificity**: Include all user-stated details. If user mentions specific entities, dates, or attributes, create constraints for them.
@@ -122,7 +125,7 @@ Remember: Your goal is to produce an evidence-grounded plan with clear acceptanc
 **Important**:
 - You MUST match the language of the task for all outputs e.g if the task is in Chinese, the outputs should be in Chinese.
 - You MUST be confident about your planning outputs grounded with discovered information through search tools.
-- You MUST write the plan to using write_file tool to /shared/plan.json
+- You MUST write the plan using the `write_file` filesystem tool with `file_path="/shared/plan.json"`
 - You MUST return the final plan to the orchestrator in your final message.
 
 {#- === KV CACHE BOUNDARY — dynamic content below === -#}

--- a/src/aiq_agent/agents/deep_researcher/prompts/researcher.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/researcher.j2
@@ -73,6 +73,10 @@ Do NOT add URLs from memory — only use URLs that appeared in tool call respons
 
 Write this output using the `write_file` filesystem tool with `file_path="/shared/[query_topic_x].txt"` and return.
 
+## Filesystem Notes
+- `/shared/` is a virtual path managed by the agent runtime, NOT a real directory. Inspect it ONLY via `read_file`, `ls`, `glob`. Shell commands (`execute "ls /shared"`, `rm`, `stat`, `mv`, `find`) will not see `/shared/` files and will fail or show an empty directory — do not use them on `/shared/` paths.
+- `write_file` cannot overwrite an existing file. If you need to revise content, either pick a new filename (e.g. `[topic]_v2.txt`) or use `edit_file` to modify the existing file. Do not loop on `write_file` for the same path.
+
 {#- === KV CACHE BOUNDARY — dynamic content below === -#}
 
 ## Context

--- a/src/aiq_agent/agents/deep_researcher/prompts/researcher.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/researcher.j2
@@ -7,6 +7,7 @@ Aim to provide substantial depth and breadth, while prioritizing factual reliabi
 3. **After each search, pause and assess** - Do I have enough to answer? What's still missing?
 4. **Execute narrower searches as you gather information** - Fill in the gaps
 5. **Stop when you can answer confidently** - Don't keep searching for perfection
+{% if skills_enabled %}6. **Use applicable skills before specialized work** - Review the Skills System section and available skill sources ({% for source in skill_sources %}`{{ source }}`{% if not loop.last %}, {% endif %}{% endfor %}). If the assigned query requires specialized analysis, calculations, transformations, visualizations, file generation, sandbox execution, or structured outputs covered by an available skill, call `read_file` on that skill's `SKILL.md` and follow it before doing the work yourself. Use search tools for evidence gathering and relevant skills for the specialized workflow they cover.{% endif %}
 
 ## Guidelines
 - If possible, cross-reference multiple sources for accuracy
@@ -18,6 +19,14 @@ Aim to provide substantial depth and breadth, while prioritizing factual reliabi
     - Do I have enough to answer the query comprehensively?
     - Should I search more or provide my answer?
 - Synthesize insights across sources rather than summarizing each separately
+
+{% if skills_enabled %}Available Skills:
+1. **Read skills (REQUIRED)**: Use read_file to load the relevant SKILL.md BEFORE writing any code. Copy initialization boilerplate and API patterns directly from the skill.
+2. **Write script**: Use write_file to create a Python script at /workspace/[name].py. Base your code on the patterns from the skill — do not write from scratch.
+3. **Execute**: Use the execute tool to run the script: `execute("python /workspace/[name].py")`
+4. **Review output**: Check the execution output for results or errors
+5. **Iterate if needed**: Fix errors and re-run (max 2 retries)
+6. **Write findings**: Summarize results to /shared/[task_topic].txt{% endif %}
 
 ## Depth Requirements
 Your output will be used to write a long-form report. Produce **in-depth, detailed findings**:
@@ -62,8 +71,7 @@ List every source used, one per line, using ONLY URLs from search tool results:
 [2] Source Title: URL
 Do NOT add URLs from memory — only use URLs that appeared in tool call responses.
 
-Write this output using write_file to /shared/[query_topic_x].txt and return.
-Paths are VIRTUAL.
+Write this output using the `write_file` filesystem tool with `file_path="/shared/[query_topic_x].txt"` and return.
 
 {#- === KV CACHE BOUNDARY — dynamic content below === -#}
 

--- a/src/aiq_agent/agents/deep_researcher/register.py
+++ b/src/aiq_agent/agents/deep_researcher/register.py
@@ -37,6 +37,8 @@ from nat.data_models.component_ref import LLMRef
 from nat.data_models.function import FunctionBaseConfig
 
 from .agent import DeepResearcherAgent
+from .deepagents_runtime import SandboxConfig
+from .deepagents_runtime import SkillsConfig
 from .models import DeepResearchAgentState
 
 logger = logging.getLogger(__name__)
@@ -58,6 +60,11 @@ class DeepResearchAgentConfig(FunctionBaseConfig, name="deep_research_agent"):
     )
     max_loops: int = Field(default=2)
     verbose: bool = Field(default=True)
+    skills: SkillsConfig = Field(default_factory=SkillsConfig)
+    sandbox: SandboxConfig | None = Field(
+        default=None,
+        description="Optional DeepAgents sandbox backend for execute support.",
+    )
 
 
 @register_function(config_type=DeepResearchAgentConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
@@ -110,6 +117,8 @@ async def deep_research_agent(config: DeepResearchAgentConfig, builder: Builder)
         max_loops=config.max_loops,
         verbose=verbose,
         callbacks=callbacks,
+        skills=config.skills,
+        sandbox=config.sandbox,
     )
 
     async def _run(state: DeepResearchAgentState) -> DeepResearchAgentState:
@@ -118,13 +127,15 @@ async def deep_research_agent(config: DeepResearchAgentConfig, builder: Builder)
             data_sources = state.data_sources
             selected_tools = filter_tools_by_sources(tools, data_sources)
             active_agent = agent
-            if data_sources is not None and selected_tools != tools:
+            if config.sandbox is not None or (data_sources is not None and selected_tools != tools):
                 active_agent = DeepResearcherAgent(
                     llm_provider=provider,
                     tools=selected_tools,
                     max_loops=config.max_loops,
                     verbose=verbose,
                     callbacks=callbacks,
+                    skills=config.skills,
+                    sandbox=config.sandbox,
                 )
             elif data_sources is not None and not selected_tools:
                 logger.warning("Deep research received data_sources with no matching tools")

--- a/src/aiq_agent/agents/deep_researcher/register.py
+++ b/src/aiq_agent/agents/deep_researcher/register.py
@@ -128,6 +128,16 @@ async def deep_research_agent(config: DeepResearchAgentConfig, builder: Builder)
             selected_tools = filter_tools_by_sources(tools, data_sources)
             active_agent = agent
             if config.sandbox is not None or (data_sources is not None and selected_tools != tools):
+                # Scope the Modal sandbox to the async job_id when one is in
+                # NAT context (set by aiq_api/jobs/runner.py). Falls back to a
+                # per-request uuid in DeepAgentsRuntime when None.
+                job_id: str | None = None
+                try:
+                    from nat.builder.context import Context
+
+                    job_id = Context.get().workflow_run_id
+                except Exception:  # noqa: BLE001 - Context may be unavailable in sync/eval paths
+                    job_id = None
                 active_agent = DeepResearcherAgent(
                     llm_provider=provider,
                     tools=selected_tools,
@@ -136,6 +146,7 @@ async def deep_research_agent(config: DeepResearchAgentConfig, builder: Builder)
                     callbacks=callbacks,
                     skills=config.skills,
                     sandbox=config.sandbox,
+                    job_id=job_id,
                 )
             elif data_sources is not None and not selected_tools:
                 logger.warning("Deep research received data_sources with no matching tools")

--- a/src/aiq_agent/agents/deep_researcher/skills/data-table-analysis/SKILL.md
+++ b/src/aiq_agent/agents/deep_researcher/skills/data-table-analysis/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: data-table-analysis
+description: >
+  Use this skill for converting researched facts or user-provided data into structured tables by writing code, then running Python/pandas calculations in the job-scoped sandbox. This skill is for numeric normalization, tabular analysis, rankings, growth rates, summary statistics, CSV/JSON generation, and markdown tables.
+  Triggers: "compute table", "calculate growth", "normalize values", "extract figures",
+  "rank companies", "QoQ", "YoY", "CAGR", "summary statistics", "CSV", "JSON",
+  "markdown table", "standardize quarters", "standardize currencies", "compare over time"
+  Outputs: Markdown tables, CSV text, JSON records, summary statistics, rankings, and data-quality notes.
+---
+
+# Data Table Analysis Skill
+
+Generate accurate, source-grounded tables and computed quantitative summaries using Python/pandas.
+This skill produces text artifacts that can be read and included in the final report.
+
+## Required Execution Standard
+
+To ensure the calculation is reproducible and useful, you MUST:
+1. **Structure Inputs:** Convert facts from research notes or the user request into explicit rows before running pandas.
+2. **Preserve Provenance:** Keep source URLs, filing names, or note references in the input table when available.
+3. **Normalize Units:** Convert currencies, magnitudes, periods, and date labels into consistent fields before comparing values.
+4. **Compute Deterministically:** Call the `execute` tool to run Python/pandas for arithmetic, rankings, growth rates, aggregates, and formatting. Do not hand-compute these values in prose.
+5. **Write Text Outputs:** Save markdown, CSV, or JSON outputs to `/shared/...` with descriptive filenames using `write_file`.
+6. **Report Caveats:** Include assumptions, missing values, restatements, estimated figures, or non-comparable metrics in the output notes.
+
+## Execution Flow
+
+1. Gather candidate facts from researcher outputs, user-provided data, or source excerpts.
+
+2. Create a normalized input table with one row per comparable observation. Prefer explicit CSV or JSON records embedded in the Python script. If the source rows are in `/shared/...`, call `read_file` first and embed the returned content in the script, or write a sandbox-local input file under `/workspace`. Sandbox code cannot open `/shared/...` directly.
+
+3. Call the `execute` tool with a Python command or script that:
+   - imports pandas,
+   - builds a DataFrame from the normalized rows,
+   - validates data types,
+   - standardizes units and period labels,
+   - computes the requested metrics,
+   - prints markdown, CSV, JSON, and data-quality notes as text.
+   - uses `/workspace` for any sandbox-local input or output files.
+   - does not read from or write to `/shared/...` inside the sandbox process.
+
+4. Inspect the `execute` output. If the code fails, fix the code and call `execute` again. Do not continue with hand-computed fallback tables unless the sandbox or pandas is unavailable.
+
+5. Write final text artifacts from the successful `execute` output to `/shared/...` using `write_file`, for example:
+   - `/shared/capex_growth_table.md`
+   - `/shared/capex_normalized.csv`
+   - `/shared/capex_analysis.json`
+
+6. In the response or report, cite the original sources for the input figures. Computed columns should be clearly labeled as calculations.
+
+**Required Tool Use:** For tasks that request calculated tables, growth rates, rankings, summary statistics, normalization, CSV, or JSON, this skill requires at least one `execute` call that runs Python/pandas before writing the final artifacts.
+
+---
+
+## Input Normalization Guidelines
+
+| Input Issue | Required Handling |
+|-------------|-------------------|
+| Mixed magnitudes | Convert millions/billions/trillions into one numeric unit, such as USD billions. |
+| Mixed currencies | Convert to one currency only when an exchange-rate source is available; otherwise keep currencies separate and flag the limitation. |
+| Fiscal vs. calendar quarters | Preserve the reported fiscal period and add a normalized sortable period field when possible. |
+| Company-specific definitions | Keep metric names explicit, such as "capital expenditures", "PP&E additions", or "cash capex". |
+| Missing values | Use null/blank values, not zero, unless the source explicitly reports zero. |
+| Approximate figures | Mark estimates with an `is_estimate` column or a notes field. |
+| Conflicting figures | Keep both rows with source notes unless one source is clearly authoritative. |
+
+## Calculation Specifications
+
+| Calculation | Formula / Logic Guide |
+|-------------|------------------------|
+| **QoQ Growth** | `(current_value / prior_quarter_value - 1) * 100` within each entity and metric. |
+| **YoY Growth** | `(current_value / value_four_quarters_ago - 1) * 100` within each entity and metric. |
+| **CAGR** | `(ending_value / beginning_value) ** (1 / years) - 1`, only when periods are comparable. |
+| **Ranking** | Sort by the normalized numeric value and include rank ties deterministically. |
+| **Share of Total** | `value / group_total * 100`, computed within the relevant period or category. |
+| **Summary Stats** | Include count, mean, median, min, max, and missing-value count when useful. |
+
+## Output Formats
+
+The sandbox supports text outputs that should be saved through `/shared/`:
+- `.md` - Markdown tables and explanatory notes for report inclusion.
+- `.csv` - Normalized tabular data for reuse.
+- `.json` - Structured records, assumptions, and summary metrics.
+
+**Storage Note:** Always use descriptive filenames (e.g., ai_capex_8q_growth.md) rather than generic names like output.md.
+
+---
+
+## Example Code Templates
+
+### A. Normalize Rows and Compute QoQ/YoY
+
+Use this when researched figures need growth calculations.
+
+```python
+import pandas as pd
+
+rows = [
+    {
+        "company": "ExampleCo",
+        "period": "FY2025-Q1",
+        "period_index": 202501,
+        "metric": "capital_expenditures",
+        "value_usd_billions": 12.4,
+        "source": "https://example.com/filing",
+        "notes": "",
+    },
+]
+
+df = pd.DataFrame(rows)
+df = df.sort_values(["company", "metric", "period_index"])
+df["qoq_growth_pct"] = (
+    df.groupby(["company", "metric"])["value_usd_billions"].pct_change(1) * 100
+)
+df["yoy_growth_pct"] = (
+    df.groupby(["company", "metric"])["value_usd_billions"].pct_change(4) * 100
+)
+
+display_cols = [
+    "company",
+    "period",
+    "metric",
+    "value_usd_billions",
+    "qoq_growth_pct",
+    "yoy_growth_pct",
+    "source",
+    "notes",
+]
+markdown_table = df[display_cols].to_markdown(index=False, floatfmt=".1f")
+csv_text = df[display_cols].to_csv(index=False)
+```
+
+### B. Rank Entities by Latest Comparable Period
+
+Use this for company rankings or top-N comparisons.
+
+```python
+import pandas as pd
+
+df = pd.DataFrame(rows)
+latest_period = df["period_index"].max()
+latest = df[df["period_index"] == latest_period].copy()
+latest = latest.sort_values(
+    ["value_usd_billions", "company"],
+    ascending=[False, True],
+)
+latest["rank"] = range(1, len(latest) + 1)
+
+ranking_table = latest[
+    ["rank", "company", "period", "value_usd_billions", "source", "notes"]
+].to_markdown(index=False, floatfmt=".1f")
+```
+
+### C. Generate Data-Quality Notes
+
+Use this to make limitations explicit before synthesis.
+
+```python
+import pandas as pd
+
+df = pd.DataFrame(rows)
+notes = []
+
+missing = df["value_usd_billions"].isna().sum()
+if missing:
+    notes.append(f"{missing} rows have missing normalized values.")
+
+if "is_estimate" in df.columns and df["is_estimate"].fillna(False).any():
+    notes.append("Some values are estimates and should be labeled as such.")
+
+if df.duplicated(["company", "period", "metric"]).any():
+    notes.append("Some company-period-metric combinations have multiple source rows.")
+
+data_quality_notes = "\n".join(f"- {note}" for note in notes) or "- No major data-quality issues identified."
+```
+
+---
+
+## Troubleshooting in the Sandbox
+
+- Missing pandas: If `import pandas` fails, report that the sandbox image needs `pandas` installed. Do not hand-compute large tables in prose.
+- Sorting Periods: Do not sort fiscal quarters alphabetically. Create a numeric `period_index` or date column.
+- Percent Formatting: Keep computed growth as numeric values in CSV/JSON; format percentages only in markdown tables.
+- Zero Division: If a prior period is zero or missing, leave growth blank/null and explain the limitation.
+---

--- a/tests/aiq_agent/agents/deep_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_agent.py
@@ -90,11 +90,16 @@ class TestDeepResearcherAgent:
             assert agent.max_loops == 2
             assert agent.verbose is True
             assert agent.callbacks == []
+            assert agent.deepagents_runtime.skill_sources is None
+            assert agent.deepagents_runtime.sandbox is None
 
     def test_init_with_custom_settings(self, mock_llm_provider, real_tool, mock_create_deep_agent):
         """Test DeepResearcherAgent initialization with custom settings."""
         with patch("aiq_agent.agents.deep_researcher.agent.create_deep_agent", return_value=mock_create_deep_agent):
             from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+            from aiq_agent.agents.deep_researcher.deepagents_runtime import BUILTIN_SKILL_SOURCE
+            from aiq_agent.agents.deep_researcher.deepagents_runtime import SandboxConfig
+            from aiq_agent.agents.deep_researcher.deepagents_runtime import SkillsConfig
 
             callbacks = [MagicMock()]
             agent = DeepResearcherAgent(
@@ -103,11 +108,59 @@ class TestDeepResearcherAgent:
                 max_loops=5,
                 verbose=False,
                 callbacks=callbacks,
+                skills=SkillsConfig.enabled_builtin(),
+                sandbox=SandboxConfig(app_name="custom-aiq"),
             )
 
             assert agent.max_loops == 5
             assert agent.verbose is False
             assert agent.callbacks == callbacks
+            assert agent.deepagents_runtime.skill_sources == [BUILTIN_SKILL_SOURCE]
+            assert agent.deepagents_runtime.sandbox is not None
+            assert agent.deepagents_runtime.sandbox.provider == "modal"
+            assert agent.deepagents_runtime.sandbox.app_name == "custom-aiq"
+            assert agent.deepagents_runtime.sandbox.python_packages == ()
+            assert agent.deepagents_runtime.sandbox.block_network is True
+
+    def test_sandbox_config_rejects_unsupported_provider(self):
+        """Unsupported sandbox providers fail early with a clear error."""
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import SandboxConfig
+
+        with pytest.raises(ValueError, match="Unsupported sandbox provider"):
+            SandboxConfig(provider="not-modal")
+
+    def test_register_uses_runtime_config_models(self):
+        """NAT config uses the same skills and sandbox models as runtime."""
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import BUILTIN_SKILL_SOURCE
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import SandboxConfig
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import SkillsConfig
+        from aiq_agent.agents.deep_researcher.register import DeepResearchAgentConfig
+
+        config = DeepResearchAgentConfig(
+            orchestrator_llm="llm",
+            skills=SkillsConfig(enabled=True),
+            sandbox=SandboxConfig(app_name="custom-aiq", python_packages=["matplotlib", "pillow"]),
+        )
+
+        assert config.skills.enabled is True
+        assert config.skills.sources == (BUILTIN_SKILL_SOURCE,)
+        assert config.sandbox is not None
+        assert config.sandbox.provider == "modal"
+        assert config.sandbox.app_name == "custom-aiq"
+        assert config.sandbox.python_packages == ("matplotlib", "pillow")
+
+    def test_modal_sandbox_name_is_job_id(self):
+        """Modal sandbox names use the resolved job ID directly."""
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import _validate_modal_sandbox_name
+
+        assert _validate_modal_sandbox_name("job-123") == "job-123"
+
+    def test_modal_sandbox_name_rejects_invalid_job_id(self):
+        """Invalid custom job IDs fail before creating a Modal sandbox."""
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import _validate_modal_sandbox_name
+
+        with pytest.raises(ValueError, match="valid Modal sandbox name"):
+            _validate_modal_sandbox_name("bad/job/id")
 
     def test_init_without_tools(self, mock_llm_provider, mock_create_deep_agent):
         """Test DeepResearcherAgent initialization without tools."""
@@ -135,6 +188,193 @@ class TestDeepResearcherAgent:
             assert "planner" in agent._prompts
             assert "researcher" in agent._prompts
             assert "orchestrator" in agent._prompts
+
+    def test_prepare_state_preloads_builtin_skill_files(self, mock_llm_provider, real_tool):
+        """Built-in skills are added to state so StateBackend can discover them."""
+        from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import SkillsConfig
+
+        agent = DeepResearcherAgent(
+            llm_provider=mock_llm_provider,
+            tools=[real_tool],
+            skills=SkillsConfig.enabled_builtin(),
+        )
+        state = DeepResearchAgentState(
+            messages=[],
+            files={"/existing.txt": {"content": "keep", "encoding": "utf-8"}},
+        )
+        mock_skill_files = {
+            "/mock-skill/SKILL.md": {
+                "content": "name: mock-skill\n",
+                "encoding": "utf-8",
+                "created_at": "2026-01-01T00:00:00",
+                "modified_at": "2026-01-01T00:00:00",
+            }
+        }
+
+        with patch(
+            "aiq_agent.agents.deep_researcher.deepagents_runtime._builtin_skill_state_files",
+            return_value=mock_skill_files,
+        ):
+            prepared = agent.deepagents_runtime.prepare_state(state)
+
+        assert prepared.files["/existing.txt"]["content"] == "keep"
+        for path, file_data in mock_skill_files.items():
+            assert prepared.files[path] == file_data
+
+    def test_build_orchestrator_passes_skills_to_top_level_agent(
+        self,
+        mock_llm_provider,
+        real_tool,
+        mock_create_deep_agent,
+    ):
+        """Skills are exposed to the orchestrator, not added as a separate subagent."""
+        with patch(
+            "aiq_agent.agents.deep_researcher.agent.create_deep_agent",
+            return_value=mock_create_deep_agent,
+        ) as create:
+            from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+            from aiq_agent.agents.deep_researcher.deepagents_runtime import BUILTIN_SKILL_SOURCE
+            from aiq_agent.agents.deep_researcher.deepagents_runtime import SkillsConfig
+
+            agent = DeepResearcherAgent(
+                llm_provider=mock_llm_provider,
+                tools=[real_tool],
+                skills=SkillsConfig.enabled_builtin(),
+            )
+            state = DeepResearchAgentState(messages=[HumanMessage(content="Compare revenue growth")])
+
+            agent._build_orchestrator_agent(state)
+
+            kwargs = create.call_args.kwargs
+            assert kwargs["skills"] == [BUILTIN_SKILL_SOURCE]
+            assert not callable(kwargs["backend"])
+            assert "Available Skills:" in kwargs["system_prompt"]
+            assert "Use read_file to load the relevant SKILL.md BEFORE writing any code" in kwargs["system_prompt"]
+            assert 'execute("python /workspace/[name].py")' in kwargs["system_prompt"]
+            assert "Tell the planner to account for available skills" in kwargs["system_prompt"]
+            assert "Include any applicable skill-use requirements from the plan" in kwargs["system_prompt"]
+            assert "data-table-analysis" not in kwargs["system_prompt"]
+            subagents = {subagent["name"]: subagent for subagent in kwargs["subagents"]}
+            assert subagents["planner-agent"]["skills"] == [BUILTIN_SKILL_SOURCE]
+            assert subagents["researcher-agent"]["skills"] == [BUILTIN_SKILL_SOURCE]
+            assert "Skill-aware planning" in subagents["planner-agent"]["system_prompt"]
+            assert "Use applicable skills before specialized work" in subagents["researcher-agent"]["system_prompt"]
+            assert "data-table-analysis" not in subagents["planner-agent"]["system_prompt"]
+            assert "data-table-analysis" not in subagents["researcher-agent"]["system_prompt"]
+
+    def test_build_orchestrator_omits_skills_when_disabled(
+        self,
+        mock_llm_provider,
+        real_tool,
+        mock_create_deep_agent,
+    ):
+        """Default deep research runs do not add SkillsMiddleware."""
+        with patch(
+            "aiq_agent.agents.deep_researcher.agent.create_deep_agent",
+            return_value=mock_create_deep_agent,
+        ) as create:
+            from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+
+            agent = DeepResearcherAgent(llm_provider=mock_llm_provider, tools=[real_tool])
+            state = DeepResearchAgentState(messages=[HumanMessage(content="Compare CUDA vs OpenCL")])
+
+            agent._build_orchestrator_agent(state)
+
+            assert "skills" not in create.call_args.kwargs
+            assert (
+                "When available skills apply during planning, research, or synthesis"
+                not in (create.call_args.kwargs["system_prompt"])
+            )
+
+    def test_modal_backend_is_concrete_cached_and_routes_skills_locally(self, mock_llm_provider, real_tool):
+        """Modal backend creation is lazy, cached, and skill reads do not hit Modal."""
+        from deepagents.backends import StateBackend
+
+        from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import BUILTIN_SKILL_SOURCE
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import SandboxConfig
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import SkillsConfig
+
+        agent = DeepResearcherAgent(
+            llm_provider=mock_llm_provider,
+            tools=[real_tool],
+            skills=SkillsConfig.enabled_builtin(),
+            sandbox=SandboxConfig(),
+            job_id="job-123",
+        )
+        fake_modal_backend = MagicMock()
+
+        with (
+            patch(
+                "aiq_agent.agents.deep_researcher.deepagents_runtime._create_sandbox_backend",
+                return_value=fake_modal_backend,
+            ) as create_backend,
+        ):
+            backend_one = agent.deepagents_runtime.backend
+            backend_two = agent.deepagents_runtime.backend
+
+        assert backend_one is backend_two
+        assert backend_one.default is fake_modal_backend
+        create_backend.assert_called_once_with(
+            agent.deepagents_runtime.sandbox,
+            "job-123",
+        )
+        assert isinstance(backend_one.routes[BUILTIN_SKILL_SOURCE], StateBackend)
+        fake_modal_backend.ls.assert_not_called()
+        fake_modal_backend.read.assert_not_called()
+
+    def test_modal_backend_creates_sandbox_lazily(self):
+        """Modal sandbox lifetime starts on first sandbox operation, not agent construction."""
+        from deepagents.backends.protocol import ExecuteResponse
+
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import SandboxConfig
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import _create_sandbox_backend
+
+        fake_modal_backend = MagicMock()
+        fake_modal_backend.execute.return_value = ExecuteResponse(output="ok", exit_code=0)
+
+        with patch(
+            "aiq_agent.agents.deep_researcher.deepagents_runtime._create_modal_backend_now",
+            return_value=fake_modal_backend,
+        ) as create_modal:
+            backend = _create_sandbox_backend(SandboxConfig(), "job-123")
+
+            create_modal.assert_not_called()
+            result = backend.execute("echo ok", timeout=5)
+
+        assert result.output == "ok"
+        create_modal.assert_called_once()
+        fake_modal_backend.execute.assert_called_once_with("echo ok", timeout=5)
+
+    def test_modal_backend_recreates_and_retries_once_on_not_found(self):
+        """A disappeared Modal container is recreated once for the same job-scoped name."""
+        import modal
+        from deepagents.backends.protocol import ExecuteResponse
+
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import SandboxConfig
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import _create_sandbox_backend
+
+        first_modal_backend = MagicMock()
+        first_modal_backend.execute.side_effect = modal.exception.NotFoundError("gone")
+        second_modal_backend = MagicMock()
+        second_modal_backend.execute.return_value = ExecuteResponse(output="ok", exit_code=0)
+        config = SandboxConfig()
+
+        with patch(
+            "aiq_agent.agents.deep_researcher.deepagents_runtime._create_modal_backend_now",
+            side_effect=[first_modal_backend, second_modal_backend],
+        ) as create_modal:
+            backend = _create_sandbox_backend(config, "job-123")
+            result = backend.execute("echo ok", timeout=5)
+
+        assert result.output == "ok"
+        assert create_modal.call_args_list[0].args == (config, "job-123")
+        assert create_modal.call_args_list[0].kwargs == {}
+        assert create_modal.call_args_list[1].args == (config, "job-123")
+        assert create_modal.call_args_list[1].kwargs == {"force_new": True}
+        first_modal_backend.execute.assert_called_once_with("echo ok", timeout=5)
+        second_modal_backend.execute.assert_called_once_with("echo ok", timeout=5)
 
     def test_load_prompts_fallback(self, mock_llm_provider, real_tool, mock_create_deep_agent):
         """Test _load_prompts uses inline defaults when files not found."""

--- a/tests/aiq_agent/agents/deep_researcher/test_deepagents_runtime.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_deepagents_runtime.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for DeepAgentsRuntime, especially the StateBackend error-path wrapper.
+
+Background: deepagents' CompositeBackend strips the route prefix before
+delegating to a routed StateBackend. The success path is restored via
+``WriteResult.path``, but error messages embed the stripped key, which
+caused the failing trajectory in PR #211: a researcher subagent saw
+``Cannot write to /0_weather_data.txt`` instead of ``/shared/0_weather_data.txt``
+and chased the phantom path through the sandbox shell.
+
+StateBackend itself reads/writes via LangGraph's RunnableConfig channel API
+and cannot be exercised in isolation. We patch the two channel helpers
+(``_read_files`` / ``_send_files_update``) with a plain dict so the wrapper's
+path-rewriting behavior can be tested without spinning up a graph.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from deepagents.backends import CompositeBackend
+
+from aiq_agent.agents.deep_researcher.deepagents_runtime import BUILTIN_SKILL_SOURCE
+from aiq_agent.agents.deep_researcher.deepagents_runtime import SHARED_ROUTE
+from aiq_agent.agents.deep_researcher.deepagents_runtime import DeepAgentsRuntime
+from aiq_agent.agents.deep_researcher.deepagents_runtime import SkillsConfig
+from aiq_agent.agents.deep_researcher.deepagents_runtime import _PrefixedStateBackend
+
+
+def _attach_dict_state(backend: _PrefixedStateBackend, state: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Replace StateBackend's LangGraph channel I/O with a plain dict.
+
+    Returns the state dict so tests can inspect or seed it directly.
+    """
+    files: dict[str, Any] = state if state is not None else {}
+
+    def _read_files() -> dict[str, Any]:
+        return files
+
+    def _send_files_update(update: dict[str, Any]) -> None:
+        files.update(update)
+
+    backend._read_files = _read_files  # type: ignore[method-assign]
+    backend._send_files_update = _send_files_update  # type: ignore[method-assign]
+    return files
+
+
+class TestPrefixedStateBackend:
+    """The wrapper exists to keep error messages aligned with the user-visible path."""
+
+    def test_write_then_overwrite_error_uses_full_path(self) -> None:
+        backend = _PrefixedStateBackend(SHARED_ROUTE)
+        _attach_dict_state(backend)
+
+        first = backend.write("/notes.md", "hello")
+        assert first.error is None
+        assert first.path == "/notes.md"
+
+        second = backend.write("/notes.md", "again")
+        assert second.error is not None
+        # The whole point of the wrapper: error must reference /shared/notes.md,
+        # NOT the stripped /notes.md key that vanilla StateBackend reports.
+        assert "/shared/notes.md" in second.error
+        assert second.error.startswith("Cannot write to /shared/notes.md")
+
+    def test_edit_error_uses_full_path_when_file_missing(self) -> None:
+        backend = _PrefixedStateBackend(SHARED_ROUTE)
+        _attach_dict_state(backend)
+        # File does not exist; StateBackend.edit reports the (stripped) path it received.
+        result = backend.edit("/missing.md", "old", "new")
+        assert result.error is not None
+        assert "/shared/missing.md" in result.error
+
+    def test_edit_error_without_path_is_passed_through_unchanged(self) -> None:
+        # StateBackend's "string not found" error does not embed the path, so
+        # the wrapper should be a no-op for it (vs. spuriously injecting the
+        # full path into an unrelated error string).
+        backend = _PrefixedStateBackend(SHARED_ROUTE)
+        _attach_dict_state(backend)
+        backend.write("/notes.md", "hello world")
+        result = backend.edit("/notes.md", "GOODBYE", "BYE")
+        assert result.error is not None
+        assert "GOODBYE" in result.error
+        # The wrapper does not invent a path on errors that don't reference one.
+        assert "/shared/" not in result.error
+
+    def test_skill_route_prefix(self) -> None:
+        # Same wrapper used for the skills route — confirm its prefix sticks.
+        backend = _PrefixedStateBackend(BUILTIN_SKILL_SOURCE)
+        _attach_dict_state(backend)
+        backend.write("/foo/SKILL.md", "stub")
+        result = backend.write("/foo/SKILL.md", "again")
+        assert result.error is not None
+        assert "/skills/foo/SKILL.md" in result.error
+
+    def test_successful_write_path_unchanged(self) -> None:
+        # Success case: the wrapper must not corrupt result.path
+        # (CompositeBackend rewrites it back to the full path itself).
+        backend = _PrefixedStateBackend(SHARED_ROUTE)
+        _attach_dict_state(backend)
+        result = backend.write("/notes.md", "hello")
+        assert result.error is None
+        # Wrapper passes the StateBackend-relative path through unchanged.
+        # CompositeBackend is responsible for restoring the full path.
+        assert result.path == "/notes.md"
+
+
+class TestDeepAgentsRuntimeRouting:
+    """Confirm DeepAgentsRuntime wires the wrapper into both routes dicts."""
+
+    def test_no_sandbox_uses_prefixed_state_backend_for_routes(self) -> None:
+        runtime = DeepAgentsRuntime(skills=SkillsConfig.enabled_builtin())
+        backend = runtime.backend
+        assert isinstance(backend, CompositeBackend)
+        # CompositeBackend stores routes as a list of (prefix, backend) tuples.
+        routes_by_prefix = dict(backend.sorted_routes)
+        assert SHARED_ROUTE in routes_by_prefix
+        assert BUILTIN_SKILL_SOURCE in routes_by_prefix
+        assert isinstance(routes_by_prefix[SHARED_ROUTE], _PrefixedStateBackend)
+        assert isinstance(routes_by_prefix[BUILTIN_SKILL_SOURCE], _PrefixedStateBackend)
+
+
+class TestDeepAgentsRuntimeJobId:
+    """job_id should drive the sandbox name; a missing one falls back to uuid."""
+
+    def test_explicit_job_id_is_kept(self) -> None:
+        runtime = DeepAgentsRuntime(job_id="job-abc-123")
+        assert runtime.job_id == "job-abc-123"
+
+    def test_missing_job_id_generates_uuid(self) -> None:
+        runtime_a = DeepAgentsRuntime()
+        runtime_b = DeepAgentsRuntime()
+        # uuid4 strings are 36 chars, distinct between instances.
+        assert len(runtime_a.job_id) == 36
+        assert runtime_a.job_id != runtime_b.job_id

--- a/tests/aiq_agent/agents/deep_researcher/test_deepagents_runtime.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_deepagents_runtime.py
@@ -85,6 +85,24 @@ class TestPrefixedStateBackend:
         assert result.error is not None
         assert "/shared/missing.md" in result.error
 
+    def test_read_missing_file_error_uses_full_path(self) -> None:
+        # Same bug as write/edit: StateBackend.read embeds the stripped key in
+        # its "File '/X' not found" error. The wrapper must restore /shared/X.
+        backend = _PrefixedStateBackend(SHARED_ROUTE)
+        _attach_dict_state(backend)
+        result = backend.read("/missing.json")
+        assert result.error is not None
+        assert "/shared/missing.json" in result.error
+        assert result.error.startswith("File '/shared/missing.json'")
+
+    def test_read_existing_file_passes_through(self) -> None:
+        backend = _PrefixedStateBackend(SHARED_ROUTE)
+        _attach_dict_state(backend)
+        backend.write("/notes.md", "hello")
+        result = backend.read("/notes.md")
+        assert result.error is None
+        assert result.file_data is not None
+
     def test_edit_error_without_path_is_passed_through_unchanged(self) -> None:
         # StateBackend's "string not found" error does not embed the path, so
         # the wrapper should be a no-op for it (vs. spuriously injecting the

--- a/tests/aiq_agent/jobs/test_runner.py
+++ b/tests/aiq_agent/jobs/test_runner.py
@@ -1297,3 +1297,173 @@ class TestSQLAlchemyPoolFilter:
         )
 
         assert filter_obj.filter(record) is True
+
+
+class TestAsyncJobRunnerAgentFactory:
+    """Tests for async job agent construction."""
+
+    def test_create_agent_instance_passes_config_and_job_id_when_supported(self):
+        """Async workers can receive generic function config without runner-specific agent knowledge."""
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import SandboxConfig
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import SkillsConfig
+        from aiq_agent.agents.deep_researcher.register import DeepResearchAgentConfig
+        from aiq_api.jobs.runner import _create_agent_instance
+
+        class FakeDeepResearcherAgent:
+            def __init__(
+                self,
+                *,
+                llm_provider,
+                tools,
+                max_loops,
+                verbose,
+                callbacks,
+                config=None,
+                job_id=None,
+            ):
+                self.llm_provider = llm_provider
+                self.tools = tools
+                self.max_loops = max_loops
+                self.verbose = verbose
+                self.callbacks = callbacks
+                self.config = config
+                self.job_id = job_id
+
+        fn_config = DeepResearchAgentConfig(
+            orchestrator_llm="llm",
+            max_loops=7,
+            skills=SkillsConfig(enabled=True),
+            sandbox=SandboxConfig(app_name="async-aiq"),
+        )
+
+        agent = _create_agent_instance(
+            agent_cls=FakeDeepResearcherAgent,
+            llm_provider="provider",
+            llm="llm",
+            tools=["tool"],
+            fn_config=fn_config,
+            verbose=True,
+            callbacks=["callback"],
+            job_id="job-123",
+        )
+
+        assert agent.max_loops == 7
+        assert agent.job_id == "job-123"
+        assert agent.config is fn_config
+        assert agent.config.skills.enabled is True
+        assert agent.config.skills.sources == ("/skills/",)
+        assert agent.config.sandbox is not None
+        assert agent.config.sandbox.app_name == "async-aiq"
+
+    def test_async_deep_researcher_constructor_gets_rendered_skill_instructions(self):
+        """Async job construction preserves skills/sandbox config through orchestrator prompt creation."""
+        from langchain_core.messages import HumanMessage
+        from langchain_core.tools import tool
+
+        from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import SandboxConfig
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import SkillsConfig
+        from aiq_agent.agents.deep_researcher.models import DeepResearchAgentState
+        from aiq_agent.agents.deep_researcher.register import DeepResearchAgentConfig
+        from aiq_agent.common import LLMProvider
+        from aiq_agent.common import LLMRole
+        from aiq_api.jobs.runner import _create_agent_instance
+
+        @tool
+        def async_test_search(query: str) -> str:
+            """Search test tool."""
+            return f"results for {query}"
+
+        mock_llm = MagicMock()
+        provider = LLMProvider()
+        provider.set_default(mock_llm)
+        provider.configure(LLMRole.ORCHESTRATOR, mock_llm)
+        provider.configure(LLMRole.PLANNER, mock_llm)
+        provider.configure(LLMRole.RESEARCHER, mock_llm)
+        fn_config = DeepResearchAgentConfig(
+            orchestrator_llm="llm",
+            skills=SkillsConfig(enabled=True),
+            sandbox=SandboxConfig(app_name="async-aiq"),
+        )
+        mock_deep_agent = MagicMock()
+        mock_deep_agent.with_config.return_value = mock_deep_agent
+
+        with (
+            patch(
+                "aiq_agent.agents.deep_researcher.deepagents_runtime._create_sandbox_backend",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "aiq_agent.agents.deep_researcher.agent.create_deep_agent",
+                return_value=mock_deep_agent,
+            ) as create,
+        ):
+            agent = _create_agent_instance(
+                agent_cls=DeepResearcherAgent,
+                llm_provider=provider,
+                llm=mock_llm,
+                tools=[async_test_search],
+                fn_config=fn_config,
+                verbose=False,
+                callbacks=[],
+                job_id="async-job-123",
+            )
+            state = DeepResearchAgentState(
+                messages=[
+                    HumanMessage(
+                        content=(
+                            "Compare AI infrastructure capex over the last 8 quarters. Include QoQ and YoY growth."
+                        )
+                    )
+                ]
+            )
+            agent._build_orchestrator_agent(state)
+
+        kwargs = create.call_args.kwargs
+        assert kwargs["skills"] == ["/skills/"]
+        assert "Available Skills:" in kwargs["system_prompt"]
+        assert "Use read_file to load the relevant SKILL.md BEFORE writing any code" in kwargs["system_prompt"]
+        assert 'execute("python /workspace/[name].py")' in kwargs["system_prompt"]
+        assert "Tell the planner to account for available skills" in kwargs["system_prompt"]
+        assert "Include any applicable skill-use requirements from the plan" in kwargs["system_prompt"]
+        assert "data-table-analysis" not in kwargs["system_prompt"]
+        assert agent.deepagents_runtime.job_id == "async-job-123"
+
+    def test_create_agent_instance_does_not_drop_config_on_internal_type_error(self):
+        """Constructor bugs must not silently fall back to no-config construction."""
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import SandboxConfig
+        from aiq_agent.agents.deep_researcher.deepagents_runtime import SkillsConfig
+        from aiq_agent.agents.deep_researcher.register import DeepResearchAgentConfig
+        from aiq_api.jobs.runner import _create_agent_instance
+
+        class BrokenDeepResearcherAgent:
+            def __init__(
+                self,
+                *,
+                llm_provider,
+                tools,
+                max_loops,
+                verbose,
+                callbacks,
+                config=None,
+                job_id=None,
+            ):
+                raise TypeError("internal constructor failure")
+
+        fn_config = DeepResearchAgentConfig(
+            orchestrator_llm="llm",
+            skills=SkillsConfig(enabled=True),
+            sandbox=SandboxConfig(app_name="async-aiq"),
+        )
+
+        with pytest.raises(TypeError, match="internal constructor failure"):
+            _create_agent_instance(
+                agent_cls=BrokenDeepResearcherAgent,
+                llm_provider="provider",
+                llm="llm",
+                tools=["tool"],
+                fn_config=fn_config,
+                verbose=True,
+                callbacks=["callback"],
+                job_id="job-123",
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -223,6 +223,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "deepagents" },
     { name = "knowledge-layer", extra = ["all"] },
+    { name = "langchain-modal" },
     { name = "langgraph-checkpoint-postgres" },
     { name = "langgraph-checkpoint-sqlite" },
     { name = "nvidia-nat", extra = ["async-endpoints", "langchain", "phoenix", "weave"] },
@@ -287,8 +288,9 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.19.0" },
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "cryptography", specifier = ">=46.0.6,<47" },
-    { name = "deepagents", specifier = ">=0.3.0" },
+    { name = "deepagents", specifier = "==0.5.0" },
     { name = "knowledge-layer", extras = ["all"], editable = "sources/knowledge_layer" },
+    { name = "langchain-modal", specifier = "==0.0.3" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=3.0.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=2.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
@@ -469,7 +471,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.79.0"
+version = "0.97.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -481,9 +483,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/b1/91aea3f8fd180d01d133d931a167a78a3737b3fd39ccef2ae8d6619c24fd/anthropic-0.79.0.tar.gz", hash = "sha256:8707aafb3b1176ed6c13e2b1c9fb3efddce90d17aee5d8b83a86c70dcdcca871", size = 509825, upload-time = "2026-02-07T18:06:18.388Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/93/f66ea8bfe39f2e6bb9da8e27fa5457ad2520e8f7612dfc547b17fad55c4d/anthropic-0.97.0.tar.gz", hash = "sha256:021e79fd8e21e90ad94dc5ba2bbbd8b1599f424f5b1fab6c06204009cab764be", size = 669502, upload-time = "2026-04-23T20:52:34.445Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/b2/cc0b8e874a18d7da50b0fda8c99e4ac123f23bf47b471827c5f6f3e4a767/anthropic-0.79.0-py3-none-any.whl", hash = "sha256:04cbd473b6bbda4ca2e41dd670fe2f829a911530f01697d0a1e37321eb75f3cf", size = 405918, upload-time = "2026-02-07T18:06:20.246Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b6/8e851369fa661ad0fef2ae6266bf3b7d52b78ccf011720058f4adaca59e2/anthropic-0.97.0-py3-none-any.whl", hash = "sha256:8a1a472dfabcfc0c52ff6a3eecf724ac7e07107a2f6e2367be55ceb42f5d5613", size = 662126, upload-time = "2026-04-23T20:52:32.377Z" },
 ]
 
 [[package]]
@@ -793,6 +795,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/38/b4/244d58127e1cdf04cf2dc7d9566f0d24ef01d5ce21811bab088ecc62b5ea/catalogue-2.0.10.tar.gz", hash = "sha256:4f56daa940913d3f09d589c191c74e5a6d51762b3a9e37dd53b7437afd6cda15", size = 19561, upload-time = "2023-09-25T06:29:24.962Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/96/d32b941a501ab566a16358d68b6eb4e4acc373fab3c3c4d7d9e649f7b4bb/catalogue-2.0.10-py3-none-any.whl", hash = "sha256:58c2de0020aa90f4a2da7dfad161bf7b3b054c86a5f09fcedc0b2b740c109a9f", size = 17325, upload-time = "2023-09-25T06:29:23.337Z" },
+]
+
+[[package]]
+name = "cbor2"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/fe/5d7f37d51ec21cccf9ae14a42a674907b8385779e639482f83c6eff1bcee/cbor2-6.0.1.tar.gz", hash = "sha256:46a745c296ec336fe83fa7905b77b4faa243eb32bb84fab1cfdb0e4636d1985b", size = 84191, upload-time = "2026-04-28T21:23:37.629Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/7d/b2f9cd0c27bce0415a7dec71d0073e29b8e3f5bf45ea25f6874392c24add/cbor2-6.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4d8dba16aa67ca13aa85849c5cbe4a88a353d6ed28ca8c11afc2ad9bc96b7ea7", size = 401782, upload-time = "2026-04-28T21:22:42.383Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/24/0d42399c25cdf9310f7a980c52a178dcc4cc4cc2786d435601396875ed3a/cbor2-6.0.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:3dfe0bf4dbd0e522d0446c5e544b5e43fcb23115996f556b7d02092fc07bb0a1", size = 447870, upload-time = "2026-04-28T21:22:43.886Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/66/fbbdf6924848f2c31632e6801c0b109216bacbc278ebb11c21ad4b312336/cbor2-6.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:873ac665a1e8b3b9baa7d9384221917c828e8c72f670b2df887ed4a627367842", size = 458778, upload-time = "2026-04-28T21:22:45.582Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/79/183adadb623f88dd017caab8252a0750be97a0073d7ca3020101a315e636/cbor2-6.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:36519c11fda756c466b70082ff912708e9c6a6f8d0858983935f287654c1e75a", size = 514018, upload-time = "2026-04-28T21:22:47.334Z" },
+    { url = "https://files.pythonhosted.org/packages/37/47/9a3f2413100a68ec10416739bad2075e72f58e31c0ee51f59318cb86941b/cbor2-6.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d4659353f9ae454b1d2a3130f2690232c7bdb68f3d144558c4d8e0b5eb53691f", size = 525481, upload-time = "2026-04-28T21:22:48.95Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/e5/004946ebd82db48fc72cb18a0eea2f720de97dd3f5c7e87a5f2f716f1ed4/cbor2-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:ce23169d812f37636dbf92af67460a4eee5c340c4b838b883e307ac1cde9f67e", size = 288765, upload-time = "2026-04-28T21:22:50.679Z" },
+    { url = "https://files.pythonhosted.org/packages/58/48/f4a9250e17341341d6014cb45e9f5f01990fec00ebf32fd743c48dd99680/cbor2-6.0.1-cp311-cp311-win_arm64.whl", hash = "sha256:b7958d97f6d8646a336f035cfa7da74eccef4ce4295ae948e2f0f50210c2e8ee", size = 280895, upload-time = "2026-04-28T21:22:52.514Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/06/9bdbdf550f5bddb103efd0fa57023e73ec2339c8e1269a77191a5c5897d0/cbor2-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:778746168f80403dcb5e0e85a16076967652aef74bf2d13f53ce3d150e9b8be7", size = 401250, upload-time = "2026-04-28T21:22:53.838Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/0b/8c2b44c7513c58f96a2ef9fed97e504f965ed5cc922f08c1edfe9a0aa808/cbor2-6.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:82802f05ae595cfe451ab6a15948b20445a411fb83ef8568591577f6b91313aa", size = 445322, upload-time = "2026-04-28T21:22:55.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/6c/2c1d9a26bac69b9c97530e342a49c2d8a2fc0aa9e253c5645f074afa17d6/cbor2-6.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:65f0dc88cbd2cc252c31212b0bac3d10ae8e94db5e476a662022593cdd3cc56a", size = 456460, upload-time = "2026-04-28T21:22:57.021Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c1/feacc2e1278ef708787d61c5e670288353e68dc3a023246d57764e03f373/cbor2-6.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:10f0376763ce8913c1a5b9f21c51ca55848ed16795bd2b80860d56ed944374ab", size = 511095, upload-time = "2026-04-28T21:22:59.58Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2e/8c4b5d9d53ca3750ce19878e40be3a7628d7e6e4fb303456ed7c3fc03155/cbor2-6.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83d2b27908f8697041cee46af54ab684e9dd6e9710d70d31dc50e89cc908433d", size = 524005, upload-time = "2026-04-28T21:23:01.284Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/36/786ec690daad8d8574a2bf94e6532e39936bbad1d576f2225102298084d1/cbor2-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:4d324878156075778da61f9d4a09e6c4306493964f24f8fd92b43d97e99eac10", size = 288302, upload-time = "2026-04-28T21:23:03.081Z" },
+    { url = "https://files.pythonhosted.org/packages/97/64/757b3cede871c52af6e26d713546048953d66db60c8840e5a2434a412e70/cbor2-6.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:3e8eaee64cd09d67a413e1fc758750e9e9c15cdb677a725163da834b981552ec", size = 277907, upload-time = "2026-04-28T21:23:04.518Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ee/d11300317773bc8e85e23f59fc71c732ba1176d059341588318cab81f501/cbor2-6.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:067d23ac75bfa35bed0e795169139259dc9d9bae503c8ede29740f99b37415f3", size = 400366, upload-time = "2026-04-28T21:23:06.234Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/0bc836d8259333277fc532d13197238b7c097e83c8ee3df13e8c5e418ec1/cbor2-6.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5df6d0cd72c62dfb300facd6ccb982214fe3376b69f393d0d271e4436fd7b624", size = 444682, upload-time = "2026-04-28T21:23:07.494Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d0/3ffca18a38f0d8b6b1a6649d1245b876f5cf4cf9be3f5b2d19717b227af8/cbor2-6.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:50ebae27b72061c8baf3cd8458c3eb2de7c112d0be77af24e8c4206a2b0e7b61", size = 454983, upload-time = "2026-04-28T21:23:09.115Z" },
+    { url = "https://files.pythonhosted.org/packages/73/95/bc054345ef594a6ac92398a453f5e4ec7f45faaf6f18aff61d06fc9bc0c6/cbor2-6.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c1cfab10d65989cd79c203a00b5460feb6f34c519714779a77ccfb772704ff4b", size = 510410, upload-time = "2026-04-28T21:23:10.96Z" },
+    { url = "https://files.pythonhosted.org/packages/13/27/47bfc56a269d83713f69166dcadfba6890ff87cdae787c11bcd924d369f8/cbor2-6.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:df1e47d7dfb335ee82cd6593db111e6ca12d2c370a08a94d3622b4c08fda3b69", size = 522764, upload-time = "2026-04-28T21:23:12.376Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/c86f51bc78c211bcf685485a8c888713d714ebd64192435a45b68bef2b0b/cbor2-6.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:897f6fe58d1522608b6b71a7aa964f31c40deed5fff2d00511233bacb396dded", size = 287646, upload-time = "2026-04-28T21:23:13.799Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e9/4670d40a86ae74b0afcb976e346d5429d745b6780a0407143346b4dab408/cbor2-6.0.1-cp313-cp313-win_arm64.whl", hash = "sha256:80765e22c387fb489102ed751f5706fc184c9cdb34257df3dab4d393564b00e6", size = 276903, upload-time = "2026-04-28T21:23:15.398Z" },
 ]
 
 [[package]]
@@ -1279,18 +1310,19 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.4.2"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain" },
     { name = "langchain-anthropic" },
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
+    { name = "langsmith" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/2f/46668b426bc9d383e7b9dd0e4c4cf7b4e550b62c82c5217293fd71d14f65/deepagents-0.4.2.tar.gz", hash = "sha256:9b266b4f936bc3a953132183ab75d1ba191f15220c9a70930fe651fca4d9913e", size = 79300, upload-time = "2026-02-12T21:01:42.179Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/3b/7a942931e4b6189c25eb9bcce0e9bc0cd5925371991f32e19885a5def32d/deepagents-0.5.0.tar.gz", hash = "sha256:b4fc4b6aa8677b319618d5474df6927f03e7cfed5116606ea510067288624d03", size = 109679, upload-time = "2026-04-07T16:08:27.591Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/da/80c7b9b7899b30c16a91d29a19d76622ede008a5f0297a0f52f3c129bb29/deepagents-0.4.2-py3-none-any.whl", hash = "sha256:5eff263bf9ba962727caeee052545e1ad329282446bc1bcd9a629a903cf45da2", size = 89260, upload-time = "2026-02-12T21:01:41.161Z" },
+    { url = "https://files.pythonhosted.org/packages/be/87/1f709f4d6d77bc3286cf595713c3e380e59203acce1f34fd896cc7d99477/deepagents-0.5.0-py3-none-any.whl", hash = "sha256:ae6eefad4d04f078328a31479cf2568c352f957a351856dec8b9d0ca8619f8fb", size = 123057, upload-time = "2026-04-07T16:08:26.18Z" },
 ]
 
 [[package]]
@@ -1687,16 +1719,15 @@ wheels = [
 
 [[package]]
 name = "google-auth"
-version = "2.48.0"
+version = "2.49.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
-    { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/41/242044323fbd746615884b1c16639749e73665b718209946ebad7ba8a813/google_auth-2.48.0.tar.gz", hash = "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce", size = 326522, upload-time = "2026-01-26T19:22:47.157Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958, upload-time = "2026-04-10T00:41:21.888Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/1d/d6466de3a5249d35e832a52834115ca9d1d0de6abc22065f049707516d47/google_auth-2.48.0-py3-none-any.whl", hash = "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f", size = 236499, upload-time = "2026-01-26T19:22:45.099Z" },
+    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638, upload-time = "2026-04-10T00:41:14.501Z" },
 ]
 
 [package.optional-dependencies]
@@ -1706,7 +1737,7 @@ requests = [
 
 [[package]]
 name = "google-genai"
-version = "1.63.0"
+version = "1.73.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1720,9 +1751,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/d7/07ec5dadd0741f09e89f3ff5f0ce051ce2aa3a76797699d661dc88def077/google_genai-1.63.0.tar.gz", hash = "sha256:dc76cab810932df33cbec6c7ef3ce1538db5bef27aaf78df62ac38666c476294", size = 491970, upload-time = "2026-02-11T23:46:28.472Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/d8/40f5f107e5a2976bbac52d421f04d14fc221b55a8f05e66be44b2f739fe6/google_genai-1.73.1.tar.gz", hash = "sha256:b637e3a3b9e2eccc46f27136d470165803de84eca52abfed2e7352081a4d5a15", size = 530998, upload-time = "2026-04-14T21:06:19.153Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/c8/ba32159e553fab787708c612cf0c3a899dafe7aca81115d841766e3bfe69/google_genai-1.63.0-py3-none-any.whl", hash = "sha256:6206c13fc20f332703ca7375bea7c191c82f95d6781c29936c6982d86599b359", size = 724747, upload-time = "2026-02-11T23:46:26.697Z" },
+    { url = "https://files.pythonhosted.org/packages/65/af/508e0528015240d710c6763f7c89ff44fab9a94a80b4377e265d692cbfd6/google_genai-1.73.1-py3-none-any.whl", hash = "sha256:af2d2287d25e42a187de19811ef33beb2e347c7e2bdb4dc8c467d78254e43a2c", size = 783595, upload-time = "2026-04-14T21:06:17.464Z" },
 ]
 
 [[package]]
@@ -1902,12 +1933,38 @@ wheels = [
 ]
 
 [[package]]
+name = "grpclib"
+version = "0.4.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h2" },
+    { name = "multidict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/28/5a2c299ec82a876a252c5919aa895a6f1d1d35c96417c5ce4a4660dc3a80/grpclib-0.4.9.tar.gz", hash = "sha256:cc589c330fa81004c6400a52a566407574498cb5b055fa927013361e21466c46", size = 84798, upload-time = "2025-12-14T22:23:14.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/90/b0cbbd9efcc82816c58f31a34963071aa19fb792a212a5d9caf8e0fc3097/grpclib-0.4.9-py3-none-any.whl", hash = "sha256:7762ec1c8ed94dfad597475152dd35cbd11aecaaca2f243e29702435ca24cf0e", size = 77063, upload-time = "2025-12-14T22:23:13.224Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
 ]
 
 [[package]]
@@ -1930,6 +1987,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/dd/7ac658d54b9fb7999a0ccb07ad863b413cbaf5cf172f48ebcd9497ec7263/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4c1428c9ae73ec0939410ec73023c4f842927f39db09b063b9482dac5a3bb737", size = 3413812, upload-time = "2025-10-24T19:04:24.585Z" },
     { url = "https://files.pythonhosted.org/packages/92/68/89ac4e5b12a9ff6286a12174c8538a5930e2ed662091dd2572bbe0a18c8a/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a55558084c16b09b5ed32ab9ed38421e2d87cf3f1f89815764d1177081b99865", size = 3508920, upload-time = "2025-10-24T19:04:26.927Z" },
     { url = "https://files.pythonhosted.org/packages/cb/44/870d44b30e1dcfb6a65932e3e1506c103a8a5aea9103c337e7a53180322c/hf_xet-1.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:e6584a52253f72c9f52f9e549d5895ca7a471608495c4ecaa6cc73dba2b24d69", size = 2905735, upload-time = "2025-10-24T19:04:35.928Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
 ]
 
 [[package]]
@@ -2015,6 +2081,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -2341,30 +2416,30 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.2.10"
+version = "1.2.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/22/a4d4ac98fc2e393537130bbfba0d71a8113e6f884d96f935923e247397fe/langchain-1.2.10.tar.gz", hash = "sha256:bdcd7218d9c79a413cf15e106e4eb94408ac0963df9333ccd095b9ed43bf3be7", size = 570071, upload-time = "2026-02-10T14:56:49.74Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/3f/888a7099d2bd2917f8b0c3ffc7e347f1e664cf64267820b0b923c4f339fc/langchain-1.2.15.tar.gz", hash = "sha256:1717b6719daefae90b2728314a5e2a117ff916291e2862595b6c3d6fba33d652", size = 574732, upload-time = "2026-04-03T14:26:03.994Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/06/c3394327f815fade875724c0f6cff529777c96a1e17fea066deb997f8cf5/langchain-1.2.10-py3-none-any.whl", hash = "sha256:e07a377204451fffaed88276b8193e894893b1003e25c5bca6539288ccca3698", size = 111738, upload-time = "2026-02-10T14:56:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e8/a3b8cb0005553f6a876865073c81ef93bd7c5b18381bcb9ba4013af96ebc/langchain-1.2.15-py3-none-any.whl", hash = "sha256:e349db349cb3e9550c4044077cf90a1717691756cc236438404b23500e615874", size = 112714, upload-time = "2026-04-03T14:26:02.557Z" },
 ]
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.3.3"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/48/cf217b3836099220737ff1f8fd07a554993080dfc9c0b4dd4af16ccb0604/langchain_anthropic-1.3.3.tar.gz", hash = "sha256:37198413c9bde5a9e9829f13c7b9ed4870d7085e7fba9fd803ef4d98ef8ea220", size = 686916, upload-time = "2026-02-10T21:02:28.924Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/57/1f6be85f408d28864ec9b04c989011915f48ddbd43545d29e56a1e6818f2/langchain_anthropic-1.4.2.tar.gz", hash = "sha256:cc75cf4facfaf9f345e789b22986fdf23c6524921d4453a75bba32251e9fb0ec", size = 685094, upload-time = "2026-04-28T20:50:39.068Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/f1/cf56d47964b6fe080cdc54c3e32bc05e560927d549b2634b39d14aaf6e05/langchain_anthropic-1.3.3-py3-none-any.whl", hash = "sha256:8008ce5fb680268681673e09f93a9ac08eba9e304477101e5e138f06b5cd8710", size = 46831, upload-time = "2026-02-10T21:02:27.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/66/2b26b1f7949a7484bce68832a1e4f558bb24f9e2e8ebced504a19351133c/langchain_anthropic-1.4.2-py3-none-any.whl", hash = "sha256:f48e340dffcac2b760d2024ca6b3f83647782929bd01e62199a4b29d72e18c3e", size = 50423, upload-time = "2026-04-28T20:50:37.684Z" },
 ]
 
 [[package]]
@@ -2425,10 +2500,11 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.28"
+version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -2437,9 +2513,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/a4/317a1a3ac1df33a64adb3670bf88bbe3b3d5baa274db6863a979db472897/langchain_core-1.2.28.tar.gz", hash = "sha256:271a3d8bd618f795fdeba112b0753980457fc90537c46a0c11998516a74dc2cb", size = 846119, upload-time = "2026-04-08T18:19:34.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/03/7219502e8ca728d65eb44d7a3eb60239230742a70dbfc9241b9bfd61c4ab/langchain_core-1.3.2.tar.gz", hash = "sha256:fd7a50b2f28ba561fd9d7f5d2760bc9e06cf00cdf820a3ccafe88a94ffa8d5b7", size = 911813, upload-time = "2026-04-24T15:49:23.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/92/32f785f077c7e898da97064f113c73fbd9ad55d1e2169cf3a391b183dedb/langchain_core-1.2.28-py3-none-any.whl", hash = "sha256:80764232581eaf8057bcefa71dbf8adc1f6a28d257ebd8b95ba9b8b452e8c6ac", size = 508727, upload-time = "2026-04-08T18:19:32.823Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d5/8fa4431007cbb7cfed7590f4d6a5dea3ad724f4174d248f6642ef5ce7d05/langchain_core-1.3.2-py3-none-any.whl", hash = "sha256:d44a66127f9f8db735bdfd0ab9661bccb47a97113cfd3f2d89c74864422b7274", size = 542390, upload-time = "2026-04-24T15:49:21.991Z" },
 ]
 
 [[package]]
@@ -2457,7 +2533,7 @@ wheels = [
 
 [[package]]
 name = "langchain-google-genai"
-version = "4.2.0"
+version = "4.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filetype" },
@@ -2465,9 +2541,9 @@ dependencies = [
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/0b/eae2305e207574dc633983a8a82a745e0ede1bce1f3a9daff24d2341fadc/langchain_google_genai-4.2.0.tar.gz", hash = "sha256:9a8d9bfc35354983ed29079cefff53c3e7c9c2a44b6ba75cc8f13a0cf8b55c33", size = 277361, upload-time = "2026-01-13T20:41:17.63Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/78/dfe068937338727b0dee637d971d59fe2fa275f9d0f0edee3fa80e811846/langchain_google_genai-4.2.2.tar.gz", hash = "sha256:5fc774bf41d1dc1c1a5ba8d7b9f2017dfa77e30653c9b44d2dfbaf0e877e7388", size = 267457, upload-time = "2026-04-15T15:08:32.18Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/51/39942c0083139652494bb354dddf0ed397703a4882302f7b48aeca531c96/langchain_google_genai-4.2.0-py3-none-any.whl", hash = "sha256:856041aaafceff65a4ef0d5acf5731f2db95229ff041132af011aec51e8279d9", size = 66452, upload-time = "2026-01-13T20:41:16.296Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/5c/adf81d68ab89b4cf505e690f8c1956d11b5969c831c951c7b4b1b1818080/langchain_google_genai-4.2.2-py3-none-any.whl", hash = "sha256:c8d09aac0304d26f1c2483e41a350f15587af1fbe034c39a304e1e17a3b743f3", size = 67605, upload-time = "2026-04-15T15:08:31.346Z" },
 ]
 
 [[package]]
@@ -2511,6 +2587,19 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-modal"
+version = "0.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deepagents" },
+    { name = "modal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/e2/5ad67f83c30fd131b9dd224a3fadc245881c4746846a9d9102447c20c538/langchain_modal-0.0.3.tar.gz", hash = "sha256:848ecafc796300f3034fb822ff6339830e313626fdfaa9ff73208b053bbf5a59", size = 188235, upload-time = "2026-04-07T18:02:21.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/68/fc3d079108948f873de0b4aacc7e1a0f764a0f71ef664a2ed1afda2975b9/langchain_modal-0.0.3-py3-none-any.whl", hash = "sha256:9deeaa3c9bbbee49731d3a1bd0e579cc624b6f2d5540787f6bea749c89dd7c41", size = 4291, upload-time = "2026-04-07T18:02:21.166Z" },
+]
+
+[[package]]
 name = "langchain-nvidia-ai-endpoints"
 version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2536,6 +2625,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/49/ae/1dbeb49ab8f098f78ec52e21627e705e5d7c684dc8826c2c34cc2746233a/langchain_openai-1.1.9.tar.gz", hash = "sha256:fdee25dcf4b0685d8e2f59856f4d5405431ef9e04ab53afe19e2e8360fed8234", size = 1004828, upload-time = "2026-02-10T21:03:21.615Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a1/8a20d19f69d022c10d34afa42d972cc50f971b880d0eb4a828cf3dd824a8/langchain_openai-1.1.9-py3-none-any.whl", hash = "sha256:ca2482b136c45fb67c0db84a9817de675e0eb8fb2203a33914c1b7a96f273940", size = 85769, upload-time = "2026-02-10T21:03:20.333Z" },
+]
+
+[[package]]
+name = "langchain-protocol"
+version = "0.0.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]
@@ -2567,7 +2668,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.0.8"
+version = "1.1.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -2577,9 +2678,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/49/e9551965d8a44dd9afdc55cbcdc5a9bd18bee6918cc2395b225d40adb77c/langgraph-1.0.8.tar.gz", hash = "sha256:2630fc578846995114fd659f8b14df9eff5a4e78c49413f67718725e88ceb544", size = 498708, upload-time = "2026-02-06T12:31:13.776Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/b3/7dec224369c7938eb3227ff69542a0d0f517862a0d27945b8c395f2a781f/langgraph-1.1.10.tar.gz", hash = "sha256:3115beb58203283c98d8752a90c034f3432177d2979a1fe205f76e5f1b744500", size = 560685, upload-time = "2026-04-27T17:19:10.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/72/b0d7fc1007821a08dfc03ce232f39f209aa4aa46414ea3d125b24e35093a/langgraph-1.0.8-py3-none-any.whl", hash = "sha256:da737177c024caad7e5262642bece4f54edf4cba2c905a1d1338963f41cf0904", size = 158144, upload-time = "2026-02-06T12:31:12.489Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/057dc1aa7991115fca53f1fa6573a7cc0dd296c05360c672cc67fdb6245b/langgraph-1.1.10-py3-none-any.whl", hash = "sha256:8a4f163f72f4401648d0c11b48ee906947d938ba8cf1f474540fe591534f0d17", size = 173750, upload-time = "2026-04-27T17:19:09.073Z" },
 ]
 
 [[package]]
@@ -2626,15 +2727,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.7"
+version = "1.0.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/59/711aecd1a50999456850dc328f3cad72b4372d8218838d8d5326f80cb76f/langgraph_prebuilt-1.0.7.tar.gz", hash = "sha256:38e097e06de810de4d0e028ffc0e432bb56d1fb417620fb1dfdc76c5e03e4bf9", size = 163692, upload-time = "2026-01-22T16:45:22.801Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/8b/5fff4c63bbfef1475d577e13f5970f91955a4069d8dc4adbaeef92f36732/langgraph_prebuilt-1.0.12.tar.gz", hash = "sha256:edcb11ff29996def816243f267fb2c85c0a2e4fb618c275f3d238aee8dd6a5ec", size = 172831, upload-time = "2026-04-27T17:14:27.152Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/49/5e37abb3f38a17a3487634abc2a5da87c208cc1d14577eb8d7184b25c886/langgraph_prebuilt-1.0.7-py3-none-any.whl", hash = "sha256:e14923516504405bb5edc3977085bc9622c35476b50c1808544490e13871fe7c", size = 35324, upload-time = "2026-01-22T16:45:21.784Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/1e6e6fd478a1b1e643de03505570103dcb89c57c429c0fd3084d521e522e/langgraph_prebuilt-1.0.12-py3-none-any.whl", hash = "sha256:ab83822d2724d434d3536dc127b86c7d16fe3fb8dc02a89a683bc77b2e55f6e9", size = 37195, upload-time = "2026-04-27T17:14:25.788Z" },
 ]
 
 [[package]]
@@ -2652,7 +2753,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.7.1"
+version = "0.7.38"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2665,9 +2766,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/67/48/3151de6df96e0977b8d319b03905e29db0df6929a85df1d922a030b7e68d/langsmith-0.7.1.tar.gz", hash = "sha256:e3fec2f97f7c5192f192f4873d6a076b8c6469768022323dded07087d8cb70a4", size = 984367, upload-time = "2026-02-10T01:55:24.696Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/c9/b3e54cfcb480876dfe33ecfdd64feeb621a86d9e6f4a6b9eb46851807018/langsmith-0.7.38.tar.gz", hash = "sha256:0db529b768d66c45f22fe959a0af7151342704fefafdecf3c60b14097c14fdb1", size = 4431914, upload-time = "2026-04-29T00:21:42.865Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/87/6f2b008a456b4f5fd0fb1509bb7e1e9368c1a0c9641a535f224a9ddc10f3/langsmith-0.7.1-py3-none-any.whl", hash = "sha256:92cfa54253d35417184c297ad25bfd921d95f15d60a1ca75f14d4e7acd152a29", size = 322515, upload-time = "2026-02-10T01:55:22.531Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bc/a19d0a6d5575c637796675831dbef3555568e84d913f14ec579f92162ffa/langsmith-0.7.38-py3-none-any.whl", hash = "sha256:9c400ad508c0e4edc37bd55987047c6b8aac36ddd55f6096e3806f4d6a100618", size = 392310, upload-time = "2026-04-29T00:21:40.534Z" },
 ]
 
 [[package]]
@@ -3218,6 +3319,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/23/665296fce4f33488deec39a750ffd245cfc07aafb0e3ef37835f91775d14/mmh3-5.2.0-cp313-cp313-win32.whl", hash = "sha256:03e08c6ebaf666ec1e3d6ea657a2d363bb01effd1a9acfe41f9197decaef0051", size = 40806, upload-time = "2025-07-29T07:42:48.166Z" },
     { url = "https://files.pythonhosted.org/packages/59/b0/92e7103f3b20646e255b699e2d0327ce53a3f250e44367a99dc8be0b7c7a/mmh3-5.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:7fddccd4113e7b736706e17a239a696332360cbaddf25ae75b57ba1acce65081", size = 41600, upload-time = "2025-07-29T07:42:49.371Z" },
     { url = "https://files.pythonhosted.org/packages/99/22/0b2bd679a84574647de538c5b07ccaa435dbccc37815067fe15b90fe8dad/mmh3-5.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:fa0c966ee727aad5406d516375593c5f058c766b21236ab8985693934bb5085b", size = 39349, upload-time = "2025-07-29T07:42:50.268Z" },
+]
+
+[[package]]
+name = "modal"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "cbor2" },
+    { name = "certifi" },
+    { name = "click" },
+    { name = "grpclib" },
+    { name = "protobuf" },
+    { name = "rich" },
+    { name = "synchronicity" },
+    { name = "toml" },
+    { name = "typer" },
+    { name = "types-certifi" },
+    { name = "types-toml" },
+    { name = "typing-extensions" },
+    { name = "watchfiles" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/67/c84029cf5a0eaa366400d2cae3901c757a313349e7e1ccf4fc4644bf3cf8/modal-1.4.2.tar.gz", hash = "sha256:ab4e76a2c28fc0e0aebb616f11a2658051518d38cd241825af27fb34e2688b46", size = 699847, upload-time = "2026-04-16T20:28:00.589Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/65/fa87a72b7bf150dbf9949e503b8a45e278789201ac3691b8af1cd861a7d6/modal-1.4.2-py3-none-any.whl", hash = "sha256:6993874476dfd51057e36c778dbd7aae58811802515532447336eced00c81e28", size = 802775, upload-time = "2026-04-16T20:27:58.065Z" },
 ]
 
 [[package]]
@@ -5433,18 +5559,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5996,6 +6110,18 @@ wheels = [
 ]
 
 [[package]]
+name = "synchronicity"
+version = "0.12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/5e/50ea27817003665c7cc4f5bdad309f13d6329037f657848ee87fe06c3740/synchronicity-0.12.2.tar.gz", hash = "sha256:6fd605a5035d1ec74ce48fffaca80ea00345c84ca34223914e2436fb4f162ff9", size = 60018, upload-time = "2026-04-06T15:06:15.447Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/44/4f6ba4e2c171847e6f9a460213b196bbf26edea43d0e66889c7ccc55d368/synchronicity-0.12.2-py3-none-any.whl", hash = "sha256:9dbaca81fb7f2b57c6dea326e514e1c80e9ccfd9c9618515e84fa6091026273b", size = 41312, upload-time = "2026-04-06T15:06:14.459Z" },
+]
+
+[[package]]
 name = "tabulate"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6167,6 +6293,15 @@ wheels = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6253,6 +6388,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7e/e6/44e073787aa57cd71c151f44855232feb0f748428fd5242d7366e3c4ae8b/typer-0.23.0.tar.gz", hash = "sha256:d8378833e47ada5d3d093fa20c4c63427cc4e27127f6b349a6c359463087d8cc", size = 120181, upload-time = "2026-02-11T15:22:18.637Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/ed/d6fca788b51d0d4640c4bc82d0e85bad4b49809bca36bf4af01b4dcb66a7/typer-0.23.0-py3-none-any.whl", hash = "sha256:79f4bc262b6c37872091072a3cb7cb6d7d79ee98c0c658b4364bdcde3c42c913", size = 56668, upload-time = "2026-02-11T15:22:21.075Z" },
+]
+
+[[package]]
+name = "types-certifi"
+version = "2021.10.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", size = 2095, upload-time = "2022-06-09T15:19:05.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", size = 2136, upload-time = "2022-06-09T15:19:03.127Z" },
+]
+
+[[package]]
+name = "types-toml"
+version = "0.10.8.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/9b/887564a51a84c96ba08b715570e546f0ea793df6372b736bfbc596ca5536/types_toml-0.10.8.20260408.tar.gz", hash = "sha256:6b30b031235565a12febb1388900b129f1adeabfcfa594da46d0372b2ac107ad", size = 9341, upload-time = "2026-04-08T04:27:54.394Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/f1/942d95ba026779bc6e3064f8b094216588dc3276cc328cf8e03a0541918d/types_toml-0.10.8.20260408-py3-none-any.whl", hash = "sha256:e958d4c660385e548705a298f17dc162baf44c8b6d6aff79aeefe75f4f77ac87", size = 9677, upload-time = "2026-04-08T04:27:53.526Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Job-scoped deep agents sandbox support with modal as the first provider.
- Built-in skills loading from the deep researcher skills directory.
- A quantitative data-table-analysis skill that uses sandboxed Python/pandas for normalized tables, growth rates, rankings, CSV/JSON, and markdown outputs.
- Example `config_skills.yml` showing how to enable skills and Modal sandbox execution.
 - Documentation for running AI-Q with skills/sandbox and adding new skills.