### PR TITLE
docs: add v2.1.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+Release v2.1.0 (Unreleased — target 2026-05-19)
+
+- AI-Q REST API with pluggable auth middleware, entry-point-registered token validators, and async job ownership enforcement
+- Auth extensibility hooks (`register_token_fetcher`, provider lifecycle) and auth refactor eliminating the refresh race
+- Data source registry driving UI toggles, per-message filtering, and agent tool inheritance
+- New `exa_web_search` data source with `full_text` and `highlights` controls
+- Deep researcher consumes DeepAgents skills with a job-scoped Modal sandbox; built-in `data-table-analysis` skill and `configs/config_skills.yml` example
+- AI-Q is consumable as a Claude Code skill (`.claude/skills/aiq-research/`) for routed `/chat` and async job lifecycle against a local AI-Q server
+- Cost analysis tool with pricing configs and profiling example
+- Documented MCP client patterns scoped for 2.1: `mcp_client`, `mcp_service_account`, and user-identity tools
+- Prompt restructure across all agents for KV cache prefix reuse
+- Operability: idempotent DB init, tuned Dask/Postgres defaults, request tracing into NAT spans, UI stream-failure hardening
+- New authentication and MCP tools guides; new skills-and-sandbox example
+- Pinned to NeMo Agent Toolkit (NAT) v1.6.0; CVE bumps for Pillow, cryptography, pygments, authlib, pyopenssl, and pytest
+
 Release v2.0.0
 
 Ground-up rewrite of the NVIDIA AI-Q Blueprint, built on the NVIDIA NeMo Agent Toolkit (NAT).


### PR DESCRIPTION
## Summary

- Adds a `Release v2.1.0 (Unreleased — target 2026-05-19)` section to `CHANGELOG.md` covering the 45 commits landed on `develop` since v2.0
- Matches the v2.0 prose-bullet style: one line per change, no sub-bullets
- Marked `Unreleased` so any further changes before code freeze can be appended in place; drop the marker on the release commit

## Why now

QA is cutting the RC tag today against `develop`. Landing this entry beforehand gives QA a single source of truth for "what's actually in 2.1" alongside the test plan, and surfaces any plan-vs-reality drift (e.g. NeMo Guardrails / ServiceNow / Salesforce MCP are intentionally not listed because they did not land).

## Test plan

- [x] `git log 62101c8..HEAD` reviewed; every PR since v2.0 maps to a bullet or is intentionally omitted (style/lint-only fixes, internal test coverage, dependency lockfile churn)
- [x] No claims about features not in the repo (Guardrails, ServiceNow/Salesforce MCP, OAuth gateway, Codex/Cursor/NemoClaw skills)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)