### PR TITLE
Issue 214 data sources job submit

### DIFF
--- a/docs/source/architecture/agents/clarifier.md
+++ b/docs/source/architecture/agents/clarifier.md
@@ -77,7 +77,7 @@ graph TD
 | Field | Type | Default | Description |
 | ----- | ---- | ------- | ----------- |
 | `messages` | `Annotated[list[AnyMessage], add_messages]` | required | Conversation history with [LangGraph](https://docs.langchain.com/oss/python/langgraph/overview) message reducer |
-| `data_sources` | `list[str]` or `None` | `None` | Data source IDs for tool filtering |
+| `data_sources` | `list[str]` or `None` | `None` | Data source IDs for tool filtering. `None` uses all configured tools; `[]` keeps only unmapped utility tools; a populated list scopes to the named sources plus unmapped utility tools. |
 | `available_documents` | `list[dict[str, Any]]` or `None` | `None` | User-uploaded documents (file name, summary) for context; the user may refer to these |
 | `max_turns` | `int` | `3` | Maximum clarification Q&A turns |
 | `clarifier_log` | `str` | `""` | Accumulated clarification dialog log |

--- a/docs/source/architecture/agents/deep-researcher.md
+++ b/docs/source/architecture/agents/deep-researcher.md
@@ -116,7 +116,7 @@ to `create_deep_agent` rather than being routed through middleware.
 | Field | Type | Default | Description |
 | ----- | ---- | ------- | ----------- |
 | `messages` | `Annotated[list[AnyMessage], add_messages]` | required | Conversation history with LangGraph message reducer |
-| `data_sources` | `list[str]` or `None` | `None` | User-selected data source IDs for tool filtering |
+| `data_sources` | `list[str]` or `None` | `None` | User-selected data source IDs for tool filtering. `None` uses all configured tools; `[]` keeps only unmapped utility tools; a populated list scopes to the named sources plus unmapped utility tools. |
 | `user_info` | `dict` or `None` | `None` | User information |
 | `tools_info` | `list[dict]` or `None` | `None` | Available tools information |
 | `todos` | `list[dict]` | `[]` | Todo list for research task tracking |

--- a/docs/source/architecture/agents/shallow-researcher.md
+++ b/docs/source/architecture/agents/shallow-researcher.md
@@ -83,7 +83,7 @@ the agent-tools round trips plus headroom.
 | Field | Type | Default | Description |
 | ----- | ---- | ------- | ----------- |
 | `messages` | `Annotated[list[AnyMessage], add_messages]` | required | Conversation history with LangGraph message reducer |
-| `data_sources` | `list[str]` or `None` | `None` | User-selected data source IDs for tool filtering |
+| `data_sources` | `list[str]` or `None` | `None` | User-selected data source IDs for tool filtering. `None` uses all configured tools; `[]` keeps only unmapped utility tools; a populated list scopes to the named sources plus unmapped utility tools. |
 | `user_info` | `dict` or `None` | `None` | User information for prompt personalization |
 | `tools_info` | `list[dict]` or `None` | `None` | Override tools info (used when data_sources filters tools) |
 | `available_documents` | `list[AvailableDocument]` or `None` | `None` | User-uploaded documents with summaries |

--- a/docs/source/architecture/overview.md
+++ b/docs/source/architecture/overview.md
@@ -78,7 +78,7 @@ The central state model carries data through the entire workflow:
 | ----- | ---- | ------- |
 | `messages` | `list[AnyMessage]` | Conversation history (LangGraph message reducer) |
 | `user_info` | `dict` or `None` | Authenticated user information for personalization |
-| `data_sources` | `list[str]` or `None` | User-selected data source IDs for tool filtering |
+| `data_sources` | `list[str]` or `None` | User-selected data source IDs for tool filtering. `None` uses all configured tools; `[]` keeps only unmapped utility tools; a populated list scopes to the named sources plus unmapped utility tools. |
 | `user_intent` | `IntentResult` or `None` | Classification result: `meta` or `research` |
 | `depth_decision` | `DepthDecision` or `None` | Routing decision: `shallow` or `deep` |
 | `final_report` | `str` or `None` | Final report output from deep research |

--- a/docs/source/customization/tools-and-sources.md
+++ b/docs/source/customization/tools-and-sources.md
@@ -34,7 +34,7 @@ functions:
 
 The `GET /v1/data_sources` API endpoint returns these entries, which the UI renders as toggles. Clients can scope a request to a subset by passing `data_sources: ["web_search"]` in the WebSocket chat payload or in the body of `POST /v1/jobs/async/submit`; only tools belonging to selected sources are active for that request.
 
-Tools not listed in any data source entry (e.g., utility tools like "think") are included when filtering to one or more selected sources. Passing an explicit empty list (`data_sources: []`) disables all tools.
+Tools not listed in any data source entry (e.g., utility tools like "think") are always included regardless of filtering. Passing an explicit empty list (`data_sources: []`) -- in the WebSocket chat payload or in a `POST /v1/jobs/async/submit` body -- disables data-source tools while leaving those unmapped utility tools available.
 
 ### Source Entry Fields
 

--- a/docs/source/customization/tools-and-sources.md
+++ b/docs/source/customization/tools-and-sources.md
@@ -34,7 +34,7 @@ functions:
 
 The `GET /v1/data_sources` API endpoint returns these entries, which the UI renders as toggles. Clients can scope a request to a subset by passing `data_sources: ["web_search"]` in the WebSocket chat payload or in the body of `POST /v1/jobs/async/submit`; only tools belonging to selected sources are active for that request.
 
-Tools not listed in any data source entry (e.g., utility tools like "think") are always included regardless of filtering.
+Tools not listed in any data source entry (e.g., utility tools like "think") are included when filtering to one or more selected sources. Passing an explicit empty list (`data_sources: []`) disables all tools.
 
 ### Source Entry Fields
 

--- a/docs/source/customization/tools-and-sources.md
+++ b/docs/source/customization/tools-and-sources.md
@@ -32,7 +32,7 @@ functions:
           - eci
 ```
 
-The `GET /v1/data_sources` API endpoint returns these entries, which the UI renders as toggles. When a user sends a message with `data_sources: ["web_search"]`, only tools belonging to that source are active for that request.
+The `GET /v1/data_sources` API endpoint returns these entries, which the UI renders as toggles. Clients can scope a request to a subset by passing `data_sources: ["web_search"]` in the WebSocket chat payload or in the body of `POST /v1/jobs/async/submit`; only tools belonging to selected sources are active for that request.
 
 Tools not listed in any data source entry (e.g., utility tools like "think") are always included regardless of filtering.
 

--- a/docs/source/extending/adding-a-data-source.md
+++ b/docs/source/extending/adding-a-data-source.md
@@ -320,7 +320,7 @@ The `data_source_registry` provides:
 - **Auth gating** -- set `requires_auth: true` on a source to grey it out in the UI until the user signs in (e.g., enterprise sources that need user-level OAuth tokens). Sources using backend API keys (Tavily, Serper) should leave this `false` (the default).
 - **Auto-inheritance** -- all agents get every registered tool by default (use `exclude_tools` on an agent for per-agent specialization)
 
-If a tool isn't listed in any `data_source_registry` source entry, it is included when filtering to one or more selected sources (e.g., utility tools like "think" or "calculator"). Passing an explicit empty list (`data_sources: []`) disables all tools.
+If a tool isn't listed in any `data_source_registry` source entry, it is always included regardless of filtering (e.g., utility tools like "think" or "calculator"). Passing an explicit empty list (`data_sources: []`) -- in the WebSocket chat payload or in a `POST /v1/jobs/async/submit` body -- disables data-source tools while leaving those unmapped utility tools available.
 
 ### Source Entry Field Reference
 

--- a/docs/source/extending/adding-a-data-source.md
+++ b/docs/source/extending/adding-a-data-source.md
@@ -315,7 +315,7 @@ functions:
 The `data_source_registry` provides:
 
 - **`GET /v1/data_sources`** API endpoint returns the registered sources (the UI renders these as toggles)
-- **Per-message filtering** via `data_sources: ["web_search"]` in the chat payload -- only tools belonging to selected sources are active
+- **Per-message filtering** via `data_sources: ["web_search"]` in the WebSocket chat payload, or as a `data_sources` field on `POST /v1/jobs/async/submit` -- only tools belonging to selected sources are active
 - **Display metadata** (name, description) shown in the UI
 - **Auth gating** -- set `requires_auth: true` on a source to grey it out in the UI until the user signs in (e.g., enterprise sources that need user-level OAuth tokens). Sources using backend API keys (Tavily, Serper) should leave this `false` (the default).
 - **Auto-inheritance** -- all agents get every registered tool by default (use `exclude_tools` on an agent for per-agent specialization)

--- a/docs/source/extending/adding-a-data-source.md
+++ b/docs/source/extending/adding-a-data-source.md
@@ -320,7 +320,7 @@ The `data_source_registry` provides:
 - **Auth gating** -- set `requires_auth: true` on a source to grey it out in the UI until the user signs in (e.g., enterprise sources that need user-level OAuth tokens). Sources using backend API keys (Tavily, Serper) should leave this `false` (the default).
 - **Auto-inheritance** -- all agents get every registered tool by default (use `exclude_tools` on an agent for per-agent specialization)
 
-If a tool isn't listed in any `data_source_registry` source entry, it is always included regardless of filtering (e.g., utility tools like "think" or "calculator").
+If a tool isn't listed in any `data_source_registry` source entry, it is included when filtering to one or more selected sources (e.g., utility tools like "think" or "calculator"). Passing an explicit empty list (`data_sources: []`) disables all tools.
 
 ### Source Entry Field Reference
 

--- a/docs/source/integration/rest-api.md
+++ b/docs/source/integration/rest-api.md
@@ -76,6 +76,7 @@ curl -X POST http://localhost:8000/v1/jobs/async/submit \
 | `input` | `string` | Yes | Research query (min 1 character) |
 | `job_id` | `string` | No | Custom job ID. Auto-generated UUID if omitted. Pattern: `[a-zA-Z0-9_-]`, max 64 chars |
 | `expiry_seconds` | `integer` | No | Job expiry in seconds. Range: 600--604800 (10 min to 7 days). Default from config |
+| `data_sources` | `list[string]` | No | Optional data source IDs (from `/v1/data_sources`) to scope the job. Omit or `null` for all sources; `[]` to run with no data-source tools. Unknown IDs return 422 |
 
 **Response (`JobStatusResponse`):**
 
@@ -92,6 +93,7 @@ curl -X POST http://localhost:8000/v1/jobs/async/submit \
 | Status | Reason |
 |--------|--------|
 | `400` | Unknown agent type or invalid request |
+| `422` | One or more unknown data source IDs |
 | `503` | Dask scheduler not available |
 
 ### Get Job Status

--- a/docs/source/integration/rest-api.md
+++ b/docs/source/integration/rest-api.md
@@ -76,7 +76,7 @@ curl -X POST http://localhost:8000/v1/jobs/async/submit \
 | `input` | `string` | Yes | Research query (min 1 character) |
 | `job_id` | `string` | No | Custom job ID. Auto-generated UUID if omitted. Pattern: `[a-zA-Z0-9_-]`, max 64 chars |
 | `expiry_seconds` | `integer` | No | Job expiry in seconds. Range: 600--604800 (10 min to 7 days). Default from config |
-| `data_sources` | `list[string]` | No | Optional data source IDs (from `/v1/data_sources`) to scope the job. Omit or `null` for all sources; `[]` to run with no tools. Unknown IDs return 422 |
+| `data_sources` | `list[string]` | No | Optional data source IDs (from `/v1/data_sources`) to scope the job. Omit or `null` for all data-source tools; `[]` for no data-source tools. Unmapped utility tools remain available. Unknown IDs return 422 |
 
 **Response (`JobStatusResponse`):**
 

--- a/docs/source/integration/rest-api.md
+++ b/docs/source/integration/rest-api.md
@@ -76,7 +76,7 @@ curl -X POST http://localhost:8000/v1/jobs/async/submit \
 | `input` | `string` | Yes | Research query (min 1 character) |
 | `job_id` | `string` | No | Custom job ID. Auto-generated UUID if omitted. Pattern: `[a-zA-Z0-9_-]`, max 64 chars |
 | `expiry_seconds` | `integer` | No | Job expiry in seconds. Range: 600--604800 (10 min to 7 days). Default from config |
-| `data_sources` | `list[string]` | No | Optional data source IDs (from `/v1/data_sources`) to scope the job. Omit or `null` for all sources; `[]` to run with no data-source tools. Unknown IDs return 422 |
+| `data_sources` | `list[string]` | No | Optional data source IDs (from `/v1/data_sources`) to scope the job. Omit or `null` for all sources; `[]` to run with no tools. Unknown IDs return 422 |
 
 **Response (`JobStatusResponse`):**
 
@@ -93,7 +93,7 @@ curl -X POST http://localhost:8000/v1/jobs/async/submit \
 | Status | Reason |
 |--------|--------|
 | `400` | Unknown agent type or invalid request |
-| `422` | One or more unknown data source IDs |
+| `422` | One or more unknown data source IDs. Response `detail` includes `message`, `invalid_ids`, and `known_ids` for client-side recovery UX |
 | `503` | Dask scheduler not available |
 
 ### Get Job Status

--- a/frontends/aiq_api/README.md
+++ b/frontends/aiq_api/README.md
@@ -101,7 +101,7 @@ curl -X POST http://localhost:8000/v1/jobs/async/submit \
   -d '{"agent_type": "deep_researcher", "input": "Research quantum computing trends in 2026"}'
 ```
 
-Optional body fields: `job_id` (custom ID), `expiry_seconds` (600–604800).
+Optional body fields: `job_id` (custom ID), `expiry_seconds` (600–604800), `data_sources` (subset of IDs from `/v1/data_sources`; `[]` runs with no data-source tools; unknown IDs return 422).
 
 Response:
 

--- a/frontends/aiq_api/README.md
+++ b/frontends/aiq_api/README.md
@@ -101,7 +101,7 @@ curl -X POST http://localhost:8000/v1/jobs/async/submit \
   -d '{"agent_type": "deep_researcher", "input": "Research quantum computing trends in 2026"}'
 ```
 
-Optional body fields: `job_id` (custom ID), `expiry_seconds` (600–604800), `data_sources` (subset of IDs from `/v1/data_sources`; `[]` runs with no data-source tools; unknown IDs return 422).
+Optional body fields: `job_id` (custom ID), `expiry_seconds` (600–604800), `data_sources` (subset of IDs from `/v1/data_sources`; `[]` runs with no tools; unknown IDs return 422).
 
 Response:
 

--- a/frontends/aiq_api/README.md
+++ b/frontends/aiq_api/README.md
@@ -101,7 +101,7 @@ curl -X POST http://localhost:8000/v1/jobs/async/submit \
   -d '{"agent_type": "deep_researcher", "input": "Research quantum computing trends in 2026"}'
 ```
 
-Optional body fields: `job_id` (custom ID), `expiry_seconds` (600–604800), `data_sources` (subset of IDs from `/v1/data_sources`; `[]` runs with no tools; unknown IDs return 422).
+Optional body fields: `job_id` (custom ID), `expiry_seconds` (600–604800), `data_sources` (subset of IDs from `/v1/data_sources`; `[]` disables data-source tools while leaving unmapped utility tools available; unknown IDs return 422).
 
 Response:
 

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -75,7 +75,7 @@ class JobSubmitRequest(BaseModel):
         description=(
             "Optional data source IDs to target. Omit or set null to use all data-source tools. "
             "When specific IDs are passed, unmapped utility tools (e.g., 'think') remain available. "
-            "Pass an empty list to run the agent with no tools, including unmapped utility tools."
+            "Pass an empty list to run the agent with no data-source tools; unmapped utility tools remain available."
         ),
     )
 

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from typing import TYPE_CHECKING
 from typing import Annotated
 
