### PR TITLE
docs: add authentication guide and scope MCP guide to AIQ 2.1

### DIFF
--- a/docs/source/customization/mcp-tools.md
+++ b/docs/source/customization/mcp-tools.md
@@ -5,57 +5,61 @@ SPDX-License-Identifier: Apache-2.0
 # MCP Tools and Authentication
 
 Model Context Protocol (MCP) is an open protocol that standardizes how applications expose tools and
-context to LLM applications. The AIQ Blueprint is built on the NVIDIA NeMo Agent toolkit (NAT), so AIQ
-can use MCP servers as data sources through NAT function groups.
+context to LLM applications. The AIQ Blueprint is built on the NVIDIA NeMo Agent toolkit (NAT), so
+AIQ can use MCP servers as data sources through NAT function groups.
 
-This guide assumes your AIQ deployment is pinned to NAT `1.6.0`, the latest stable NAT release line at
-the time this guide was written. It covers the common MCP integration patterns for AIQ:
+This guide is written for AIQ 2.1 deployments running NAT `1.6.0` or later. Verify your installed
+version with `uv pip show nvidia-nat`.
 
-- Connect AIQ to an existing MCP server with no user authentication.
-- Connect AIQ to a protected MCP server with service-account credentials.
-- Use native NAT OAuth MCP support for per-user MCP authorization.
-- Build a custom AIQ tool that forwards the current AIQ user token.
-- Publish an AIQ or NAT workflow as an MCP server.
+## What this guide covers
 