@@ -43,6 +44,12 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 
+from aiq_agent.common.data_source_registry import get_all_sources
+from aiq_agent.common.data_source_registry import get_all_tool_refs
+from aiq_agent.common.data_source_registry import get_source_id_for_tool
+from nat.builder.framework_enum import LLMFrameworkEnum
+
+from ..jobs.access import require_verified_principal
 from ..registry import AGENT_REGISTRY
 from ..registry import get_agent_config
 
@@ -73,9 +80,10 @@ class JobSubmitRequest(BaseModel):
     data_sources: list[str] | None = Field(
         None,
         description=(
-            "Optional data source IDs to target. Omit or set null to use all data-source tools. "
-            "When specific IDs are passed, unmapped utility tools (e.g., 'think') remain available. "
-            "Pass an empty list to run the agent with no data-source tools; unmapped utility tools remain available."
+            "Optional data source IDs to target. Omit or set null to use all data-source tools "
+            "available to the chosen agent. When specific IDs are passed, unmapped utility tools "
+            "(e.g., 'think') remain available. Pass an empty list to run the agent with no "
+            "data-source tools; unmapped utility tools remain available."
         ),
     )
 
@@ -98,6 +106,130 @@ JOB_SUBMIT_EXAMPLES: dict[str, dict] = {
         },
     },
 }
+
+
+def _source_ids_by_lowercase() -> tuple[list[str], dict[str, str]]:
+    """Return known source IDs and a lower-case lookup preserving canonical IDs.
+
+    Assumes registry IDs are unique under ``.lower()``. The data source registry
+    convention is snake_case (e.g. ``web_search``, ``knowledge_layer``); two IDs
+    differing only by case would collapse here.
+    """
+    known_ids = sorted(source.id for source in get_all_sources())
+    return known_ids, {source_id.lower(): source_id for source_id in known_ids}
+
+
+async def _get_agent_available_source_ids(builder: WorkflowBuilder, agent_config_name: str) -> list[str]:
+    """Return mapped source IDs with at least one effective tool for an agent config.
+
+    This mirrors the async job runner's effective tool resolution: explicit
+    `tools` wins and overrides registry refs, otherwise inherit all registry
+    refs, resolve LangChain wrappers through the builder, then apply exact
+    tool-name `exclude_tools`.
+
+    A source is reported as available if at least one of its tools survives
+    ``exclude_tools``; partial exclusion does not hide the source.
+
+    Assumes agent configs registered for async submission expose typed
+    ``tools`` and ``exclude_tools`` fields (see ``aiq_agent.agents.*.register``).
+    A registered agent without these fields is a registration-time bug, not a
+    runtime concern.
+    """
+    fn_config = builder.get_function_config(agent_config_name)
+    tool_refs = fn_config.tools if fn_config.tools is not None else get_all_tool_refs()
+    tools = await builder.get_tools(tool_names=tool_refs, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+
+    excluded = set(fn_config.exclude_tools or [])
+    if excluded:
+        tools = [tool for tool in tools if getattr(tool, "name", "") not in excluded]
+
+    source_ids: set[str] = set()
+    for tool in tools:
+        name = getattr(tool, "name", "")
+        if not name:
+            continue
+        sid = get_source_id_for_tool(name)
+        if sid is not None:
+            source_ids.add(sid)
+    return sorted(source_ids)
+
+
+async def _validate_data_sources_for_agent(
+    *,
+    builder: WorkflowBuilder,
+    agent_type: str,
+    agent_config_name: str,
+    data_sources: list[str] | None,
+) -> None:
+    """Raise HTTP 422 if requested sources are unknown or unavailable to the selected agent."""
+    # Semantic fast path: omit/null/empty means "use all data-source tools available
+    # to the chosen agent" (or, for empty list, "use no data-source tools"). In both
+    # cases there is nothing for the caller to validate against, so we skip.
+    #
+    # Bonus: this also avoids a builder.get_tools() round-trip on the default code
+    # path -- pinned by test_submit_job_forwards_omitted_data_sources_without_resolving_tools.
+    if not data_sources:
+        return
+
+    known_ids, known_by_lower = _source_ids_by_lowercase()
+
+    try:
+        available_ids = await _get_agent_available_source_ids(builder, agent_config_name)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        logger.exception(
+            "Failed to validate data sources for agent %s using config %s",
+            agent_type,
+            agent_config_name,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to validate data sources for selected agent",
+        ) from exc
+
+    available_by_lower = {source_id.lower(): source_id for source_id in available_ids}
+
+    # Single-pass partition: walk requested IDs once, deduping case-insensitively
+    # and routing each unique ID into either "unknown to system" or "known but
+    # unavailable to this agent." Preserves first-seen casing and request order.
+    seen: set[str] = set()
+    invalid_ids: list[str] = []
+    unavailable_for_agent: list[str] = []
+    for source_id in data_sources:
+        key = source_id.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        if key not in known_by_lower:
+            invalid_ids.append(source_id)
+        elif key not in available_by_lower:
+            unavailable_for_agent.append(source_id)
+
+    if not invalid_ids and not unavailable_for_agent:
+        return
+
+    parts: list[str] = []
+    if invalid_ids:
+        parts.append(f"Unknown data source(s): {', '.join(invalid_ids)}")
+    if unavailable_for_agent:
+        parts.append(f"Data source(s) are not available for agent '{agent_type}': {', '.join(unavailable_for_agent)}")
+    message = ". ".join(parts)
+
+    # Echo back the caller's request annotated with which IDs were unknown vs
+    # unavailable, plus the global registry list (which is also discoverable via
+    # /v1/data_sources). The per-agent capability list is intentionally NOT
+    # returned -- it's not exposed anywhere else and would reveal agent
+    # capability boundaries.
+    raise HTTPException(
+        status_code=422,
+        detail={
+            "message": message,
+            "invalid_ids": invalid_ids,
+            "unavailable_for_agent": unavailable_for_agent,
+            "known_ids": known_ids,
+        },
+    )
 
 
 class JobStatusResponse(BaseModel):
@@ -181,7 +313,6 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
 
     from ..jobs.access import authorize_job_access
     from ..jobs.access import ensure_job_access_table
-    from ..jobs.access import require_verified_principal
     from ..jobs.event_store import EventStore
     from ..jobs.submit import submit_agent_job as submit_authorized_job
 
@@ -296,7 +427,7 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         ),
         responses={
             400: {"description": "Unknown agent type or invalid request"},
-            422: {"description": "One or more unknown data source IDs"},
+            422: {"description": "One or more unknown or agent-unavailable data source IDs"},
             503: {"description": "Dask scheduler not available"},
         },
     )
@@ -305,29 +436,27 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
     ) -> JobStatusResponse:
         """Submit a new async job for deep research or other registered agents."""
         try:
-            get_agent_config(req.agent_type)
+            agent_config = get_agent_config(req.agent_type)
         except KeyError as e:
             raise HTTPException(400, str(e))
 
         expiry = req.expiry_seconds if req.expiry_seconds is not None else default_expiry_seconds
-        if req.data_sources is not None:
-            known_source_ids = sorted(source.id for source in get_all_sources())
-            available_source_ids = {source_id.lower() for source_id in known_source_ids}
-            invalid_source_ids = [
-                source_id for source_id in req.data_sources if source_id.lower() not in available_source_ids
-            ]
-            if invalid_source_ids:
-                message = f"Unknown data source(s): {', '.join(invalid_source_ids)}"
-                raise HTTPException(
-                    422,
-                    {
-                        "message": message,
-                        "invalid_ids": invalid_source_ids,
-                        "known_ids": known_source_ids,
-                    },
-                )
-
+        # Authenticate the caller (raises 401/403 if unverified). The returned principal
+        # is also forwarded to submit_authorized_job(...) below for ownership recording.
         principal = require_verified_principal()
+        validation_start = time.perf_counter()
+        await _validate_data_sources_for_agent(
+            builder=builder,
+            agent_type=req.agent_type,
+            agent_config_name=agent_config.config_name,
+            data_sources=req.data_sources,
+        )
+        logger.info(
+            "Validated data_sources for agent %s in %.1fms (requested=%s)",
+            req.agent_type,
+            (time.perf_counter() - validation_start) * 1000,
+            len(req.data_sources) if req.data_sources is not None else "none",
+        )
 
         # Propagate auth token to Dask worker for requires_auth data sources
         from aiq_agent.auth import get_auth_token

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -75,7 +75,7 @@ class JobSubmitRequest(BaseModel):
         description=(
             "Optional data source IDs to target. Omit or set null to use all data-source tools. "
             "When specific IDs are passed, unmapped utility tools (e.g., 'think') remain available. "
-            "Pass an empty list to run the agent with no tools."
+            "Pass an empty list to run the agent with no tools, including unmapped utility tools."
         ),
     )
 
@@ -311,12 +311,21 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
 
         expiry = req.expiry_seconds if req.expiry_seconds is not None else default_expiry_seconds
         if req.data_sources is not None:
-            available_source_ids = {source.id.lower() for source in get_all_sources()}
+            known_source_ids = sorted(source.id for source in get_all_sources())
+            available_source_ids = {source_id.lower() for source_id in known_source_ids}
             invalid_source_ids = [
                 source_id for source_id in req.data_sources if source_id.lower() not in available_source_ids
             ]
             if invalid_source_ids:
-                raise HTTPException(422, f"Unknown data source(s): {', '.join(invalid_source_ids)}")
+                message = f"Unknown data source(s): {', '.join(invalid_source_ids)}"
+                raise HTTPException(
+                    422,
+                    {
+                        "message": message,
+                        "invalid_ids": invalid_source_ids,
+                        "known_ids": known_source_ids,
+                    },
+                )
 
         principal = require_verified_principal()
 

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -33,7 +33,9 @@ import asyncio
 import json
 import logging
 from typing import TYPE_CHECKING
+from typing import Annotated
 
+from fastapi import Body
 from fastapi import FastAPI
 from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
@@ -54,19 +56,6 @@ logger = logging.getLogger(__name__)
 class JobSubmitRequest(BaseModel):
     """Request to submit an async job."""
 
-    model_config = ConfigDict(
-        json_schema_extra={
-            "examples": [
-                {
-                    "agent_type": "deep_researcher",
-                    "input": "What are the latest advances in quantum computing?",
-                    "job_id": None,
-                    "expiry_seconds": 86400,
-                }
-            ]
-        }
-    )
-
     agent_type: str = Field(..., description="Agent type (e.g., 'deep_researcher')")
     input: str = Field(..., min_length=1, description="Input query for the agent")
     job_id: str | None = Field(
@@ -81,6 +70,34 @@ class JobSubmitRequest(BaseModel):
         le=604800,
         description="Job expiry in seconds (default from config, max 7 days)",
     )