-For the full NAT MCP reference, see:
+**Supported in AIQ 2.1:**
+
+- Connect AIQ to an unauthenticated MCP server.
+- Connect AIQ to an MCP server with backend service-account credentials.
+- Forward the signed-in AIQ user's identity to a downstream service from a custom AIQ tool.
+- Publish AIQ workflows as an MCP server.
+
+**Planned for AIQ 2.2 / 2.3:**
+
+- Native per-user MCP OAuth driven by the AIQ UI. NAT 1.6 ships the protocol-level support
+  (`mcp_oauth2`, `per_user_mcp_client`); the AIQ UI cannot yet drive per-MCP consent. See the
+  short [planning note](#per-user-mcp-oauth-planned) below.
+- A first-party AIQ-token pass-through MCP auth provider. Today, if your MCP server trusts the AIQ
+  user's bearer token, you must implement and register a custom NAT auth provider in your
+  deployment package.
+
+For the full NAT MCP reference:
 
 - [NAT MCP client guide](https://docs.nvidia.com/nemo/agent-toolkit/latest/build-workflows/mcp-client.html)
-- [NAT MCP authentication guide](https://docs.nvidia.com/nemo/agent-toolkit/latest/components/auth/mcp-auth/index.html)
-- [NAT MCP service-account authentication guide](https://docs.nvidia.com/nemo/agent-toolkit/latest/components/auth/mcp-auth/mcp-service-account-auth.html)
+- [NAT MCP service-account auth guide](https://docs.nvidia.com/nemo/agent-toolkit/latest/components/auth/mcp-auth/mcp-service-account-auth.html)
 - [NAT MCP server guide](https://docs.nvidia.com/nemo/agent-toolkit/latest/run-workflows/mcp-server.html)
 
 ## Choose an Integration Pattern
 
-Use the simplest pattern that matches your security requirements:
-
-| Scenario | Recommended pattern | When to use |
+| Scenario | Pattern | Section |
 |---|---|---|
-| Public or internal MCP server with no per-user auth | `mcp_client` function group | The MCP server is reachable from AIQ and does not require a user token. |
-| MCP server uses backend credentials | `mcp_client` with server-side environment variables, or NAT `mcp_service_account` | All AIQ users should use the same service identity or app-level credentials. |
-| MCP server trusts the AIQ user's token | AIQ token pass-through with a custom MCP auth provider, MCP proxy, or custom AIQ tool | AIQ owns sign-in and the MCP server or gateway accepts the same bearer token. |
-| Downstream API needs the AIQ web/API user's token | Custom AIQ/NAT tool using `aiq_agent.auth.get_auth_token()` | You control the tool code and need to forward the token already accepted by AIQ auth middleware. |
-| MCP server requires its own user OAuth consent | Native NAT `per_user_mcp_client` with `mcp_oauth2` plus AIQ UI/backend integration | The upstream MCP server owns OAuth consent. Do not present this as out-of-the-box AIQ UI support unless you also wire the consent flow into the deployed frontend. |
-| Another app should call AIQ tools over MCP | `nat mcp serve` or `nat fastmcp server run` | AIQ or another NAT workflow should become the MCP server. |
+| MCP server has no per-user auth | `mcp_client` function group | [Connect AIQ to an MCP Server](#connect-aiq-to-an-mcp-server) |
+| MCP server uses backend / app credentials | `mcp_client` + `mcp_service_account` | [Service-Account MCP Servers](#service-account-mcp-servers) |
+| Downstream API trusts the AIQ user's bearer token | Custom AIQ tool using `get_auth_token()` | [Forwarding AIQ User Identity](#forwarding-aiq-user-identity-from-a-tool) |
+| MCP server requires per-user OAuth consent | Planned for AIQ 2.2 / 2.3 | [Per-User MCP OAuth (planned)](#per-user-mcp-oauth-planned) |
+| Another app should call AIQ tools over MCP | `nat mcp serve` or `nat fastmcp server run` | [Publish AIQ as an MCP Server](#publish-aiq-tools-as-an-mcp-server) |
 
 ## Prerequisites
 
-Install NAT and the MCP package from the stable release line used by your AIQ deployment:
+Install NAT and the MCP package on the same release line as your AIQ deployment:
 
 ```bash
 uv pip install "nvidia-nat[mcp]==1.6.0" nvidia-nat-mcp==1.6.0
 ```
 
-If you are using a newer stable NAT release, keep `nvidia-nat`, `nvidia-nat-core`,
-`nvidia-nat-eval`, and `nvidia-nat-mcp` on the same release line.
-
-If your checkout still pins an older NAT release, update the NAT pins before using the native NAT
-`mcp_service_account`, `mcp_oauth2`, or `per_user_mcp_client` examples below.
+Keep `nvidia-nat`, `nvidia-nat-core`, `nvidia-nat-eval`, and `nvidia-nat-mcp` on the same release
+line. If you are pinning newer NAT minor releases, bump all four together.
 
 You can inspect the installed MCP component schemas with:
 
 ```bash
 nat info components -t function_group -q mcp_client
-nat info components -t auth_provider -q mcp_oauth2
 nat info components -t auth_provider -q mcp_service_account
 ```
 
@@ -77,7 +81,7 @@ Supported transports:
 
 - `streamable-http`: recommended for new deployments and required for protected MCP servers.
 - `stdio`: useful for local MCP servers started as subprocesses.
-- `sse`: backward-compatible transport. Avoid it for production auth scenarios.
+- `sse`: backward-compatible. Avoid it for production auth scenarios.
 
 ### Register the MCP Group as a Data Source
 
@@ -103,8 +107,8 @@ functions:
 ```
 
 When an AIQ agent has no explicit `tools` list, it inherits all tools from `data_source_registry`.
-The registry auto-detects function groups and maps every discovered tool back to the source using NAT
-function-group prefixes, such as `mcp_financial_tools__get_stock_quote`.
+The registry auto-detects function groups and maps every discovered tool back to the source using
+NAT function-group prefixes, such as `mcp_financial_tools__get_stock_quote`.
 
 Use `exclude_tools` to specialize individual agents:
 
@@ -119,8 +123,8 @@ functions:
 
 ### Limit and Rename MCP Tools
 
-Use `include`, `exclude`, and `tool_overrides` when the MCP server exposes more tools than AIQ should
-use, or when the upstream descriptions are too generic for reliable tool routing.
+Use `include`, `exclude`, and `tool_overrides` when the MCP server exposes more tools than AIQ
+should use, or when the upstream descriptions are too generic for reliable tool routing.
 
 ```yaml
 function_groups:
@@ -143,8 +147,8 @@ function_groups:
 ## Service-Account MCP Servers
 
 Use service-account authentication when the MCP server should be accessed with an application or
-backend identity, not an individual AIQ user's identity. This is the preferred pattern for CI, batch
-jobs, shared enterprise data sources, and container deployments.
+backend identity, not an individual AIQ user's identity. This is the preferred pattern for CI,
+batch jobs, shared enterprise data sources, and container deployments.
 
 ```yaml
 function_groups:
@@ -197,215 +201,24 @@ functions:
           - mcp_enterprise_tools
 ```
 
-## Current AIQ UI Auth Support
+## Forwarding AIQ User Identity from a Tool
 
-The current AIQ UI supports one auth signal for data sources:
-
-```yaml
-requires_auth: true
-```
-
-When this flag is set, the UI disables the source until the user is signed in to AIQ. This is enough
-for:
-
-- AIQ token pass-through, where AIQ owns login and forwards the AIQ token.
-- Custom AIQ tools that use `aiq_agent.auth.get_auth_token()`.
-- Backend/service-account MCP tools that should only be visible to signed-in AIQ users.
-
-It is not enough for native per-MCP OAuth consent by itself. The current data source API returns
-`id`, `name`, `description`, and `requires_auth`; it does not return per-MCP auth status, a connect
-URL, scopes, token expiry, or reconnect/disconnect actions.
-
-If you want first-class native MCP OAuth in the AIQ UI, add a separate integration layer:
-
-- Backend APIs to report each MCP source's auth status.
-- Backend APIs to start and complete the MCP OAuth flow.
-- UI controls for connect, reconnect, disconnect, error states, and expired consent.
-- Async job validation to ensure the worker can resolve the user's MCP token.
-
-Without that work, prefer AIQ token pass-through or service-account MCP for AIQ deployments.
-
-## Per-User OAuth MCP Servers (Native NAT Capability)
-
-Use native NAT OAuth MCP support when the protected MCP server implements MCP OAuth and each user must
-authorize access to their own data. This is supported by NAT, but it should be treated as an advanced
-AIQ integration path until the AIQ frontend and backend expose the per-MCP consent flow.
-
-NAT provides:
-
-- `mcp_oauth2`: an auth provider for MCP OAuth2 flows.
-- `per_user_mcp_client`: a per-user MCP client function group.
-- Secure token storage options for persisting and isolating per-user MCP tokens.
-
-A typical NAT configuration looks like this:
-
-```yaml
-function_groups:
-  jira_mcp:
-    _type: per_user_mcp_client
-    server:
-      transport: streamable-http
-      url: ${CORPORATE_MCP_JIRA_URL}
-      auth_provider: jira_oauth
-
-authentication:
-  jira_oauth:
-    _type: mcp_oauth2
-    server_url: ${CORPORATE_MCP_JIRA_URL}
-    redirect_uri: ${NAT_REDIRECT_URI:-http://localhost:8000/auth/redirect}
-```
-
-For production or remote development, set `NAT_REDIRECT_URI` to the public URL that the user's
-browser can reach:
-
-```bash
-export NAT_REDIRECT_URI="https://aiq.example.com/auth/redirect"
-```
-
-Then register the MCP group as an authenticated data source so the AIQ UI disables it until a user is
-signed in:
-
-```yaml
-functions:
-  data_sources:
-    _type: data_source_registry
-    sources:
-      - id: jira
-        name: "Jira"
-        description: "Search and inspect Jira issues through MCP."
-        requires_auth: true
-        tools:
-          - jira_mcp
-```
-
-Native per-user MCP OAuth is the right pattern when the MCP server owns the OAuth flow. In AIQ, do
-not rely on `requires_auth: true` alone for this pattern. Validate the consent flow end to end with
-the frontend mode you deploy, especially if you use async jobs, because OAuth consent and token storage
-are managed by NAT's MCP auth layer rather than AIQ's request-token helper.
-
-## AIQ Token Pass-Through to MCP Servers
-
-Use AIQ token pass-through when AIQ is the only login surface and the MCP server, an API gateway, or
-an authenticating reverse proxy accepts the AIQ user's bearer token. In this pattern, users sign in to
-AIQ once. AIQ forwards that request token when a tool call reaches the MCP server. For the AIQ login
-and token retrieval setup, see [Authentication](../deployment/authentication.md).
-
-This is different from native MCP OAuth:
-
-- AIQ owns the user session and token validation at the AIQ boundary.
-- The MCP server trusts the AIQ token, or a gateway exchanges or validates it before forwarding.
-- Users do not complete a separate OAuth consent flow for each MCP server.
-- `requires_auth: true` only gates the UI source toggle. It does not, by itself, make `mcp_client`
-  forward an `Authorization` header to the MCP server.
-
-There are three common ways to implement pass-through.
-
-### Option 1: Custom MCP Auth Provider
-
-If your deployment uses NAT's MCP client directly and you want the MCP server to remain a real MCP
-server, add a small custom NAT authentication provider that reads the current AIQ token and injects it
-into MCP client requests. The provider should call `aiq_agent.auth.get_auth_token()` at request time,
-not at startup, so concurrent users and async jobs do not share credentials.
-
-Configure the MCP client to use that provider:
-
-```yaml
-function_groups:
-  internal_mcp:
-    _type: mcp_client
-    server:
-      transport: streamable-http
-      url: ${INTERNAL_MCP_URL}
-      auth_provider: aiq_user_token
-
-authentication:
-  aiq_user_token:
-    _type: aiq_user_token_passthrough
-```
-
-Register the group as an authenticated data source:
-
-```yaml
-functions:
-  data_sources:
-    _type: data_source_registry
-    sources:
-      - id: internal_mcp
-        name: "Internal MCP"
-        description: "Call internal MCP tools using your AIQ sign-in."
-        requires_auth: true
-        tools:
-          - internal_mcp
-```
-
-This keeps the MCP boundary intact but requires a small code plugin because the token source is
-AIQ-specific.
-
-### Option 2: Auth-Forwarding MCP Proxy
-
-Run a small internal proxy between AIQ and the MCP server. AIQ calls the proxy as its MCP server, and
-the proxy forwards the AIQ bearer token to the upstream MCP server or exchanges it for an upstream
-token. This is useful when:
-
-- The upstream MCP server expects custom headers or token exchange.
-- You want centralized policy, auditing, or allowlisting outside the AIQ process.
-- Multiple AIQ deployments should share the same MCP access policy.
-
-The AIQ YAML still uses `mcp_client`, but it must include whatever auth provider forwards the AIQ
-token to the proxy:
-
-```yaml
-function_groups:
-  internal_mcp:
-    _type: mcp_client
-    server:
-      transport: streamable-http
-      url: ${AIQ_MCP_PROXY_URL}
-      auth_provider: aiq_user_token
-```
-
-The proxy receives the user's token from AIQ, then applies your organization's upstream policy. If the
-proxy is implemented as an AIQ custom tool rather than an MCP server, use Option 3.
-
-### Option 3: Custom AIQ Tool
-
-If you do not need a real MCP client boundary inside AIQ, write a custom AIQ/NAT tool that retrieves
-the AIQ token with `get_auth_token()` and calls the downstream service directly. This is usually the
-simplest pass-through implementation when you control the downstream API. See
-[Custom AIQ Auth-Based Tools](#custom-aiq-auth-based-tools) and
-[Authentication](../deployment/authentication.md#step-5-use-the-current-user-token-in-tools).
-
-## Does AIQ Need Separate UI Login for Each MCP Server?
-
-It depends on which auth pattern you choose:
-
-| Pattern | Separate MCP-server login in the AIQ UI? | Notes |
-|---|---|---|
-| Unauthenticated MCP | No | No user credential is needed. |
-| Service-account MCP | No | AIQ uses backend credentials from config or secret storage. |
-| AIQ token pass-through | No | Users sign in to AIQ once; the MCP server trusts or exchanges the AIQ token. |
-| Native MCP OAuth with `mcp_oauth2` / `per_user_mcp_client` | Yes, for first-time consent per protected MCP server or OAuth resource | NAT manages MCP OAuth consent and token storage. The AIQ UI should expose or preserve that flow in the deployed frontend mode. |
-
-For pass-through, the current AIQ UI behavior is usually enough: mark the source with
-`requires_auth: true` so it is disabled until the user signs in to AIQ. For native MCP OAuth, plan for
-additional UI/flow validation because the user may need to approve each MCP server's scopes and the UI
-must not hide or break NAT's OAuth consent flow.
-
-## Custom AIQ Auth-Based Tools
-
-Use a custom AIQ/NAT tool when you want the tool to call a downstream service with the same bearer
-token that authenticated the current AIQ request. This is not native MCP OAuth. It is a practical
-AIQ-specific pattern for services that trust the AIQ user's JWT or for gateways that perform
-on-behalf-of authorization.
+When a downstream API or MCP gateway already trusts the AIQ user's bearer token, the supported
+AIQ 2.1 pattern is a small custom AIQ tool that reads the request token with
+`aiq_agent.auth.get_auth_token()` and forwards it on the outbound call. This works whether the
+downstream service is a real MCP server, an HTTP API, or a gateway in front of one.
 
 AIQ exposes:
 
-- `aiq_agent.auth.get_auth_token()`: returns the current request token when available.
-- `aiq_agent.auth.get_current_principal()`: returns verified identity metadata from AIQ auth middleware.
-- Async job token propagation: AIQ captures the request token and makes it available in Dask workers
-  through the same `get_auth_token()` helper.
+- `aiq_agent.auth.get_auth_token()` — returns the current request token when available.
+- `aiq_agent.auth.get_current_principal()` — returns verified identity metadata from AIQ auth
+  middleware (use this for authorization decisions; do not trust unverified JWT payloads).
+- Async job token propagation — AIQ captures the request token at submit time and makes it
+  available in Dask workers through the same `get_auth_token()` helper. The token is **not**
+  refreshed inside the worker, so jobs that outlive the access token's TTL will fail mid-execution
+  on auth-required tool calls; in-worker refresh is on the AIQ 2.2 roadmap.
 
-Example custom tool:
+Example custom tool that forwards the AIQ user's token to an internal search service:
 
 ```python
 from pydantic import Field
@@ -441,7 +254,7 @@ async def internal_search(config: InternalSearchConfig, builder):
     )
 ```
 
-Register the tool as an auth-required data source:
+Register the tool as an auth-required data source so the UI disables it until the user signs in:
 
 ```yaml
 functions:
@@ -460,16 +273,36 @@ functions:
     endpoint: ${INTERNAL_SEARCH_URL}
 ```
 
-This pattern is best when:
+This is the AIQ-user-identity MCP pattern fully supported in 2.1. The two alternatives —
+protocol-level pass-through via a custom NAT auth provider, and an auth-forwarding MCP proxy — are
+viable in NAT but are not first-class in AIQ 2.1; treat them as deployment-side extensions.
 
-- AIQ already validates the user's JWT.
-- The downstream service accepts that JWT or an exchange derived from it.
-- You need AIQ UI toggles and async deep research jobs to preserve user context.
+For the broader auth context (UI sign-in flow, validator registration, headless API callers), see
+[Authentication](../deployment/authentication.md).
 
-Do not use unverified JWT payloads for authorization decisions. Use `get_current_principal()` for
-trusted identity and `get_auth_token()` only for forwarding a token to a trusted downstream service.
+## Per-User MCP OAuth (planned)
 
-## Publish AIQ or NAT Tools as an MCP Server
+NAT 1.6 ships the protocol-level building blocks for per-user MCP OAuth — `mcp_oauth2` (auth
+provider for MCP OAuth flows) and `per_user_mcp_client` (function group with per-user token
+storage). What AIQ 2.1 **does not yet** ship is the UI integration that drives this flow: the
+data-source API does not return per-MCP auth status, connect / disconnect URLs, scopes, or token
+expiry, and the UI has no per-source "Connect" / "Reconnect" controls.
+
+Until that lands, the recommended patterns for AIQ deployments remain:
+
+- **Service-account MCP** when the access can be shared at the application level.
+- **AIQ user-identity tools** (the section above) when the downstream service trusts the AIQ
+  bearer token.
+
+Beyond the UI, two further gaps exist in 2.1: AIQ's `/v1/data_sources` does not surface per-MCP
+auth status (connect URL, scopes, token expiry, error state), and async deep research jobs cannot
+yet resolve per-user MCP tokens inside Dask workers. The full per-user MCP OAuth integration —
+backend status APIs, UI controls, and worker-side token resolution — is tracked on the AIQ 2.2 /
+2.3 roadmap. Refer to the
+[NAT MCP authentication guide](https://docs.nvidia.com/nemo/agent-toolkit/latest/components/auth/mcp-auth/index.html)
+if you want to follow NAT's MCP OAuth surface directly.
+
+## Publish AIQ Tools as an MCP Server
 
 You can publish the functions in a NAT workflow as MCP tools:
 
@@ -477,22 +310,14 @@ You can publish the functions in a NAT workflow as MCP tools:
 nat mcp serve --config_file configs/config_web_frag.yml --port 9901
 ```
 
-The MCP server is available at:
+The MCP server is available at `http://localhost:9901/mcp`.
 
-```text
-http://localhost:9901/mcp
-```
-
-List tools exposed by the server:
+List tools and call them while debugging:
 
 ```bash
 nat mcp client tool list --url http://localhost:9901/mcp
 nat mcp client tool list --url http://localhost:9901/mcp --tool <tool_name> --detail
-```
 
-Call a tool directly while debugging:
-
-```bash
 nat mcp client tool call <tool_name> \
   --url http://localhost:9901/mcp \
   --json-args '{"query": "example"}'
@@ -505,37 +330,30 @@ uv pip install nvidia-nat-fastmcp
 nat fastmcp server run --config_file configs/config_web_frag.yml --port 9902
 ```
 
-FastMCP publishes tools at `http://localhost:9902/mcp` by default. NAT's FastMCP docs note that this
-runtime depends on a beta FastMCP release, so validate it against your deployment requirements before
+FastMCP publishes tools at `http://localhost:9902/mcp` by default. NAT's FastMCP docs note this
+runtime depends on a beta FastMCP release; validate against your deployment requirements before
 using it in production.
 
 ## Security Guidance
 
-- Prefer `streamable-http` for MCP servers, especially protected servers.
-- Do not expose `nat mcp serve` directly to the public internet without an authenticating reverse
-  proxy, private network boundary, or equivalent protection.
-- Do not use `sse` for production authentication scenarios.
-- Store secrets in environment variables or a secret manager, not in YAML checked into source control.
+- Prefer `streamable-http` for MCP servers, especially protected servers. Avoid `sse` for
+  production authentication scenarios.
+- Do not expose `nat mcp serve` to the public internet without an authenticating reverse proxy or
+  private network boundary.
+- Store secrets in environment variables or a secret manager, not in YAML checked into source
+  control.
 - Use service-account MCP auth only when shared app-level access is acceptable.
-- Use per-user OAuth MCP auth or a custom AIQ token-forwarding tool when access must reflect the
-  signed-in user.
 - Keep token forwarding scoped to trusted internal services and HTTPS endpoints.
-- Mark user-authenticated data sources with `requires_auth: true` so the UI can prevent unauthenticated
-  use.
+- Mark user-authenticated data sources with `requires_auth: true` so the UI can prevent
+  unauthenticated use.
 
 ## Troubleshooting
 
 ### MCP Tools Do Not Appear in the UI
 
-Confirm the function group is listed in `data_source_registry`:
-
-```yaml
-tools:
-  - mcp_financial_tools
-```
-
-The AIQ UI gets its connection list from `GET /v1/data_sources`. If a source is missing from the
-registry, the UI has no toggle for it.
+Confirm the function group is listed in `data_source_registry`. The AIQ UI gets its connection
+list from `GET /v1/data_sources`; if a source is missing from the registry, the UI has no toggle
+for it.
 
 ### The Agent Does Not Use the MCP Tool
 
@@ -545,38 +363,32 @@ Check the remote tool descriptions:
 nat mcp client tool list --url http://localhost:9901/mcp --tool <tool_name> --detail
 ```
 
-If descriptions are vague, add `tool_overrides` with task-specific descriptions. You may also need to
-update prompts so agents know when to prefer the new source.
+If descriptions are vague, add `tool_overrides` with task-specific descriptions. You may also need
+to update prompts so agents know when to prefer the new source.
 
 ### Data Source Filtering Does Not Match MCP Tools
 
 AIQ maps function groups by prefix. A group named `mcp_financial_tools` maps tools such as
-`mcp_financial_tools__stock_price` back to the source containing `mcp_financial_tools`. If you use
-individual tool references instead of the group name, list the exact exposed tool names.
+`mcp_financial_tools__stock_price` back to the source containing `mcp_financial_tools`. If you
+list individual tool references instead of the group name, list the exact exposed tool names.
 
 ### Authenticated Source Is Disabled in the UI
 
-If a source has `requires_auth: true`, the UI disables it until the user has an auth token. Verify the
-frontend auth provider is configured and that requests include an `idToken` cookie or
+If a source has `requires_auth: true`, the UI disables it until the user has an auth token. Verify
+the frontend auth provider is configured and that requests include an `idToken` cookie or
 `Authorization: Bearer <token>` header.
 
-### Async Deep Research Loses User Auth
+### Async Deep Research Loses User Auth Mid-Job
 
-Use `get_auth_token()` inside custom AIQ tools rather than reading request headers directly. AIQ
-captures the request token during job submission and restores it in the async worker context.
-
-### OAuth Redirect Fails on a Remote Server
-
-Set `NAT_REDIRECT_URI` to the public URL users open in their browsers, not to `localhost`:
-
-```bash
-export NAT_REDIRECT_URI="https://aiq.example.com/auth/redirect"
-```
-
-Ensure the reverse proxy forwards `/auth/redirect` to the NAT server handling the OAuth callback.
+Use `get_auth_token()` inside custom AIQ tools rather than reading request headers directly — AIQ
+captures the request token at job submit and restores it in the async worker context (see
+[Authentication → Use the current user token in tools](../deployment/authentication.md#step-5-use-the-current-user-token-in-tools)).
+Note that the access token is **not** refreshed inside the worker, so jobs that outlive the
+token's TTL will fail mid-execution; in-worker refresh is on the AIQ 2.2 roadmap.
 
 ## Related Documentation
 
+- [Authentication](../deployment/authentication.md)
 - [Tools and Sources](./tools-and-sources.md)
 - [Adding a Tool](../extending/adding-a-tool.md)
 - [Adding a Data Source](../extending/adding-a-data-source.md)

--- a/docs/source/customization/mcp-tools.md
+++ b/docs/source/customization/mcp-tools.md
@@ -242,6 +242,11 @@ async def internal_search(config: InternalSearchConfig, builder):
 
         # Use an async HTTP client in production code.
         # Forward only to trusted services over HTTPS.
+        # `call_internal_search` is a placeholder for your own async HTTP call, e.g.:
+        #   async with httpx.AsyncClient() as client:
+        #       resp = await client.get(config.endpoint, params={"q": query},
+        #                               headers={"Authorization": f"Bearer {token}"})
+        #       return resp.text
         return await call_internal_search(
             endpoint=config.endpoint,
             query=query,

--- a/docs/source/customization/mcp-tools.md
+++ b/docs/source/customization/mcp-tools.md
@@ -2,174 +2,90 @@
 SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-# MCP Tools
+# MCP Tools and Authentication
 
-Model Context Protocol (MCP) is an open protocol that standardizes how applications provide context to LLMs. You can use MCP to connect the AIQ Blueprint to external tools and data sources served by remote MCP servers, without writing any custom Python code. Since the AIQ Blueprint is built on the NVIDIA NeMo Agent toolkit, MCP integration is available through configuration using `mcp_client`.
+Model Context Protocol (MCP) is an open protocol that standardizes how applications expose tools and
+context to LLM applications. The AIQ Blueprint is built on the NVIDIA NeMo Agent toolkit (NAT), so AIQ
+can use MCP servers as data sources through NAT function groups.
 
-For the full MCP documentation, refer to the [NeMo Agent Toolkit MCP Client Guide](https://docs.nvidia.com/nemo/agent-toolkit/latest/workflows/mcp/mcp-client.html).
+This guide assumes your AIQ deployment is pinned to NAT `1.6.0`, the latest stable NAT release line at
+the time this guide was written. It covers the common MCP integration patterns for AIQ:
+
+- Connect AIQ to an existing MCP server with no user authentication.
+- Connect AIQ to a protected MCP server with service-account credentials.
+- Use native NAT OAuth MCP support for per-user MCP authorization.
+- Build a custom AIQ tool that forwards the current AIQ user token.
+- Publish an AIQ or NAT workflow as an MCP server.
+
+For the full NAT MCP reference, see:
+
+- [NAT MCP client guide](https://docs.nvidia.com/nemo/agent-toolkit/latest/build-workflows/mcp-client.html)
+- [NAT MCP authentication guide](https://docs.nvidia.com/nemo/agent-toolkit/latest/components/auth/mcp-auth/index.html)
+- [NAT MCP service-account authentication guide](https://docs.nvidia.com/nemo/agent-toolkit/latest/components/auth/mcp-auth/mcp-service-account-auth.html)
+- [NAT MCP server guide](https://docs.nvidia.com/nemo/agent-toolkit/latest/run-workflows/mcp-server.html)
+
+## Choose an Integration Pattern
+
+Use the simplest pattern that matches your security requirements:
+
+| Scenario | Recommended pattern | When to use |
+|---|---|---|
+| Public or internal MCP server with no per-user auth | `mcp_client` function group | The MCP server is reachable from AIQ and does not require a user token. |
+| MCP server uses backend credentials | `mcp_client` with server-side environment variables, or NAT `mcp_service_account` | All AIQ users should use the same service identity or app-level credentials. |
+| MCP server trusts the AIQ user's token | AIQ token pass-through with a custom MCP auth provider, MCP proxy, or custom AIQ tool | AIQ owns sign-in and the MCP server or gateway accepts the same bearer token. |
+| Downstream API needs the AIQ web/API user's token | Custom AIQ/NAT tool using `aiq_agent.auth.get_auth_token()` | You control the tool code and need to forward the token already accepted by AIQ auth middleware. |
+| MCP server requires its own user OAuth consent | Native NAT `per_user_mcp_client` with `mcp_oauth2` plus AIQ UI/backend integration | The upstream MCP server owns OAuth consent. Do not present this as out-of-the-box AIQ UI support unless you also wire the consent flow into the deployed frontend. |
+| Another app should call AIQ tools over MCP | `nat mcp serve` or `nat fastmcp server run` | AIQ or another NAT workflow should become the MCP server. |
 
 ## Prerequisites
 
-Install MCP support if it is not already available:
+Install NAT and the MCP package from the stable release line used by your AIQ deployment:
 
 ```bash
-uv pip install nvidia-nat-mcp==1.5.0
+uv pip install "nvidia-nat[mcp]==1.6.0" nvidia-nat-mcp==1.6.0
 ```
 
-## Starting an Example MCP Server
+If you are using a newer stable NAT release, keep `nvidia-nat`, `nvidia-nat-core`,
+`nvidia-nat-eval`, and `nvidia-nat-mcp` on the same release line.
 
-Before connecting as a client, you need an MCP server to connect to. You can publish any NeMo Agent toolkit workflow as an MCP server using `nat mcp serve`.
+If your checkout still pins an older NAT release, update the NAT pins before using the native NAT
+`mcp_service_account`, `mcp_oauth2`, or `per_user_mcp_client` examples below.
 
-For example, given a workflow config at `my_workflow.yml`:
+You can inspect the installed MCP component schemas with:
 
 ```bash
-nat mcp serve --config_file my_workflow.yml --port 9901
+nat info components -t function_group -q mcp_client
+nat info components -t auth_provider -q mcp_oauth2
+nat info components -t auth_provider -q mcp_service_account
 ```
 
-This starts an MCP server on `http://localhost:9901/mcp` using `streamable-http` transport. All functions defined in the workflow become available as MCP tools.
+## Connect AIQ to an MCP Server
 
-You can list the tools served by any MCP server:
-
-```bash
-nat mcp client tool list --url http://localhost:9901/mcp
-```
-
-To get details about a specific tool:
-
-```bash
-nat mcp client tool list --url http://localhost:9901/mcp --tool <tool_name> --detail
-```
-
-For more details on deploying MCP servers, refer to the [NeMo Agent Toolkit MCP Server Guide](https://docs.nvidia.com/nemo/agent-toolkit/latest/workflows/mcp/mcp-server.html).
-
-## Adding MCP Tools to the Deep Researcher
-
-Use `mcp_client` to connect to an MCP server and make its tools available to the deep researcher. The `mcp_client` automatically discovers all tools served by the MCP server and registers them as functions.
-
-### Step 1: Define the MCP client in the `function_groups` section
-
-Add a `function_groups` section to your config (at the same level as `functions`):
+Use `mcp_client` to connect to an MCP server and make its tools available to AIQ agents. The
+`mcp_client` function group discovers remote tools and registers them as NAT functions.
 
 ```yaml
-function_groups:
-  mcp_financial_tools:
-    _type: mcp_client
-    server:
-      transport: streamable-http
-      url: "http://localhost:9901/mcp"
-```
-
-This connects to the MCP server at the given URL and registers all of its tools under the group name `mcp_financial_tools`.
-
-**Transport options:**
-
-- `streamable-http` (recommended): modern HTTP-based transport for new deployments
-- `sse`: Server-Sent Events, supported for backwards compatibility
-- `stdio`: standard input/output for local process communication
-
-### Step 2: Register the function group as a data source
-
-Add the MCP function group to the `data_source_registry` so all agents inherit it automatically and the UI shows a toggle:
-
-```yaml
-# (inside the existing functions: section)
-  data_sources:
-    _type: data_source_registry
-    sources:
-      - id: web_search
-        name: "Web Search"
-        description: "Search the web for real-time information."
-        tools:
-          - web_search_tool
-          - advanced_web_search_tool
-      - id: knowledge_layer
-        name: "Knowledge Base"
-        description: "Search uploaded documents and files."
-        tools:
-          - knowledge_search
-      - id: financial_data
-        name: "Financial Data"
-        description: "Query financial reports and market data."
-        tools:
-          - mcp_financial_tools
-```
-
-All agents inherit tools from the registry by default -- no per-agent `tools` lists needed. The registry auto-detects that `mcp_financial_tools` is a function group and uses prefix matching for its individual tools (e.g., `mcp_financial_tools__get_stock_quote`).
-
-### Complete Example Config
-
-Below is a complete config that adds MCP tools to the deep researcher alongside the existing web search and knowledge search tools. This extends `config_web_frag.yml`. Note that agents inherit all registry tools automatically -- no per-agent `tools` lists needed:
-
-```yaml
-general:
-  use_uvloop: true
-  telemetry:
-    logging:
-      console:
-        _type: console
-        level: INFO
-
-  front_end:
-    _type: aiq_api
-    runner_class: aiq_api.plugin.AIQAPIWorker
-    db_url: ${NAT_JOB_STORE_DB_URL:-sqlite+aiosqlite:///./jobs.db}
-    expiry_seconds: 86400
-    cors:
-      allow_origin_regex: 'http://localhost(:\d+)?|http://127.0.0.1(:\d+)?'
-      allow_methods:
-        - GET
-        - POST
-        - DELETE
-        - OPTIONS
-      allow_headers:
-        - "*"
-      allow_credentials: true
-      expose_headers:
-        - "*"
-
-llms:
-  nemotron_llm_intent:
-    _type: nim
-    model_name: nvidia/nemotron-3-nano-30b-a3b
-    base_url: "https://integrate.api.nvidia.com/v1"
-    temperature: 0.5
-    top_p: 0.9
-    max_tokens: 4096
-    num_retries: 5
-    chat_template_kwargs:
-      enable_thinking: true
-
-  nemotron_nano_llm:
-    _type: nim
-    model_name: nvidia/nemotron-3-nano-30b-a3b
-    base_url: "https://integrate.api.nvidia.com/v1"
-    temperature: 0.1
-    top_p: 0.3
-    max_tokens: 16384
-    num_retries: 5
-    chat_template_kwargs:
-      enable_thinking: true
-
-  gpt_oss_llm:
-    _type: nim
-    model_name: openai/gpt-oss-120b
-    base_url: https://integrate.api.nvidia.com/v1
-    temperature: 1.0
-    top_p: 1.0
-    max_tokens: 256000
-    api_key: ${NVIDIA_API_KEY}
-    max_retries: 10
-
-# MCP Tools: connect to an external MCP server
 function_groups:
   mcp_financial_tools:
     _type: mcp_client
     server:
       transport: streamable-http
       url: ${MCP_SERVER_URL:-http://localhost:9901/mcp}
+```
 
+Supported transports:
+
+- `streamable-http`: recommended for new deployments and required for protected MCP servers.
+- `stdio`: useful for local MCP servers started as subprocesses.
+- `sse`: backward-compatible transport. Avoid it for production auth scenarios.
+
+### Register the MCP Group as a Data Source
+
+Add the function group to `data_source_registry`. The registry is AIQ's source of truth for UI
+toggles, per-message data source filtering, and default tool inheritance.
+
+```yaml
 functions:
-  # Registry: single source of truth for tools + UI toggles
   data_sources:
     _type: data_source_registry
     sources:
@@ -179,108 +95,489 @@ functions:
         tools:
           - web_search_tool
           - advanced_web_search_tool
-      - id: knowledge_layer
-        name: "Knowledge Base"
-        description: "Search uploaded documents and files."
-        tools:
-          - knowledge_search
       - id: financial_data
         name: "Financial Data"
-        description: "Query financial reports and market data."
+        description: "Query financial reports and market data through MCP."
         tools:
           - mcp_financial_tools
+```
 
-  web_search_tool:
-    _type: tavily_web_search
-    max_results: 5
-    max_content_length: 1000
+When an AIQ agent has no explicit `tools` list, it inherits all tools from `data_source_registry`.
+The registry auto-detects function groups and maps every discovered tool back to the source using NAT
+function-group prefixes, such as `mcp_financial_tools__get_stock_quote`.
 
-  advanced_web_search_tool:
-    _type: tavily_web_search
-    max_results: 2
-    advanced_search: true
+Use `exclude_tools` to specialize individual agents:
 
-  knowledge_search:
-    _type: knowledge_retrieval
-    backend: foundational_rag
-    collection_name: ${COLLECTION_NAME:-test_collection}
-    top_k: 5
-    rag_url: ${RAG_SERVER_URL:-http://localhost:8081}
-    ingest_url: ${RAG_INGEST_URL:-http://localhost:8082}
-    timeout: 300
-
-  # Agents inherit all registry tools automatically
-  intent_classifier:
-    _type: intent_classifier
-    llm: nemotron_llm_intent
-
-  clarifier_agent:
-    _type: clarifier_agent
-    llm: nemotron_nano_llm
-    planner_llm: nemotron_nano_llm
-    max_turns: 3
-    enable_plan_approval: true
-    log_response_max_chars: 2000
-    verbose: true
-
+```yaml
+functions:
   shallow_research_agent:
     _type: shallow_research_agent
     llm: nemotron_nano_llm
     exclude_tools:
-      - advanced_web_search_tool
-    max_llm_turns: 10
-    max_tool_iterations: 5
-
-  deep_research_agent:
-    _type: deep_research_agent
-    orchestrator_llm: gpt_oss_llm
-    researcher_llm: nemotron_nano_llm
-    planner_llm: gpt_oss_llm
-    max_loops: 2
-    exclude_tools:
-      - web_search_tool
-
-workflow:
-  _type: chat_deepresearcher_agent
-  enable_escalation: true
-  enable_clarifier: true
-  use_async_deep_research: true
-  checkpoint_db: ${AIQ_CHECKPOINT_DB:-./checkpoints.db}
+      - mcp_financial_tools__expensive_long_running_tool
 ```
 
-## Overriding Tool Names and Descriptions
+### Limit and Rename MCP Tools
 
-By default, `mcp_client` exposes all tools from the MCP server. You can rename or override descriptions for specific tools using `tool_overrides`:
+Use `include`, `exclude`, and `tool_overrides` when the MCP server exposes more tools than AIQ should
+use, or when the upstream descriptions are too generic for reliable tool routing.
 
 ```yaml
 function_groups:
   mcp_financial_tools:
     _type: mcp_client
+    include:
+      - get_stock_quote
+      - get_earnings_report
     server:
       transport: streamable-http
-      url: "http://localhost:9901/mcp"
+      url: ${MCP_SERVER_URL:-http://localhost:9901/mcp}
     tool_overrides:
       get_stock_quote:
-        alias: "stock_price"
-        description: "Returns the current stock price for a given ticker symbol."
+        alias: stock_price
+        description: "Returns the current stock price for a ticker symbol."
       get_earnings_report:
         description: "Returns the latest quarterly earnings report for a company."
 ```
 
-## Authenticated MCP Tools
+## Service-Account MCP Servers
 
-MCP tools that require OAuth2 authentication (for example, corporate Jira, Confluence, or internal data platforms) are not supported in the current version of the AIQ Blueprint. The NeMo Agent toolkit provides an `mcp_oauth2` authentication provider, but it is not yet compatible with the blueprint's backend and frontend. Support for authenticated MCP tools is planned for an upcoming release.
+Use service-account authentication when the MCP server should be accessed with an application or
+backend identity, not an individual AIQ user's identity. This is the preferred pattern for CI, batch
+jobs, shared enterprise data sources, and container deployments.
 
-For non-authenticated MCP servers, or MCP servers that use service account credentials (set through environment variables on the server side), use the `mcp_client` approach described above.
+```yaml
+function_groups:
+  mcp_enterprise_tools:
+    _type: mcp_client
+    server:
+      transport: streamable-http
+      url: ${ENTERPRISE_MCP_URL}
+      auth_provider: enterprise_service_account
 
-## UI Integration
+authentication:
+  enterprise_service_account:
+    _type: mcp_service_account
+    client_id: ${SERVICE_ACCOUNT_CLIENT_ID}
+    client_secret: ${SERVICE_ACCOUNT_CLIENT_SECRET}
+    token_url: ${SERVICE_ACCOUNT_TOKEN_URL}
+    scopes:
+      - enterprise.read
+```
 
-When you register an MCP function group in the `data_source_registry`, it automatically appears as a toggleable data source in the UI via the `GET /v1/data_sources` endpoint. Users can enable or disable it per message using the data source toggles, just like web search or knowledge base.
+For MCP servers that require both an OAuth2 service-account token and a service-specific delegation
+token, add a `service_token` block:
 
-## Prompt Tuning
+```yaml
+authentication:
+  enterprise_dual_auth:
+    _type: mcp_service_account
+    client_id: ${SERVICE_ACCOUNT_CLIENT_ID}
+    client_secret: ${SERVICE_ACCOUNT_CLIENT_SECRET}
+    token_url: ${SERVICE_ACCOUNT_TOKEN_URL}
+    scopes:
+      - enterprise.read
+    service_token:
+      token: ${ENTERPRISE_SERVICE_TOKEN}
+      header: X-Service-Account-Token
+```
 
-Adding MCP tools to the config makes them available to the agents, but the agents' prompts may not reference them. For the agents to use MCP tools effectively, you should tune the relevant prompts so that the agent knows when and how to invoke the new tools. Each customization is different: the prompt changes depend on the tool's purpose and how it fits into the research workflow.
+Register the function group in `data_source_registry` the same way as unauthenticated MCP tools. If
+the source does not require the end user to sign in to AIQ, leave `requires_auth` unset or `false`.
 
-The NeMo Agent toolkit agents use tool descriptions for routing decisions. If the MCP server provides poor or generic tool descriptions, you can override them through the `tool_overrides` configuration to help the agent select the right tool for each query.
+```yaml
+functions:
+  data_sources:
+    _type: data_source_registry
+    sources:
+      - id: enterprise_mcp
+        name: "Enterprise MCP"
+        description: "Search enterprise systems using service-account credentials."
+        tools:
+          - mcp_enterprise_tools
+```
 
-For more on prompt customization, refer to [Prompts](./prompts.md).
+## Current AIQ UI Auth Support
+
+The current AIQ UI supports one auth signal for data sources:
+
+```yaml
+requires_auth: true
+```
+
+When this flag is set, the UI disables the source until the user is signed in to AIQ. This is enough
+for:
+
+- AIQ token pass-through, where AIQ owns login and forwards the AIQ token.
+- Custom AIQ tools that use `aiq_agent.auth.get_auth_token()`.
+- Backend/service-account MCP tools that should only be visible to signed-in AIQ users.
+
+It is not enough for native per-MCP OAuth consent by itself. The current data source API returns
+`id`, `name`, `description`, and `requires_auth`; it does not return per-MCP auth status, a connect
+URL, scopes, token expiry, or reconnect/disconnect actions.
+
+If you want first-class native MCP OAuth in the AIQ UI, add a separate integration layer:
+
+- Backend APIs to report each MCP source's auth status.
+- Backend APIs to start and complete the MCP OAuth flow.
+- UI controls for connect, reconnect, disconnect, error states, and expired consent.
+- Async job validation to ensure the worker can resolve the user's MCP token.
+
+Without that work, prefer AIQ token pass-through or service-account MCP for AIQ deployments.
+
+## Per-User OAuth MCP Servers (Native NAT Capability)
+
+Use native NAT OAuth MCP support when the protected MCP server implements MCP OAuth and each user must
+authorize access to their own data. This is supported by NAT, but it should be treated as an advanced
+AIQ integration path until the AIQ frontend and backend expose the per-MCP consent flow.
+
+NAT provides:
+
+- `mcp_oauth2`: an auth provider for MCP OAuth2 flows.
+- `per_user_mcp_client`: a per-user MCP client function group.
+- Secure token storage options for persisting and isolating per-user MCP tokens.
+
+A typical NAT configuration looks like this:
+
+```yaml
+function_groups:
+  jira_mcp:
+    _type: per_user_mcp_client
+    server:
+      transport: streamable-http
+      url: ${CORPORATE_MCP_JIRA_URL}
+      auth_provider: jira_oauth
+
+authentication:
+  jira_oauth:
+    _type: mcp_oauth2
+    server_url: ${CORPORATE_MCP_JIRA_URL}
+    redirect_uri: ${NAT_REDIRECT_URI:-http://localhost:8000/auth/redirect}
+```
+
+For production or remote development, set `NAT_REDIRECT_URI` to the public URL that the user's
+browser can reach:
+
+```bash
+export NAT_REDIRECT_URI="https://aiq.example.com/auth/redirect"
+```
+
+Then register the MCP group as an authenticated data source so the AIQ UI disables it until a user is
+signed in:
+
+```yaml
+functions:
+  data_sources:
+    _type: data_source_registry
+    sources:
+      - id: jira
+        name: "Jira"
+        description: "Search and inspect Jira issues through MCP."
+        requires_auth: true
+        tools:
+          - jira_mcp
+```
+
+Native per-user MCP OAuth is the right pattern when the MCP server owns the OAuth flow. In AIQ, do
+not rely on `requires_auth: true` alone for this pattern. Validate the consent flow end to end with
+the frontend mode you deploy, especially if you use async jobs, because OAuth consent and token storage
+are managed by NAT's MCP auth layer rather than AIQ's request-token helper.
+
+## AIQ Token Pass-Through to MCP Servers
+
+Use AIQ token pass-through when AIQ is the only login surface and the MCP server, an API gateway, or
+an authenticating reverse proxy accepts the AIQ user's bearer token. In this pattern, users sign in to
+AIQ once. AIQ forwards that request token when a tool call reaches the MCP server. For the AIQ login
+and token retrieval setup, see [Authentication](../deployment/authentication.md).
+
+This is different from native MCP OAuth:
+
+- AIQ owns the user session and token validation at the AIQ boundary.
+- The MCP server trusts the AIQ token, or a gateway exchanges or validates it before forwarding.
+- Users do not complete a separate OAuth consent flow for each MCP server.
+- `requires_auth: true` only gates the UI source toggle. It does not, by itself, make `mcp_client`
+  forward an `Authorization` header to the MCP server.
+
+There are three common ways to implement pass-through.
+
+### Option 1: Custom MCP Auth Provider
+
+If your deployment uses NAT's MCP client directly and you want the MCP server to remain a real MCP
+server, add a small custom NAT authentication provider that reads the current AIQ token and injects it
+into MCP client requests. The provider should call `aiq_agent.auth.get_auth_token()` at request time,
+not at startup, so concurrent users and async jobs do not share credentials.
+
+Configure the MCP client to use that provider:
+
+```yaml
+function_groups:
+  internal_mcp:
+    _type: mcp_client
+    server:
+      transport: streamable-http
+      url: ${INTERNAL_MCP_URL}
+      auth_provider: aiq_user_token
+
+authentication:
+  aiq_user_token:
+    _type: aiq_user_token_passthrough
+```
+
+Register the group as an authenticated data source:
+
+```yaml
+functions:
+  data_sources:
+    _type: data_source_registry
+    sources:
+      - id: internal_mcp
+        name: "Internal MCP"
+        description: "Call internal MCP tools using your AIQ sign-in."
+        requires_auth: true
+        tools:
+          - internal_mcp
+```
+
+This keeps the MCP boundary intact but requires a small code plugin because the token source is
+AIQ-specific.
+
+### Option 2: Auth-Forwarding MCP Proxy
+
+Run a small internal proxy between AIQ and the MCP server. AIQ calls the proxy as its MCP server, and
+the proxy forwards the AIQ bearer token to the upstream MCP server or exchanges it for an upstream
+token. This is useful when:
+
+- The upstream MCP server expects custom headers or token exchange.
+- You want centralized policy, auditing, or allowlisting outside the AIQ process.
+- Multiple AIQ deployments should share the same MCP access policy.
+
+The AIQ YAML still uses `mcp_client`, but it must include whatever auth provider forwards the AIQ
+token to the proxy:
+
+```yaml
+function_groups:
+  internal_mcp:
+    _type: mcp_client
+    server:
+      transport: streamable-http
+      url: ${AIQ_MCP_PROXY_URL}
+      auth_provider: aiq_user_token
+```
+
+The proxy receives the user's token from AIQ, then applies your organization's upstream policy. If the
+proxy is implemented as an AIQ custom tool rather than an MCP server, use Option 3.
+
+### Option 3: Custom AIQ Tool
+
+If you do not need a real MCP client boundary inside AIQ, write a custom AIQ/NAT tool that retrieves
+the AIQ token with `get_auth_token()` and calls the downstream service directly. This is usually the
+simplest pass-through implementation when you control the downstream API. See
+[Custom AIQ Auth-Based Tools](#custom-aiq-auth-based-tools) and
+[Authentication](../deployment/authentication.md#step-5-use-the-current-user-token-in-tools).
+
+## Does AIQ Need Separate UI Login for Each MCP Server?
+
+It depends on which auth pattern you choose:
+
+| Pattern | Separate MCP-server login in the AIQ UI? | Notes |
+|---|---|---|
+| Unauthenticated MCP | No | No user credential is needed. |
+| Service-account MCP | No | AIQ uses backend credentials from config or secret storage. |
+| AIQ token pass-through | No | Users sign in to AIQ once; the MCP server trusts or exchanges the AIQ token. |
+| Native MCP OAuth with `mcp_oauth2` / `per_user_mcp_client` | Yes, for first-time consent per protected MCP server or OAuth resource | NAT manages MCP OAuth consent and token storage. The AIQ UI should expose or preserve that flow in the deployed frontend mode. |
+
+For pass-through, the current AIQ UI behavior is usually enough: mark the source with
+`requires_auth: true` so it is disabled until the user signs in to AIQ. For native MCP OAuth, plan for
+additional UI/flow validation because the user may need to approve each MCP server's scopes and the UI
+must not hide or break NAT's OAuth consent flow.
+
+## Custom AIQ Auth-Based Tools
+
+Use a custom AIQ/NAT tool when you want the tool to call a downstream service with the same bearer
+token that authenticated the current AIQ request. This is not native MCP OAuth. It is a practical
+AIQ-specific pattern for services that trust the AIQ user's JWT or for gateways that perform
+on-behalf-of authorization.
+
+AIQ exposes:
+
+- `aiq_agent.auth.get_auth_token()`: returns the current request token when available.
+- `aiq_agent.auth.get_current_principal()`: returns verified identity metadata from AIQ auth middleware.
+- Async job token propagation: AIQ captures the request token and makes it available in Dask workers
+  through the same `get_auth_token()` helper.
+
+Example custom tool:
+
+```python
+from pydantic import Field
+
+from aiq_agent.auth import get_auth_token
+from nat.builder.function_info import FunctionInfo
+from nat.cli.register_workflow import register_function
+from nat.data_models.function import FunctionBaseConfig
+
+
+class InternalSearchConfig(FunctionBaseConfig, name="internal_search"):
+    endpoint: str = Field(..., description="Internal search endpoint")
+
+
+@register_function(config_type=InternalSearchConfig)
+async def internal_search(config: InternalSearchConfig, builder):
+    async def _search(query: str) -> str:
+        token = get_auth_token()
+        if not token:
+            return "Sign in before using Internal Search."
+
+        # Use an async HTTP client in production code.
+        # Forward only to trusted services over HTTPS.
+        return await call_internal_search(
+            endpoint=config.endpoint,
+            query=query,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    yield FunctionInfo.from_fn(
+        _search,
+        description="Search internal systems using the signed-in AIQ user's token.",
+    )
+```
+
+Register the tool as an auth-required data source:
+
+```yaml
+functions:
+  data_sources:
+    _type: data_source_registry
+    sources:
+      - id: internal_search
+        name: "Internal Search"
+        description: "Search internal systems using your AIQ sign-in."
+        requires_auth: true
+        tools:
+          - internal_search
+
+  internal_search:
+    _type: internal_search
+    endpoint: ${INTERNAL_SEARCH_URL}
+```
+
+This pattern is best when:
+
+- AIQ already validates the user's JWT.
+- The downstream service accepts that JWT or an exchange derived from it.
+- You need AIQ UI toggles and async deep research jobs to preserve user context.
+
+Do not use unverified JWT payloads for authorization decisions. Use `get_current_principal()` for
+trusted identity and `get_auth_token()` only for forwarding a token to a trusted downstream service.
+
+## Publish AIQ or NAT Tools as an MCP Server
+
+You can publish the functions in a NAT workflow as MCP tools:
+
+```bash
+nat mcp serve --config_file configs/config_web_frag.yml --port 9901
+```
+
+The MCP server is available at:
+
+```text
+http://localhost:9901/mcp
+```
+
+List tools exposed by the server:
+
+```bash
+nat mcp client tool list --url http://localhost:9901/mcp
+nat mcp client tool list --url http://localhost:9901/mcp --tool <tool_name> --detail
+```
+
+Call a tool directly while debugging:
+
+```bash
+nat mcp client tool call <tool_name> \
+  --url http://localhost:9901/mcp \
+  --json-args '{"query": "example"}'
+```
+
+NAT also supports a FastMCP server runtime:
+
+```bash
+uv pip install nvidia-nat-fastmcp
+nat fastmcp server run --config_file configs/config_web_frag.yml --port 9902
+```
+
+FastMCP publishes tools at `http://localhost:9902/mcp` by default. NAT's FastMCP docs note that this
+runtime depends on a beta FastMCP release, so validate it against your deployment requirements before
+using it in production.
+
+## Security Guidance
+
+- Prefer `streamable-http` for MCP servers, especially protected servers.
+- Do not expose `nat mcp serve` directly to the public internet without an authenticating reverse
+  proxy, private network boundary, or equivalent protection.
+- Do not use `sse` for production authentication scenarios.
+- Store secrets in environment variables or a secret manager, not in YAML checked into source control.
+- Use service-account MCP auth only when shared app-level access is acceptable.
+- Use per-user OAuth MCP auth or a custom AIQ token-forwarding tool when access must reflect the
+  signed-in user.
+- Keep token forwarding scoped to trusted internal services and HTTPS endpoints.
+- Mark user-authenticated data sources with `requires_auth: true` so the UI can prevent unauthenticated
+  use.
+
+## Troubleshooting
+
+### MCP Tools Do Not Appear in the UI
+
+Confirm the function group is listed in `data_source_registry`:
+
+```yaml
+tools:
+  - mcp_financial_tools
+```
+
+The AIQ UI gets its connection list from `GET /v1/data_sources`. If a source is missing from the
+registry, the UI has no toggle for it.
+
+### The Agent Does Not Use the MCP Tool
+
+Check the remote tool descriptions:
+
+```bash
+nat mcp client tool list --url http://localhost:9901/mcp --tool <tool_name> --detail
+```
+
+If descriptions are vague, add `tool_overrides` with task-specific descriptions. You may also need to
+update prompts so agents know when to prefer the new source.
+
+### Data Source Filtering Does Not Match MCP Tools
+
+AIQ maps function groups by prefix. A group named `mcp_financial_tools` maps tools such as
+`mcp_financial_tools__stock_price` back to the source containing `mcp_financial_tools`. If you use
+individual tool references instead of the group name, list the exact exposed tool names.
+
+### Authenticated Source Is Disabled in the UI
+
+If a source has `requires_auth: true`, the UI disables it until the user has an auth token. Verify the
+frontend auth provider is configured and that requests include an `idToken` cookie or
+`Authorization: Bearer <token>` header.
+
+### Async Deep Research Loses User Auth
+
+Use `get_auth_token()` inside custom AIQ tools rather than reading request headers directly. AIQ
+captures the request token during job submission and restores it in the async worker context.
+
+### OAuth Redirect Fails on a Remote Server
+
+Set `NAT_REDIRECT_URI` to the public URL users open in their browsers, not to `localhost`:
+
+```bash
+export NAT_REDIRECT_URI="https://aiq.example.com/auth/redirect"
+```
+
+Ensure the reverse proxy forwards `/auth/redirect` to the NAT server handling the OAuth callback.
+
+## Related Documentation
+
+- [Tools and Sources](./tools-and-sources.md)
+- [Adding a Tool](../extending/adding-a-tool.md)
+- [Adding a Data Source](../extending/adding-a-data-source.md)
+- [Prompts](./prompts.md)

--- a/docs/source/deployment/authentication.md
+++ b/docs/source/deployment/authentication.md
@@ -51,6 +51,7 @@ export const MySSOProvider = {
     params: { scope: 'openid profile email', response_type: 'code' },
   },
   clientId: process.env.MY_SSO_CLIENT_ID,
+  // MY_SSO_CLIENT_SECRET must be set; an empty string causes silent OAuth failures.
   clientSecret: process.env.MY_SSO_CLIENT_SECRET || '',
   checks: ['pkce', 'state'] as ('pkce' | 'state' | 'nonce')[],
   idToken: true,
@@ -217,6 +218,8 @@ async def internal_lookup(config: InternalLookupConfig, builder):
         if not token:
             return "Sign in before using Internal Lookup."
 
+        # `call_internal_service` is a placeholder for your own async HTTP call
+        # (e.g. via httpx.AsyncClient) — replace with the real client invocation.
         return await call_internal_service(
             endpoint=config.endpoint,
             query=query,

--- a/docs/source/deployment/authentication.md
+++ b/docs/source/deployment/authentication.md
@@ -1,0 +1,291 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+# Authentication
+
+AIQ authentication is disabled by default for local development. When enabled, the web UI signs users
+in with an OAuth/OIDC provider and the backend validates the resulting JWT before serving protected
+API routes.
+
+Use this guide when you need to:
+
+- Require users to sign in before using AIQ.
+- Add an OAuth/OIDC provider to the AIQ UI.
+- Configure backend JWT validation.
+- Gate data sources that need an authenticated AIQ user.
+- Forward the AIQ user token to custom tools or MCP pass-through integrations.
+
+## How AIQ Auth Works
+
+AIQ has two auth layers that must be configured together:
+
+| Layer | Responsibility |
+|---|---|
+| Frontend UI | Runs the OAuth/OIDC sign-in flow with NextAuth, stores the session, and sets an `idToken` cookie after login. |
+| Backend API | Runs `AuthMiddleware`, validates bearer tokens or the `idToken` cookie with registered validators, and exposes the verified principal to tools and jobs. |
+
+The same `REQUIRE_AUTH=true` setting is used by both services, but each service also needs its own
+configuration. The frontend needs an OAuth provider. The backend needs at least one token validator.
+
+## Step 1: Add a UI OAuth Provider
+
+Create a provider file in:
+
+```text
+frontends/ui/src/adapters/auth/providers/
+```
+
+For example:
+
+```typescript
+// frontends/ui/src/adapters/auth/providers/my-sso.ts
+import type { TokenRefreshResult } from './types'
+
+export const MySSOProvider = {
+  id: 'my-sso',
+  name: 'My SSO',
+  type: 'oauth' as const,
+  wellKnown: `${process.env.MY_SSO_ISSUER}/.well-known/openid-configuration`,
+  authorization: {
+    params: { scope: 'openid profile email', response_type: 'code' },
+  },
+  clientId: process.env.MY_SSO_CLIENT_ID,
+  clientSecret: process.env.MY_SSO_CLIENT_SECRET || '',
+  checks: ['pkce', 'state'] as ('pkce' | 'state' | 'nonce')[],
+  idToken: true,
+  profile(profile: { sub: string; email: string; name: string; picture?: string }) {
+    return {
+      id: profile.sub,
+      email: profile.email,
+      name: profile.name,
+      image: profile.picture,
+    }
+  },
+}
+
+export const refreshMySSOToken = async (refreshToken: string): Promise<TokenRefreshResult> => {
+  const response = await fetch(process.env.MY_SSO_TOKEN_URL!, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: process.env.MY_SSO_CLIENT_ID || '',
+      client_secret: process.env.MY_SSO_CLIENT_SECRET || '',
+    }),
+  })
+
+  const tokens = await response.json()
+  if (!response.ok) {
+    throw tokens
+  }
+  return tokens
+}
+```
+
+Then update the provider registry:
+
+```typescript
+// frontends/ui/src/adapters/auth/providers/index.ts
+import type { AuthProviderConfig } from './types'
+import { MySSOProvider, refreshMySSOToken } from './my-sso'
+
+export type { AuthProviderConfig, TokenRefreshResult } from './types'
+
+export const getAuthProviderConfig = (): AuthProviderConfig => ({
+  provider: MySSOProvider,
+  providerId: 'my-sso',
+  refreshToken: refreshMySSOToken,
+})
+```
+
+Use `frontends/ui/src/adapters/auth/providers/auth-example.ts` as the implementation checklist for a
+new provider.
+
+## Step 2: Configure UI Auth Environment
+
+Set these environment variables for the frontend:
+
+```bash
+REQUIRE_AUTH=true
+NEXTAUTH_SECRET=<generate-with-openssl-rand-base64-32>
+NEXTAUTH_URL=https://aiq.example.com
+SESSION_MAX_AGE_HOURS=24
+
+MY_SSO_ISSUER=https://sso.example.com
+MY_SSO_CLIENT_ID=<client-id>
+MY_SSO_CLIENT_SECRET=<client-secret>
+MY_SSO_TOKEN_URL=https://sso.example.com/token
+```
+
+Set `NEXTAUTH_URL` to the public URL users open in their browser. If the public URL is HTTPS, cookies
+are secure by default. For reverse proxies that terminate TLS, still use the external HTTPS URL.
+
+## Step 3: Add a Backend Token Validator
+
+The backend only enforces auth when `REQUIRE_AUTH=true` and a request is classified as external. Set
+`AIQ_EXTERNAL_HOSTNAMES` to the hostnames that should be treated as externally reachable:
+
+```bash
+REQUIRE_AUTH=true
+AIQ_EXTERNAL_HOSTNAMES=aiq-api.example.com
+```
+
+Register a validator before the backend starts. The recommended approach for deployment packages is
+an entry point:
+
+```toml
+# pyproject.toml of your deployment package
+[project.entry-points."aiq_api.validators"]
+my_sso = "my_aiq_auth.validators:get_validators"
+```
+
+```python
+# my_aiq_auth/validators.py
+import os
+
+from aiq_api.auth.jwt_validator import JWTValidator
+
+
+def get_validators() -> list:
+    issuer = os.environ["AIQ_JWT_ISSUER"]
+    audience = os.environ.get("AIQ_JWT_AUDIENCE")
+    return [JWTValidator(issuer_url=issuer, audience=audience)]
+```
+
+Then set the validator environment:
+
+```bash
+AIQ_JWT_ISSUER=https://sso.example.com
+AIQ_JWT_AUDIENCE=<optional-api-audience>
+```
+
+Install the deployment package into the backend environment before starting AIQ. At startup, AIQ
+loads validators from the `aiq_api.validators` entry point group. If `REQUIRE_AUTH=true` and no
+validators are registered, the backend fails fast.
+
+For simple embedded deployments, you can also register programmatically before `nat serve` starts:
+
+```python
+from aiq_api.auth.jwt_validator import JWTValidator
+from aiq_api.plugin import register_validator
+
+register_validator(JWTValidator(issuer_url="https://sso.example.com", audience="api://aiq"))
+```
+
+## Step 4: Mark Authenticated Data Sources
+
+Use `requires_auth: true` for sources that require a signed-in AIQ user:
+
+```yaml
+functions:
+  data_sources:
+    _type: data_source_registry
+    sources:
+      - id: internal_mcp
+        name: "Internal MCP"
+        description: "Call internal MCP tools using your AIQ sign-in."
+        requires_auth: true
+        tools:
+          - internal_mcp
+```
+
+The UI disables these sources until the user signs in to AIQ. This flag does not automatically
+authenticate to an upstream MCP server or API. Tools still need service-account credentials, native
+MCP auth, or AIQ token pass-through.
+
+## Step 5: Use the Current User Token in Tools
+
+Custom tools can read the current AIQ request token with `get_auth_token()`:
+
+```python
+from aiq_agent.auth import get_auth_token
+from nat.builder.function_info import FunctionInfo
+from nat.cli.register_workflow import register_function
+from nat.data_models.function import FunctionBaseConfig
+
+
+class InternalLookupConfig(FunctionBaseConfig, name="internal_lookup"):
+    endpoint: str
+
+
+@register_function(config_type=InternalLookupConfig)
+async def internal_lookup(config: InternalLookupConfig, builder):
+    async def _lookup(query: str) -> str:
+        token = get_auth_token()
+        if not token:
+            return "Sign in before using Internal Lookup."
+
+        return await call_internal_service(
+            endpoint=config.endpoint,
+            query=query,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    yield FunctionInfo.from_fn(
+        _lookup,
+        description="Look up internal information using the signed-in AIQ user's token.",
+    )
+```
+
+AIQ also propagates the request token into async Dask jobs, so custom tools should use
+`get_auth_token()` instead of reading HTTP headers directly.
+
+Use `get_current_principal()` when you need trusted identity metadata:
+
+```python
+from aiq_agent.auth import get_current_principal
+
+principal = get_current_principal()
+if principal:
+    user_id = principal.sub
+```
+
+Do not use unverified JWT payloads for authorization decisions.
+
+## Headless API Callers
+
+API clients can send a bearer token directly:
+
+```bash
+curl -H "Authorization: Bearer ${AIQ_ID_TOKEN}" \
+     -H "X-AIQ-Mode: headless" \
+     https://aiq-api.example.com/v1/data_sources
+```
+
+`X-AIQ-Mode: headless` tells AIQ the caller cannot participate in interactive clarifier back-and-forth.
+
+## Troubleshooting
+
+### Backend Fails at Startup
+
+If `REQUIRE_AUTH=true`, make sure at least one validator is registered. The backend will fail with a
+clear error if no validators are available.
+
+### Requests Are Not Rejected
+
+Set `AIQ_EXTERNAL_HOSTNAMES` to the external backend hostname. AIQ treats requests to other hostnames
+as internal traffic for cluster-to-cluster communication.
+
+### UI Shows Default User
+
+Confirm `frontends/ui/src/adapters/auth/providers/index.ts` returns your provider, not the default
+`provider: null` configuration.
+
+### Authenticated Data Source Is Disabled
+
+The source has `requires_auth: true`, but the UI does not have an `idToken`. Confirm the user is
+signed in and that the NextAuth callback sets the `idToken` cookie.
+
+### Tool Cannot See the Token
+
+Use `get_auth_token()` inside the tool call body. Do not capture the token at startup, because startup
+does not run in a user request context.
+
+## Related Documentation
+
+- [MCP Tools and Authentication](../customization/mcp-tools.md)
+- [Tools and Sources](../customization/tools-and-sources.md)
+- [Production Considerations](./production.md)
+- [Observability](./observability.md)

--- a/docs/source/deployment/index.md
+++ b/docs/source/deployment/index.md
@@ -29,6 +29,8 @@ All containerized deployments run the same three services:
 
 - **[Docker Build System](./docker-build.md)** -- Multi-stage Dockerfile architecture, build targets (dev vs. release), base images, and startup scripts (`entrypoint.py` and `start_web.py`).
 
+- **[Authentication](./authentication.md)** -- Enable OAuth/OIDC sign-in, configure backend JWT validation, and use AIQ user tokens in tools and MCP pass-through integrations.
+
 - **[Observability](./observability.md)** -- Tracing and monitoring with Phoenix, LangSmith, Weave, and OpenTelemetry.
 
 - **[Production Considerations](./production.md)** -- Guidance on managed databases, horizontal scaling, security hardening, monitoring, and resource requirements.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -94,6 +94,7 @@ Profiling & Cost Analysis <./profiling/index.md>
 Overview <./deployment/index.md>
 Docker Compose <./deployment/docker-compose.md>
 Docker Build System <./deployment/docker-build.md>
+Authentication <./deployment/authentication.md>
 Observability <./deployment/observability.md>
 Production <./deployment/production.md>
 Kubernetes <./deployment/kubernetes.md>


### PR DESCRIPTION
## Summary

Two doc-only commits in the customization + deployment areas:

1. **New `docs/source/deployment/authentication.md`** — operator-facing guide covering OAuth/OIDC sign-in, backend JWT validation, AIQ user-token use in tools, AIQ-token pass-through to MCP integrations, headless API caller pattern, and troubleshooting.
2. **Rewrite `docs/source/customization/mcp-tools.md`** — scoped tightly to what AIQ 2.1 actually supports end-to-end.

Both docs are wired into the deployment and top-level indexes.

## What the MCP guide now covers

**Supported patterns (full walkthroughs):**
- `mcp_client` for unauthenticated MCP servers
- `mcp_service_account` (incl. dual-auth) for backend-credential MCP
- AIQ-user-identity tools using `aiq_agent.auth.get_auth_token()`
- `nat mcp serve` / `nat fastmcp server run` for publishing AIQ as MCP

**Deferred to AIQ 2.2 / 2.3 (short, honest planning notes):**
- Per-user MCP OAuth driven by the AIQ UI. NAT 1.6 ships the protocol-level building blocks (`mcp_oauth2`, `per_user_mcp_client`) but AIQ 2.1 lacks the UI controls, the per-MCP auth-status surface on `/v1/data_sources`, and the async-job worker-side per-user MCP token resolution required to deliver this end-to-end.
- A first-party AIQ-token pass-through MCP auth provider. Today this requires implementing a custom NAT auth provider in your deployment package.

## Cuts vs. the previous draft

- The three "Options 1/2/3" pass-through recipes collapse to a single `Forwarding AIQ User Identity from a Tool` section with the working `internal_search` example.
- The long native per-user OAuth walkthrough (Jira example, redirect URI setup) is replaced by a short note pointing at the NAT MCP auth reference.
- The "Does AIQ Need Separate UI Login..." combinatorial table.
- A custom-provider Python skeleton for `aiq_user_token_passthrough` (the doc no longer recommends a flow AIQ does not ship out of the box).

Net for `mcp-tools.md`: 395 lines, down from 622 in the prior draft.

## Test plan

- [x] Docs build cleanly (sphinx)
- [x] Doc-tree TOC includes the new authentication.md
- [x] All cross-references between mcp-tools.md and authentication.md resolve

## Notes

- Doc-only PR; no code changes.
- Markdown-link-checker may flag external sites that 403 the bot UA (FastAPI, Dask, Next.js, Postgres, LangGraph) — these were pre-existing in `deployment/index.md`, not introduced here.
- Follow-ups for AIQ 2.2 / 2.3 (per-user MCP OAuth UI, async-job auth refresh) are tracked separately under the auth/MCP umbrellas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)