+    data_sources: list[str] | None = Field(
+        None,
+        description=(
+            "Optional data source IDs to target. Omit or set null to use all data-source tools. "
+            "When specific IDs are passed, unmapped utility tools (e.g., 'think') remain available. "
+            "Pass an empty list to run the agent with no tools."
+        ),
+    )
+
+
+JOB_SUBMIT_EXAMPLES: dict[str, dict] = {
+    "default": {
+        "summary": "Default (all data sources)",
+        "value": {
+            "agent_type": "deep_researcher",
+            "input": "What are the latest advances in quantum computing?",
+            "expiry_seconds": 86400,
+        },
+    },
+    "scoped": {
+        "summary": "Scoped to specific data sources",
+        "value": {
+            "agent_type": "deep_researcher",
+            "input": "What are the latest advances in quantum computing?",
+            "data_sources": ["web_search"],
+        },
+    },
+}
 
 
 class JobStatusResponse(BaseModel):
@@ -279,10 +296,13 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         ),
         responses={
             400: {"description": "Unknown agent type or invalid request"},
+            422: {"description": "One or more unknown data source IDs"},
             503: {"description": "Dask scheduler not available"},
         },
     )
-    async def submit_job(req: JobSubmitRequest) -> JobStatusResponse:
+    async def submit_job(
+        req: Annotated[JobSubmitRequest, Body(openapi_examples=JOB_SUBMIT_EXAMPLES)],
+    ) -> JobStatusResponse:
         """Submit a new async job for deep research or other registered agents."""
         try:
             get_agent_config(req.agent_type)
@@ -290,6 +310,14 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
             raise HTTPException(400, str(e))
 
         expiry = req.expiry_seconds if req.expiry_seconds is not None else default_expiry_seconds
+        if req.data_sources is not None:
+            available_source_ids = {source.id.lower() for source in get_all_sources()}
+            invalid_source_ids = [
+                source_id for source_id in req.data_sources if source_id.lower() not in available_source_ids
+            ]
+            if invalid_source_ids:
+                raise HTTPException(422, f"Unknown data source(s): {', '.join(invalid_source_ids)}")
+
         principal = require_verified_principal()
 
         # Propagate auth token to Dask worker for requires_auth data sources
@@ -304,6 +332,7 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
                 principal=principal,
                 job_id=req.job_id,
                 expiry_seconds=expiry,
+                data_sources=req.data_sources,
                 auth_token=auth_token,
             )
         except RuntimeError as e:

--- a/frontends/aiq_api/tests/test_job_submit_data_sources.py
+++ b/frontends/aiq_api/tests/test_job_submit_data_sources.py
@@ -172,8 +172,11 @@ async def test_submit_job_rejects_unknown_data_sources(submit_app):
         )
 
     assert response.status_code == 422
-    assert "does_not_exist" in response.text
-    assert "also_missing" in response.text
+    assert response.json()["detail"] == {
+        "message": "Unknown data source(s): does_not_exist, also_missing",
+        "invalid_ids": ["does_not_exist", "also_missing"],
+        "known_ids": ["knowledge_layer", "web_search"],
+    }
     submitted_job.assert_not_awaited()
 
 
@@ -210,6 +213,9 @@ async def test_submit_job_mixed_valid_and_unknown_rejects_naming_only_unknown(su
         )
 
     assert response.status_code == 422
-    assert "does_not_exist" in response.text
-    assert "web_search" not in response.text
+    assert response.json()["detail"] == {
+        "message": "Unknown data source(s): does_not_exist",
+        "invalid_ids": ["does_not_exist"],
+        "known_ids": ["knowledge_layer", "web_search"],
+    }
     submitted_job.assert_not_awaited()

--- a/frontends/aiq_api/tests/test_job_submit_data_sources.py
+++ b/frontends/aiq_api/tests/test_job_submit_data_sources.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for async job submit data source targeting."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from aiq_agent.auth import Principal
+from aiq_agent.common.data_source_registry import populate_from_config
+from aiq_agent.common.data_source_registry import reset_registry
+
+
+@pytest.fixture(autouse=True)
+def data_source_registry():
+    """Provide deterministic data sources for submit route validation."""
+    reset_registry()
+    populate_from_config(
+        [
+            {
+                "id": "web_search",
+                "name": "Web Search",
+                "description": "Search the web.",
+                "tools": ["web_search_tool"],
+            },
+            {
+                "id": "knowledge_layer",
+                "name": "Knowledge Base",
+                "description": "Search uploaded documents.",
+                "tools": ["knowledge_search_tool"],
+            },
+        ]
+    )
+    yield
+    reset_registry()
+
+
+@pytest.fixture
+async def submit_app(monkeypatch):
+    """Build a minimal app with async submit routes and patched side effects."""
+    import aiq_agent.auth
+    import aiq_api.routes.jobs as jobs_routes
+
+    submitted_job = AsyncMock(return_value="job-1")
+    monkeypatch.setattr(jobs_routes, "_start_periodic_cleanup", MagicMock())
+
+    async def _no_op_reaper(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(jobs_routes, "_reap_ghost_jobs", _no_op_reaper)
+    monkeypatch.setattr(aiq_agent.auth, "get_auth_token", lambda: "token-1")
+
+    from aiq_api.jobs import access
+    from aiq_api.jobs import event_store
+    from aiq_api.jobs import submit
+
+    monkeypatch.setattr(access, "ensure_job_access_table", MagicMock())
+    monkeypatch.setattr(
+        access,
+        "require_verified_principal",
+        lambda: Principal(type="jwt", sub="user-1", email="user@example.com"),
+    )
+    monkeypatch.setattr(event_store.EventStore, "_ensure_table_exists", MagicMock())
+    monkeypatch.setattr(submit, "submit_agent_job", submitted_job)
+
+    worker = SimpleNamespace(
+        _dask_available=True,
+        _job_store=MagicMock(),
+        _scheduler_address="tcp://localhost:8786",
+        _db_url="sqlite:///./test.db",
+        _config_file_path="config.yml",
+        _log_level=20,
+        _use_dask_threads=False,
+        _front_end_config=SimpleNamespace(expiry_seconds=86400),
+    )
+
+    app = FastAPI()
+    await jobs_routes.register_job_routes(app, MagicMock(), worker)
+    return app, submitted_job
+
+
+@pytest.mark.asyncio
+async def test_submit_job_forwards_selected_data_sources(submit_app):
+    app, submitted_job = submit_app
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={"agent_type": "deep_researcher", "input": "query", "data_sources": ["web_search"]},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["job_id"] == "job-1"
+    submitted_job.assert_awaited_once()
+    assert submitted_job.await_args.kwargs["data_sources"] == ["web_search"]
+
+
+@pytest.mark.asyncio
+async def test_submit_job_omitted_data_sources_keeps_all_sources(submit_app):
+    app, submitted_job = submit_app
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={"agent_type": "deep_researcher", "input": "query"},
+        )
+
+    assert response.status_code == 200
+    assert submitted_job.await_args.kwargs["data_sources"] is None
+
+
+@pytest.mark.asyncio
+async def test_submit_job_explicit_null_data_sources_keeps_all_sources(submit_app):
+    """Explicit `null` in the JSON body must behave identically to field omission."""
+    app, submitted_job = submit_app
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={"agent_type": "deep_researcher", "input": "query", "data_sources": None},
+        )
+
+    assert response.status_code == 200
+    assert submitted_job.await_args.kwargs["data_sources"] is None
+
+
+@pytest.mark.asyncio
+async def test_submit_job_forwards_empty_data_sources(submit_app):
+    app, submitted_job = submit_app
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={"agent_type": "deep_researcher", "input": "query", "data_sources": []},
+        )
+
+    assert response.status_code == 200
+    assert submitted_job.await_args.kwargs["data_sources"] == []
+
+
+@pytest.mark.asyncio
+async def test_submit_job_rejects_unknown_data_sources(submit_app):
+    app, submitted_job = submit_app
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={
+                "agent_type": "deep_researcher",
+                "input": "query",
+                "data_sources": ["does_not_exist", "also_missing"],
+            },
+        )
+
+    assert response.status_code == 422
+    assert "does_not_exist" in response.text
+    assert "also_missing" in response.text
+    submitted_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_forwards_multiple_data_sources(submit_app):
+    app, submitted_job = submit_app
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={
+                "agent_type": "deep_researcher",
+                "input": "query",
+                "data_sources": ["web_search", "knowledge_layer"],
+            },
+        )
+
+    assert response.status_code == 200
+    assert submitted_job.await_args.kwargs["data_sources"] == ["web_search", "knowledge_layer"]
+
+
+@pytest.mark.asyncio
+async def test_submit_job_mixed_valid_and_unknown_rejects_naming_only_unknown(submit_app):
+    app, submitted_job = submit_app
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={
+                "agent_type": "deep_researcher",
+                "input": "query",
+                "data_sources": ["web_search", "does_not_exist"],
+            },
+        )
+
+    assert response.status_code == 422
+    assert "does_not_exist" in response.text
+    assert "web_search" not in response.text
+    submitted_job.assert_not_awaited()

--- a/frontends/aiq_api/tests/test_job_submit_data_sources.py
+++ b/frontends/aiq_api/tests/test_job_submit_data_sources.py
@@ -17,17 +17,20 @@
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
 import pytest
 from fastapi import FastAPI
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from aiq_agent.auth import Principal
 from aiq_agent.common.data_source_registry import populate_from_config
 from aiq_agent.common.data_source_registry import reset_registry
+from aiq_api.registry import AgentConfig
 
 
 @pytest.fixture(autouse=True)
@@ -63,6 +66,13 @@ async def submit_app(monkeypatch):
     submitted_job = AsyncMock(return_value="job-1")
     monkeypatch.setattr(jobs_routes, "_start_periodic_cleanup", MagicMock())
 
+    agent_config = AgentConfig(
+        class_path="aiq_agent.agents.deep_researcher.agent.DeepResearcherAgent",
+        config_name="deep_research_agent",
+        description="Test deep researcher",
+    )
+    monkeypatch.setattr(jobs_routes, "get_agent_config", lambda _agent_type: agent_config)
+
     async def _no_op_reaper(*_args, **_kwargs):
         return None
 
@@ -75,7 +85,7 @@ async def submit_app(monkeypatch):
 
     monkeypatch.setattr(access, "ensure_job_access_table", MagicMock())
     monkeypatch.setattr(
-        access,
+        jobs_routes,
         "require_verified_principal",
         lambda: Principal(type="jwt", sub="user-1", email="user@example.com"),
     )
@@ -93,14 +103,33 @@ async def submit_app(monkeypatch):
         _front_end_config=SimpleNamespace(expiry_seconds=86400),
     )
 
+    web_tool = SimpleNamespace(name="web_search_tool")
+    knowledge_tool = SimpleNamespace(name="knowledge_search_tool")
+    # Map tool names to their LangChain-wrapper stand-ins. The mock get_tools
+    # below filters by tool_names so the validator's "tools=None means inherit
+    # all registry refs" branch is actually exercised by the test suite.
+    tools_by_name: dict[str, SimpleNamespace] = {
+        "web_search_tool": web_tool,
+        "knowledge_search_tool": knowledge_tool,
+    }
+
+    async def _filtered_get_tools(*, tool_names, wrapper_type):  # noqa: ARG001 - mirror real signature
+        return [tools_by_name[name] for name in tool_names if name in tools_by_name]
+
+    builder = MagicMock()
+    # Realistic default for researcher agents: tools=None means "inherit all
+    # registry refs," which the validator resolves via get_all_tool_refs().
+    builder.get_function_config.return_value = SimpleNamespace(tools=None, exclude_tools=[])
+    builder.get_tools = AsyncMock(side_effect=_filtered_get_tools)
+
     app = FastAPI()
-    await jobs_routes.register_job_routes(app, MagicMock(), worker)
-    return app, submitted_job
+    await jobs_routes.register_job_routes(app, builder, worker)
+    return app, submitted_job, builder
 
 
 @pytest.mark.asyncio
 async def test_submit_job_forwards_selected_data_sources(submit_app):
-    app, submitted_job = submit_app
+    app, submitted_job, builder = submit_app
 
     with TestClient(app) as client:
         response = client.post(
@@ -116,7 +145,7 @@ async def test_submit_job_forwards_selected_data_sources(submit_app):
 
 @pytest.mark.asyncio
 async def test_submit_job_omitted_data_sources_keeps_all_sources(submit_app):
-    app, submitted_job = submit_app
+    app, submitted_job, builder = submit_app
 
     with TestClient(app) as client:
         response = client.post(
@@ -131,7 +160,7 @@ async def test_submit_job_omitted_data_sources_keeps_all_sources(submit_app):
 @pytest.mark.asyncio
 async def test_submit_job_explicit_null_data_sources_keeps_all_sources(submit_app):
     """Explicit `null` in the JSON body must behave identically to field omission."""
-    app, submitted_job = submit_app
+    app, submitted_job, builder = submit_app
 
     with TestClient(app) as client:
         response = client.post(
@@ -145,7 +174,7 @@ async def test_submit_job_explicit_null_data_sources_keeps_all_sources(submit_ap
 
 @pytest.mark.asyncio
 async def test_submit_job_forwards_empty_data_sources(submit_app):
-    app, submitted_job = submit_app
+    app, submitted_job, builder = submit_app
 
     with TestClient(app) as client:
         response = client.post(
@@ -159,7 +188,7 @@ async def test_submit_job_forwards_empty_data_sources(submit_app):
 
 @pytest.mark.asyncio
 async def test_submit_job_rejects_unknown_data_sources(submit_app):
-    app, submitted_job = submit_app
+    app, submitted_job, builder = submit_app
 
     with TestClient(app) as client:
         response = client.post(
@@ -175,14 +204,232 @@ async def test_submit_job_rejects_unknown_data_sources(submit_app):
     assert response.json()["detail"] == {
         "message": "Unknown data source(s): does_not_exist, also_missing",
         "invalid_ids": ["does_not_exist", "also_missing"],
+        "unavailable_for_agent": [],
         "known_ids": ["knowledge_layer", "web_search"],
     }
     submitted_job.assert_not_awaited()
 
 
 @pytest.mark.asyncio
+async def test_submit_job_rejects_source_unavailable_for_agent(submit_app):
+    app, submitted_job, builder = submit_app
+    builder.get_function_config.return_value = SimpleNamespace(
+        tools=None,
+        exclude_tools=["web_search_tool"],
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={"agent_type": "deep_researcher", "input": "query", "data_sources": ["web_search"]},
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == {
+        "message": "Data source(s) are not available for agent 'deep_researcher': web_search",
+        "invalid_ids": [],
+        "unavailable_for_agent": ["web_search"],
+        "known_ids": ["knowledge_layer", "web_search"],
+    }
+    submitted_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_rejects_mixed_available_and_agent_unavailable_sources(submit_app):
+    app, submitted_job, builder = submit_app
+    builder.get_function_config.return_value = SimpleNamespace(tools=None, exclude_tools=["web_search_tool"])
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={
+                "agent_type": "deep_researcher",
+                "input": "query",
+                "data_sources": ["web_search", "knowledge_layer"],
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == {
+        "message": "Data source(s) are not available for agent 'deep_researcher': web_search",
+        "invalid_ids": [],
+        "unavailable_for_agent": ["web_search"],
+        "known_ids": ["knowledge_layer", "web_search"],
+    }
+    submitted_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_rejects_combined_unknown_and_agent_unavailable_sources(submit_app):
+    app, submitted_job, builder = submit_app
+    builder.get_function_config.return_value = SimpleNamespace(tools=None, exclude_tools=["web_search_tool"])
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={
+                "agent_type": "deep_researcher",
+                "input": "query",
+                "data_sources": ["does_not_exist", "web_search"],
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == {
+        "message": (
+            "Unknown data source(s): does_not_exist. "
+            "Data source(s) are not available for agent 'deep_researcher': web_search"
+        ),
+        "invalid_ids": ["does_not_exist"],
+        "unavailable_for_agent": ["web_search"],
+        "known_ids": ["knowledge_layer", "web_search"],
+    }
+    submitted_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_dedupes_problematic_ids_preserving_first_seen_order_and_casing(submit_app):
+    app, submitted_job, builder = submit_app
+    builder.get_function_config.return_value = SimpleNamespace(tools=None, exclude_tools=["web_search_tool"])
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={
+                "agent_type": "deep_researcher",
+                "input": "query",
+                "data_sources": ["Missing", "web_search", "missing", "WEB_SEARCH"],
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == {
+        "message": (
+            "Unknown data source(s): Missing. Data source(s) are not available for agent 'deep_researcher': web_search"
+        ),
+        "invalid_ids": ["Missing"],
+        "unavailable_for_agent": ["web_search"],
+        "known_ids": ["knowledge_layer", "web_search"],
+    }
+    submitted_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_rejects_known_source_when_agent_has_no_available_sources(submit_app):
+    app, submitted_job, builder = submit_app
+    builder.get_function_config.return_value = SimpleNamespace(
+        tools=None,
+        exclude_tools=["web_search_tool", "knowledge_search_tool"],
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={"agent_type": "deep_researcher", "input": "query", "data_sources": ["web_search"]},
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == {
+        "message": "Data source(s) are not available for agent 'deep_researcher': web_search",
+        "invalid_ids": [],
+        "unavailable_for_agent": ["web_search"],
+        "known_ids": ["knowledge_layer", "web_search"],
+    }
+    submitted_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_forwards_omitted_data_sources_without_resolving_tools(submit_app):
+    app, submitted_job, builder = submit_app
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={"agent_type": "deep_researcher", "input": "query"},
+        )
+
+    assert response.status_code == 200
+    builder.get_function_config.assert_not_called()
+    builder.get_tools.assert_not_awaited()
+    submitted_job.assert_awaited_once()
+    _, kwargs = submitted_job.await_args
+    assert kwargs["data_sources"] is None
+
+
+@pytest.mark.asyncio
+async def test_submit_job_forwards_null_data_sources_without_resolving_tools(submit_app):
+    app, submitted_job, builder = submit_app
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={"agent_type": "deep_researcher", "input": "query", "data_sources": None},
+        )
+
+    assert response.status_code == 200
+    builder.get_function_config.assert_not_called()
+    builder.get_tools.assert_not_awaited()
+    submitted_job.assert_awaited_once()
+    _, kwargs = submitted_job.await_args
+    assert kwargs["data_sources"] is None
+
+
+@pytest.mark.asyncio
+async def test_submit_job_forwards_valid_data_sources_exactly_as_provided(submit_app):
+    app, submitted_job, builder = submit_app
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={
+                "agent_type": "deep_researcher",
+                "input": "query",
+                "data_sources": ["WEB_SEARCH", "web_search", "knowledge_layer"],
+            },
+        )
+
+    assert response.status_code == 200
+    submitted_job.assert_awaited_once()
+    _, kwargs = submitted_job.await_args
+    assert kwargs["data_sources"] == ["WEB_SEARCH", "web_search", "knowledge_layer"]
+
+
+@pytest.mark.asyncio
+async def test_submit_job_validates_sources_for_shallow_researcher(submit_app, monkeypatch):
+    app, submitted_job, builder = submit_app
+    import aiq_api.routes.jobs as jobs_routes
+
+    shallow_config = AgentConfig(
+        class_path="aiq_agent.agents.shallow_researcher.agent.ShallowResearcherAgent",
+        config_name="shallow_research_agent",
+        description="Test shallow researcher",
+    )
+    monkeypatch.setattr(jobs_routes, "get_agent_config", lambda _agent_type: shallow_config)
+    builder.get_function_config.return_value = SimpleNamespace(
+        tools=None,
+        exclude_tools=["web_search_tool"],
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={"agent_type": "shallow_researcher", "input": "query", "data_sources": ["web_search"]},
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == {
+        "message": "Data source(s) are not available for agent 'shallow_researcher': web_search",
+        "invalid_ids": [],
+        "unavailable_for_agent": ["web_search"],
+        "known_ids": ["knowledge_layer", "web_search"],
+    }
+    submitted_job.assert_not_awaited()
+    builder.get_function_config.assert_called_with("shallow_research_agent")
+
+
+@pytest.mark.asyncio
 async def test_submit_job_forwards_multiple_data_sources(submit_app):
-    app, submitted_job = submit_app
+    app, submitted_job, builder = submit_app
 
     with TestClient(app) as client:
         response = client.post(
@@ -200,7 +447,7 @@ async def test_submit_job_forwards_multiple_data_sources(submit_app):
 
 @pytest.mark.asyncio
 async def test_submit_job_mixed_valid_and_unknown_rejects_naming_only_unknown(submit_app):
-    app, submitted_job = submit_app
+    app, submitted_job, builder = submit_app
 
     with TestClient(app) as client:
         response = client.post(
@@ -216,6 +463,156 @@ async def test_submit_job_mixed_valid_and_unknown_rejects_naming_only_unknown(su
     assert response.json()["detail"] == {
         "message": "Unknown data source(s): does_not_exist",
         "invalid_ids": ["does_not_exist"],
+        "unavailable_for_agent": [],
         "known_ids": ["knowledge_layer", "web_search"],
     }
     submitted_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_auth_runs_before_data_source_validation(submit_app, monkeypatch):
+    app, submitted_job, builder = submit_app
+    import aiq_api.routes.jobs as jobs_routes
+
+    def _deny():
+        raise HTTPException(status_code=403, detail="auth required")
+
+    monkeypatch.setattr(jobs_routes, "require_verified_principal", _deny)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={"agent_type": "deep_researcher", "input": "query", "data_sources": ["does_not_exist"]},
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "auth required"
+    builder.get_tools.assert_not_awaited()
+    submitted_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_agent_type_validation_runs_before_auth(submit_app, monkeypatch):
+    app, submitted_job, builder = submit_app
+    import aiq_api.routes.jobs as jobs_routes
+
+    def _deny():
+        raise HTTPException(status_code=403, detail="auth required")
+
+    monkeypatch.setattr(jobs_routes, "require_verified_principal", _deny)
+    monkeypatch.setattr(
+        jobs_routes,
+        "get_agent_config",
+        lambda _agent_type: (_ for _ in ()).throw(KeyError("unknown agent")),
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={"agent_type": "nonexistent_agent", "input": "query"},
+        )
+
+    assert response.status_code == 400
+    builder.get_tools.assert_not_awaited()
+    submitted_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_returns_500_when_validation_tool_resolution_fails_for_known_source(submit_app, caplog):
+    app, submitted_job, builder = submit_app
+    builder.get_tools.side_effect = RuntimeError("tool resolution failed")
+    caplog.set_level(logging.ERROR, logger="aiq_api.routes.jobs")
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={"agent_type": "deep_researcher", "input": "query", "data_sources": ["web_search"]},
+        )
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to validate data sources for selected agent"
+    assert "Failed to validate data sources for agent deep_researcher using config deep_research_agent" in caplog.text
+    submitted_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_submit_job_returns_500_when_validation_tool_resolution_fails_for_unknown_source(submit_app):
+    app, submitted_job, builder = submit_app
+    builder.get_tools.side_effect = RuntimeError("tool resolution failed")
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={"agent_type": "deep_researcher", "input": "query", "data_sources": ["does_not_exist"]},
+        )
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to validate data sources for selected agent"
+    submitted_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_validation_calls_get_all_tool_refs_when_fn_config_tools_is_none(submit_app, monkeypatch):
+    """Regression test: ``tools is None`` must inherit refs via ``get_all_tool_refs``.
+
+    The fixture's default ``tools=None`` exercises this branch, but no other
+    test asserts the exact call. This pins the contract so future refactors
+    that swap the inheritance mechanism (e.g. caching, alternate registries)
+    surface here instead of silently changing agent capability resolution.
+    """
+    app, submitted_job, builder = submit_app
+    # Default fixture is tools=None, exclude_tools=[]. Spy on the name as bound
+    # in the routes module (Python testing idiom: patch where used, not where
+    # defined).
+    import aiq_api.routes.jobs as jobs_routes
+
+    spy = MagicMock(wraps=jobs_routes.get_all_tool_refs)
+    monkeypatch.setattr(jobs_routes, "get_all_tool_refs", spy)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={"agent_type": "deep_researcher", "input": "query", "data_sources": ["web_search"]},
+        )
+
+    assert response.status_code == 200
+    spy.assert_called_once()
+    # Sanity check: the spy returned the registry-populated tool refs and the
+    # builder was asked to resolve those exact refs via LangChain wrappers.
+    builder.get_tools.assert_awaited_once()
+    _, kwargs = builder.get_tools.await_args
+    assert sorted(kwargs["tool_names"]) == ["knowledge_search_tool", "web_search_tool"]
+    submitted_job.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_validation_does_not_call_get_all_tool_refs_when_fn_config_tools_is_explicit(submit_app, monkeypatch):
+    """Regression test: explicit ``tools=[...]`` must override registry inheritance.
+
+    Mirror of the test above for the opposite branch: when the agent declares
+    an explicit tool list, the validator must use it verbatim and skip the
+    inheritance call entirely.
+    """
+    app, submitted_job, builder = submit_app
+    builder.get_function_config.return_value = SimpleNamespace(
+        tools=["knowledge_search_tool"],
+        exclude_tools=[],
+    )
+
+    import aiq_api.routes.jobs as jobs_routes
+
+    spy = MagicMock(wraps=jobs_routes.get_all_tool_refs)
+    monkeypatch.setattr(jobs_routes, "get_all_tool_refs", spy)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={"agent_type": "deep_researcher", "input": "query", "data_sources": ["knowledge_layer"]},
+        )
+
+    assert response.status_code == 200
+    spy.assert_not_called()
+    builder.get_tools.assert_awaited_once()
+    _, kwargs = builder.get_tools.await_args
+    assert kwargs["tool_names"] == ["knowledge_search_tool"]
+    submitted_job.assert_awaited_once()

--- a/src/aiq_agent/agents/clarifier/register.py
+++ b/src/aiq_agent/agents/clarifier/register.py
@@ -37,6 +37,7 @@ from pydantic import Field
 
 from aiq_agent.common import LLMProvider
 from aiq_agent.common import VerboseTraceCallback
+from aiq_agent.common import all_mapped_tools_filtered_out
 from aiq_agent.common import filter_tools_by_sources
 from aiq_agent.common import is_verbose
 from nat.builder.builder import Builder
@@ -225,7 +226,8 @@ async def clarifier_agent(config: ClarifierConfig, builder: Builder):
                 verbose=verbose,
                 callbacks=callbacks,
             )
-        elif data_sources is not None and not selected_tools:
+
+        if all_mapped_tools_filtered_out(tools, selected_tools, data_sources):
             logger.warning("Clarifier received data_sources with no matching tools")
         return await active_agent.run(state)
 

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -175,7 +175,7 @@ class DeepResearcherAgent:
                 return source_list
             return "No sources captured yet. Run research queries first."
 
-        self.all_tools = [think, get_verified_sources, *self.tools]
+        self.all_tools = [think, get_verified_sources, *self.tools] if self.tools else []
 
         self.middleware = [
             EmptyContentFixMiddleware(),

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -175,7 +175,7 @@ class DeepResearcherAgent:
                 return source_list
             return "No sources captured yet. Run research queries first."
 
-        self.all_tools = [think, get_verified_sources, *self.tools] if self.tools else []
+        self.all_tools = [think, get_verified_sources, *self.tools]
 
         self.middleware = [
             EmptyContentFixMiddleware(),

--- a/src/aiq_agent/agents/deep_researcher/register.py
+++ b/src/aiq_agent/agents/deep_researcher/register.py
@@ -24,6 +24,7 @@ from aiq_agent.common import LLMProvider
 from aiq_agent.common import LLMRole
 from aiq_agent.common import VerboseTraceCallback
 from aiq_agent.common import _create_chat_response
+from aiq_agent.common import all_mapped_tools_filtered_out
 from aiq_agent.common import filter_tools_by_sources
 from aiq_agent.common import is_verbose
 from nat.builder.builder import Builder
@@ -148,7 +149,8 @@ async def deep_research_agent(config: DeepResearchAgentConfig, builder: Builder)
                     sandbox=config.sandbox,
                     job_id=job_id,
                 )
-            elif data_sources is not None and not selected_tools:
+
+            if all_mapped_tools_filtered_out(tools, selected_tools, data_sources):
                 logger.warning("Deep research received data_sources with no matching tools")
 
             # Validate tool availability before starting deep research

--- a/src/aiq_agent/agents/shallow_researcher/register.py
+++ b/src/aiq_agent/agents/shallow_researcher/register.py
@@ -23,6 +23,7 @@ from pydantic import Field
 from aiq_agent.common import LLMProvider
 from aiq_agent.common import VerboseTraceCallback
 from aiq_agent.common import _create_chat_response
+from aiq_agent.common import all_mapped_tools_filtered_out
 from aiq_agent.common import filter_tools_by_sources
 from aiq_agent.common import is_verbose
 from nat.builder.builder import Builder
@@ -115,7 +116,8 @@ async def shallow_research_agent(config: ShallowResearchAgentConfig, builder: Bu
                     max_tool_iterations=config.max_tool_iterations,
                     callbacks=callbacks,
                 )
-            elif data_sources is not None and not selected_tools:
+
+            if all_mapped_tools_filtered_out(tools, selected_tools, data_sources):
                 logger.warning("Shallow research received data_sources with no matching tools")
 
             # Validate tool availability before starting shallow research

--- a/src/aiq_agent/common/__init__.py
+++ b/src/aiq_agent/common/__init__.py
@@ -46,6 +46,7 @@ from .citation_verification import verify_citations
 from .data_source_registry import get_all_tool_refs
 from .data_source_registry import get_source_id_for_tool
 from .data_sources import DEFAULT_DATA_SOURCES
+from .data_sources import all_mapped_tools_filtered_out
 from .data_sources import extract_messages_and_sources
 from .data_sources import filter_tools_by_sources
 from .data_sources import format_data_source_tools
@@ -72,6 +73,7 @@ __all__ = [
     "LLMRole",
     "SourceRegistry",
     "VerboseTraceCallback",
+    "all_mapped_tools_filtered_out",
     "extract_json",
     "extract_messages_and_sources",
     "filter_tools_by_sources",

--- a/src/aiq_agent/common/data_sources.py
+++ b/src/aiq_agent/common/data_sources.py
@@ -37,7 +37,7 @@ def parse_data_sources(raw: Any) -> list[str] | None:
 
     Returns:
         - None if input is None (not specified, use all tools)
-        - Empty list [] if input was explicitly empty (no tools)
+        - Empty list [] if input was explicitly empty (no data-source tools)
         - List of data source IDs if specified
     """
     if raw is None:
@@ -59,21 +59,18 @@ def filter_tools_by_sources(tools: list[Any], data_sources: list[str] | None) ->
     """Filter tools based on selected data sources.
 
     Uses the tool->source map built at startup from config ``data_source`` fields.
-    Tools without a mapping (e.g. "think", calculator) are included when
-    filtering to one or more selected sources. An explicit empty list disables
-    all tools.
+    Tools without a mapping (e.g. "think", calculator) are always included.
 
     Args:
         tools: List of LangChain tools.
-        data_sources: List of selected data source IDs, None for all, or [] for no tools.
+        data_sources: List of selected data source IDs, None for all data-source
+            tools, or [] for no data-source tools.
 
     Returns:
         Filtered list of tools matching the selected data sources.
     """
     if data_sources is None:
         return tools
-    if len(data_sources) == 0:
-        return []
 
     selected = {s.lower() for s in data_sources}
     filtered = []
@@ -81,11 +78,43 @@ def filter_tools_by_sources(tools: list[Any], data_sources: list[str] | None) ->
         name = getattr(tool, "name", "")
         source_id = get_source_id_for_tool(name)
         if source_id is None:
-            # Not a data source tool (e.g., "think", calculator) -> include when filtering to sources
+            # Not a data source tool (e.g., "think", calculator) -> always include.
             filtered.append(tool)
         elif source_id.lower() in selected:
             filtered.append(tool)
     return filtered
+
+
+def all_mapped_tools_filtered_out(
+    tools: list[Any],
+    selected_tools: list[Any],
+    data_sources: list[str] | None,
+) -> bool:
+    """Return True when filtering dropped every data-source-mapped tool.
+
+    Useful for emitting a diagnostic when a caller passed ``data_sources`` but
+    the filter produced no mapped tools (e.g. ``data_sources=[]`` with mapped
+    tools configured, or ``data_sources=["unknown"]`` that matched nothing).
+    Returns False when ``data_sources is None`` (no filtering requested) or
+    when the original tool list had no mapped tools to filter in the first
+    place.
+
+    Args:
+        tools: Full tool list before filtering.
+        selected_tools: Tool list after ``filter_tools_by_sources``.
+        data_sources: The ``data_sources`` argument passed to the filter.
+
+    Returns:
+        True if ``data_sources`` was specified, ``tools`` contained at least
+        one mapped tool, and zero mapped tools survived the filter.
+    """
+    if data_sources is None:
+        return False
+    had_mapped = any(get_source_id_for_tool(getattr(t, "name", "")) is not None for t in tools)
+    if not had_mapped:
+        return False
+    still_has_mapped = any(get_source_id_for_tool(getattr(t, "name", "")) is not None for t in selected_tools)
+    return not still_has_mapped
 
 
 def extract_messages_and_sources(payload: Any) -> tuple[list[BaseMessage], list[str] | None]:

--- a/src/aiq_agent/common/data_sources.py
+++ b/src/aiq_agent/common/data_sources.py
@@ -59,11 +59,13 @@ def filter_tools_by_sources(tools: list[Any], data_sources: list[str] | None) ->
     """Filter tools based on selected data sources.
 
     Uses the tool->source map built at startup from config ``data_source`` fields.
-    Tools without a mapping (e.g. "think", calculator) are always included.
+    Tools without a mapping (e.g. "think", calculator) are included when
+    filtering to one or more selected sources. An explicit empty list disables
+    all tools.
 
     Args:
         tools: List of LangChain tools.
-        data_sources: List of selected data source IDs, None for all, or [] for none.
+        data_sources: List of selected data source IDs, None for all, or [] for no tools.
 
     Returns:
         Filtered list of tools matching the selected data sources.
@@ -79,7 +81,7 @@ def filter_tools_by_sources(tools: list[Any], data_sources: list[str] | None) ->
         name = getattr(tool, "name", "")
         source_id = get_source_id_for_tool(name)
         if source_id is None:
-            # Not a data source tool (e.g., "think", calculator) -> always include
+            # Not a data source tool (e.g., "think", calculator) -> include when filtering to sources
             filtered.append(tool)
         elif source_id.lower() in selected:
             filtered.append(tool)

--- a/tests/aiq_agent/common/test_data_sources.py
+++ b/tests/aiq_agent/common/test_data_sources.py
@@ -140,14 +140,16 @@ class TestFilterToolsBySourcesBasic:
         result = filter_tools_by_sources(tools, None)
         assert result == tools
 
-    def test_filter_empty_sources_returns_empty(self):
-        """Test that empty data_sources disables all tools."""
+    def test_filter_empty_sources_keeps_unmapped_tools(self):
+        """Test that empty data_sources disables source tools but keeps unmapped tools."""
         web_tool = MagicMock()
         web_tool.name = "web_search_tool"
         knowledge_tool = MagicMock()
         knowledge_tool.name = "knowledge_search"
-        result = filter_tools_by_sources([web_tool, knowledge_tool], [])
-        assert result == []
+        calculator = MagicMock()
+        calculator.name = "calculator"
+        result = filter_tools_by_sources([web_tool, knowledge_tool, calculator], [])
+        assert result == [calculator]
 
 
 class TestFilterToolsBySourcesWebSearch:
@@ -379,3 +381,51 @@ class TestDefaultDataSources:
     def test_default_is_list(self):
         """Test that default is a list."""
         assert isinstance(DEFAULT_DATA_SOURCES, list)
+
+
+class TestAllMappedToolsFilteredOut:
+    """Tests for all_mapped_tools_filtered_out predicate."""
+
+    def test_none_data_sources_returns_false(self):
+        """None means no filtering; nothing was filtered out."""
+        from aiq_agent.common.data_sources import all_mapped_tools_filtered_out
+
+        web_tool = MagicMock()
+        web_tool.name = "web_search_tool"
+        assert all_mapped_tools_filtered_out([web_tool], [web_tool], None) is False
+
+    def test_no_mapped_tools_in_input_returns_false(self):
+        """If the tools list had no mapped tools to begin with, nothing was lost."""
+        from aiq_agent.common.data_sources import all_mapped_tools_filtered_out
+
+        calculator = MagicMock()
+        calculator.name = "calculator"
+        assert all_mapped_tools_filtered_out([calculator], [calculator], ["web_search"]) is False
+
+    def test_empty_sources_drops_all_mapped_returns_true(self):
+        """data_sources=[] drops every mapped tool -> predicate fires."""
+        from aiq_agent.common.data_sources import all_mapped_tools_filtered_out
+
+        web_tool = MagicMock()
+        web_tool.name = "web_search_tool"
+        calculator = MagicMock()
+        calculator.name = "calculator"
+        assert all_mapped_tools_filtered_out([web_tool, calculator], [calculator], []) is True
+
+    def test_unknown_source_drops_all_mapped_returns_true(self):
+        """User requested a source that matches zero configured tools."""
+        from aiq_agent.common.data_sources import all_mapped_tools_filtered_out
+
+        web_tool = MagicMock()
+        web_tool.name = "web_search_tool"
+        assert all_mapped_tools_filtered_out([web_tool], [], ["nonexistent_source"]) is True
+
+    def test_some_mapped_tools_survive_returns_false(self):
+        """At least one mapped tool survived -> predicate does not fire."""
+        from aiq_agent.common.data_sources import all_mapped_tools_filtered_out
+
+        web_tool = MagicMock()
+        web_tool.name = "web_search_tool"
+        knowledge_tool = MagicMock()
+        knowledge_tool.name = "knowledge_search"
+        assert all_mapped_tools_filtered_out([web_tool, knowledge_tool], [web_tool], ["web_search"]) is False

--- a/tests/aiq_agent/common/test_data_sources.py
+++ b/tests/aiq_agent/common/test_data_sources.py
@@ -141,7 +141,7 @@ class TestFilterToolsBySourcesBasic:
         assert result == tools
 
     def test_filter_empty_sources_returns_empty(self):
-        """Test that empty data_sources excludes web and knowledge tools (only 'other' tools included)."""
+        """Test that empty data_sources disables all tools."""
         web_tool = MagicMock()
         web_tool.name = "web_search_tool"
         knowledge_tool = MagicMock()

--- a/tests/aiq_agent/fastapi_extensions/test_deep_research.py
+++ b/tests/aiq_agent/fastapi_extensions/test_deep_research.py
@@ -88,7 +88,7 @@ class TestJobSubmitRequest:
         assert req.data_sources is None
 
     def test_empty_data_sources_accepted(self):
-        """Test that empty data_sources is accepted as a deliberate 'no tools' signal."""
+        """Test that empty data_sources is accepted as a deliberate 'no data-source tools' signal."""
         req = JobSubmitRequest(agent_type="deep_researcher", input="query", data_sources=[])
 
         assert req.data_sources == []

--- a/tests/aiq_agent/fastapi_extensions/test_deep_research.py
+++ b/tests/aiq_agent/fastapi_extensions/test_deep_research.py
@@ -73,6 +73,25 @@ class TestJobSubmitRequest:
         assert req.agent_type == "deep_researcher"
         assert req.job_id is None
         assert req.expiry_seconds is None
+        assert req.data_sources is None
+
+    def test_with_data_sources(self):
+        """Test submit request with selected data sources."""
+        req = JobSubmitRequest(agent_type="deep_researcher", input="query", data_sources=["web_search"])
+
+        assert req.data_sources == ["web_search"]
+
+    def test_null_data_sources_defaults_to_all_sources(self):
+        """Test null data_sources preserves all-source behavior."""
+        req = JobSubmitRequest(agent_type="deep_researcher", input="query", data_sources=None)
+
+        assert req.data_sources is None
+
+    def test_empty_data_sources_accepted(self):
+        """Test that empty data_sources is accepted as a deliberate 'no tools' signal."""
+        req = JobSubmitRequest(agent_type="deep_researcher", input="query", data_sources=[])
+
+        assert req.data_sources == []
 
     def test_with_custom_job_id(self):
         """Test submit request with custom job ID."""

--- a/tests/aiq_agent/jobs/test_runner.py
+++ b/tests/aiq_agent/jobs/test_runner.py
@@ -1429,6 +1429,44 @@ class TestAsyncJobRunnerAgentFactory:
         assert "data-table-analysis" not in kwargs["system_prompt"]
         assert agent.deepagents_runtime.job_id == "async-job-123"
 
+    def test_async_deep_researcher_empty_tools_disables_internal_tools(self):
+        """Explicit empty data_sources must not leave DeepResearcher helper tools enabled."""
+        from langchain_core.messages import HumanMessage
+
+        from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+        from aiq_agent.agents.deep_researcher.models import DeepResearchAgentState
+        from aiq_agent.agents.deep_researcher.register import DeepResearchAgentConfig
+        from aiq_agent.common import LLMProvider
+        from aiq_agent.common import LLMRole
+        from aiq_api.jobs.runner import _create_agent_instance
+
+        mock_llm = MagicMock()
+        provider = LLMProvider()
+        provider.set_default(mock_llm)
+        provider.configure(LLMRole.ORCHESTRATOR, mock_llm)
+        provider.configure(LLMRole.PLANNER, mock_llm)
+        provider.configure(LLMRole.RESEARCHER, mock_llm)
+        mock_deep_agent = MagicMock()
+        mock_deep_agent.with_config.return_value = mock_deep_agent
+
+        with patch("aiq_agent.agents.deep_researcher.agent.create_deep_agent", return_value=mock_deep_agent) as create:
+            agent = _create_agent_instance(
+                agent_cls=DeepResearcherAgent,
+                llm_provider=provider,
+                llm=mock_llm,
+                tools=[],
+                fn_config=DeepResearchAgentConfig(orchestrator_llm="llm"),
+                verbose=False,
+                callbacks=[],
+                job_id="async-job-123",
+            )
+            state = DeepResearchAgentState(messages=[HumanMessage(content="Research without tools")])
+            agent._build_orchestrator_agent(state)
+
+        assert create.call_args.kwargs["tools"] == []
+        assert create.call_args.kwargs["subagents"][0]["tools"] == []
+        assert create.call_args.kwargs["subagents"][1]["tools"] == []
+
     def test_create_agent_instance_does_not_drop_config_on_internal_type_error(self):
         """Constructor bugs must not silently fall back to no-config construction."""
         from aiq_agent.agents.deep_researcher.deepagents_runtime import SandboxConfig

--- a/tests/aiq_agent/jobs/test_runner.py
+++ b/tests/aiq_agent/jobs/test_runner.py
@@ -1429,8 +1429,8 @@ class TestAsyncJobRunnerAgentFactory:
         assert "data-table-analysis" not in kwargs["system_prompt"]
         assert agent.deepagents_runtime.job_id == "async-job-123"
 
-    def test_async_deep_researcher_empty_tools_disables_internal_tools(self):
-        """Explicit empty data_sources must not leave DeepResearcher helper tools enabled."""
+    def test_async_deep_researcher_empty_data_sources_keeps_internal_tools(self):
+        """Explicit empty data_sources disables source tools but keeps DeepResearcher helpers."""
         from langchain_core.messages import HumanMessage
 
         from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
@@ -1463,9 +1463,10 @@ class TestAsyncJobRunnerAgentFactory:
             state = DeepResearchAgentState(messages=[HumanMessage(content="Research without tools")])
             agent._build_orchestrator_agent(state)
 
-        assert create.call_args.kwargs["tools"] == []
-        assert create.call_args.kwargs["subagents"][0]["tools"] == []
-        assert create.call_args.kwargs["subagents"][1]["tools"] == []
+        tool_names = [tool.name for tool in create.call_args.kwargs["tools"]]
+        assert tool_names == ["think", "get_verified_sources"]
+        assert [tool.name for tool in create.call_args.kwargs["subagents"][0]["tools"]] == tool_names
+        assert [tool.name for tool in create.call_args.kwargs["subagents"][1]["tools"]] == tool_names
 
     def test_create_agent_instance_does_not_drop_config_on_internal_type_error(self):
         """Constructor bugs must not silently fall back to no-config construction."""


### PR DESCRIPTION
## Summary
- Adds issue 214 data sources job submit handling.

## Note
- REST `data_sources: []` intentionally means no tools at all. Tools not listed in any data source entry (e.g., utility tools like "think") are always included regardless of filtering
- WebSocket semantics are not being aligned in this PR; alignment will be handled in a follow-up.