### PR TITLE
fix problem in websocket with expired access token

### DIFF
--- a/frontends/aiq_api/src/aiq_api/websocket_reconnect.py
+++ b/frontends/aiq_api/src/aiq_api/websocket_reconnect.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 import uuid
 from typing import Any
 
@@ -205,6 +206,56 @@ class ReconnectableWebSocketMessageHandler(WebSocketMessageHandler):
         self._user_interaction_response: asyncio.Future[TextContent] | None = None
         self._authenticated_user: dict[str, Any] | None = None
 
+    def _is_handshake_token_expired(self) -> bool:
+        """Return True if the JWT used at handshake has since passed its ``exp``.
+
+        Backend stores verified JWT claims in ``_authenticated_user`` after the
+        handshake (see ``JWTValidator.validate``). The ``exp`` claim is seconds
+        since epoch. We re-check it on every inbound message so a long-lived
+        socket cannot keep accepting work indefinitely under a dead token --
+        WebSocket browsers do NOT replay HTTP cookies on subsequent frames, so
+        the only way to refresh credentials is to close + reopen the socket.
+
+        Internal/anonymous callers do not carry an ``exp`` claim; for them
+        this returns ``False`` (no re-auth required).
+        """
+        user = self._authenticated_user
+        if not user:
+            return False
+        exp = user.get("exp")
+        if not isinstance(exp, (int, float)):
+            return False
+        return time.time() >= exp
+
+    async def _send_auth_expired_error(self, conversation_id: str | None) -> None:
+        """Notify the client that its handshake token has expired.
+
+        The client (frontend) listens for ``message == "auth_expired"`` on the
+        ERROR channel and reacts by refreshing the NextAuth session, closing
+        the socket, and reconnecting. The fresh handshake carries an updated
+        idToken cookie. After the new socket is open, the client drains any
+        buffered outgoing message it had queued during the rotation.
+        """
+        error = Error(
+            code=ErrorTypes.USER_AUTH_ERROR,
+            message="auth_expired",
+            details="Handshake token has expired; reconnect to refresh credentials.",
+        )
+        try:
+            error_message = await self._message_validator.create_system_response_token_message(
+                message_type=WebSocketMessageType.ERROR_MESSAGE,
+                conversation_id=conversation_id,
+                content=error,
+            )
+        except Exception:  # pragma: no cover - validator never fails on this contract
+            logger.exception("Failed to build auth_expired error message")
+            return
+
+        try:
+            await self._socket.send_json(error_message.model_dump())
+        except Exception as exc:  # pragma: no cover - socket may already be closed
+            logger.warning("Failed to send auth_expired: %s", exc)
+
     async def run(self) -> None:
         """Process websocket messages and allow reconnect HITL responses."""
         if self._authenticated_user is None:
@@ -219,6 +270,17 @@ class ReconnectableWebSocketMessageHandler(WebSocketMessageHandler):
                 validated_message: BaseModel = await self._message_validator.validate_message(message)
 
                 if isinstance(validated_message, WebSocketUserMessage):
+                    # Per-message re-auth: the handshake-time JWT may have
+                    # expired since the socket was opened. Reject the work
+                    # and ask the client to reconnect with a fresh token.
+                    if self._is_handshake_token_expired():
+                        logger.info(
+                            "Rejecting user_message: handshake token expired (conversation %s)",
+                            validated_message.conversation_id,
+                        )
+                        await self._send_auth_expired_error(validated_message.conversation_id)
+                        continue
+
                     await self.process_workflow_request(validated_message)
                     await _registry.set_socket(validated_message.conversation_id, self._socket)
 
@@ -231,6 +293,17 @@ class ReconnectableWebSocketMessageHandler(WebSocketMessageHandler):
                     pass
 
                 elif isinstance(validated_message, WebSocketUserInteractionResponseMessage):
+                    # Same re-auth gate for HITL interaction responses --
+                    # otherwise an idle clarification prompt could be
+                    # answered hours later under an expired token.
+                    if self._is_handshake_token_expired():
+                        logger.info(
+                            "Rejecting user_interaction: handshake token expired (conversation %s)",
+                            validated_message.conversation_id,
+                        )
+                        await self._send_auth_expired_error(validated_message.conversation_id)
+                        continue
+
                     user_content = await self._process_websocket_user_interaction_response_message(validated_message)
                     await _registry.set_socket(validated_message.conversation_id, self._socket)
                     if self._user_interaction_response is not None:

--- a/frontends/aiq_api/tests/test_websocket_reconnect.py
+++ b/frontends/aiq_api/tests/test_websocket_reconnect.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for per-message JWT re-authentication on the reconnectable WS handler.
+
+Covers the behavior added for sealing the "long-lived socket trusts an expired
+token forever" gap:
+
+* ``_is_handshake_token_expired`` correctly classifies tokens by ``exp``
+* ``_send_auth_expired_error`` builds a structured error and writes it to the socket
+* the inbound message loop short-circuits user_message / user_interaction
+  when the handshake JWT has passed its ``exp`` and emits the auth_expired
+  error instead of running the workflow
+
+We construct the handler with ``__new__`` so the heavy NAT base ``__init__``
+(session manager, message validator, step adaptor, worker) does not have to be
+satisfied by the test environment.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+from aiq_api.websocket_reconnect import ReconnectableWebSocketMessageHandler
+
+
+def _make_handler(
+    *,
+    authenticated_user: dict | None,
+    socket: MagicMock | None = None,
+    message_validator: MagicMock | None = None,
+) -> ReconnectableWebSocketMessageHandler:
+    """Return a handler instance bypassing the NAT base class __init__."""
+    handler = ReconnectableWebSocketMessageHandler.__new__(ReconnectableWebSocketMessageHandler)
+    handler._authenticated_user = authenticated_user
+    handler._socket = socket or MagicMock()
+    handler._message_validator = message_validator or MagicMock()
+    return handler
+
+
+class TestIsHandshakeTokenExpired:
+    """``_is_handshake_token_expired`` is the gate that decides re-auth on each message."""
+
+    def test_returns_false_when_no_user(self) -> None:
+        handler = _make_handler(authenticated_user=None)
+        assert handler._is_handshake_token_expired() is False
+
+    def test_returns_false_for_internal_caller_without_exp(self) -> None:
+        # Internal/anonymous callers don't carry JWT claims; we must not
+        # treat them as "expired" or we'd reject every internal call.
+        handler = _make_handler(authenticated_user={"type": "internal"})
+        assert handler._is_handshake_token_expired() is False
+
+    def test_returns_false_when_exp_is_not_a_number(self) -> None:
+        # Defensive: malformed exp (e.g. claim was a string) should NOT be
+        # interpreted as "expired" -- that would fail closed in a way the
+        # client cannot remediate. Treat as "no exp" instead.
+        handler = _make_handler(authenticated_user={"exp": "not-a-number"})
+        assert handler._is_handshake_token_expired() is False
+
+    def test_returns_false_when_exp_is_in_the_future(self) -> None:
+        future = time.time() + 600
+        handler = _make_handler(authenticated_user={"exp": future, "sub": "u-1"})
+        assert handler._is_handshake_token_expired() is False
+
+    def test_returns_true_when_exp_is_in_the_past(self) -> None:
+        past = time.time() - 1
+        handler = _make_handler(authenticated_user={"exp": past, "sub": "u-1"})
+        assert handler._is_handshake_token_expired() is True
+
+
+class TestSendAuthExpiredError:
+    """The error packet must reach the wire with the contract the client expects."""
+
+    @pytest.mark.asyncio
+    async def test_sends_user_auth_error_with_auth_expired_message(self) -> None:
+        socket = MagicMock()
+        socket.send_json = AsyncMock()
+
+        # The validator builds the payload; we only care that we forwarded
+        # an Error with the right shape into it. Echo the produced message
+        # back verbatim so we can assert on it.
+        message_validator = MagicMock()
+        built_message = MagicMock()
+        built_message.model_dump.return_value = {
+            "type": "error",
+            "content": {"code": "user_auth_error", "message": "auth_expired"},
+        }
+        message_validator.create_system_response_token_message = AsyncMock(return_value=built_message)
+
+        handler = _make_handler(
+            authenticated_user={"exp": time.time() - 1},
+            socket=socket,
+            message_validator=message_validator,
+        )
+
+        await handler._send_auth_expired_error("conv-1")
+
+        # The validator must have been asked to build an ERROR_MESSAGE for
+        # this conversation, with an Error carrying message="auth_expired".
+        call = message_validator.create_system_response_token_message.await_args
+        kwargs = call.kwargs
+        assert kwargs["conversation_id"] == "conv-1"
+        error = kwargs["content"]
+        assert error.message == "auth_expired"
+        assert error.code.value == "user_auth_error"
+
+        # And the result must have been forwarded to the socket.
+        socket.send_json.assert_awaited_once()
+        sent_payload = socket.send_json.await_args.args[0]
+        assert sent_payload["content"]["message"] == "auth_expired"
+
+    @pytest.mark.asyncio
+    async def test_swallows_send_failure_silently(self) -> None:
+        # If the socket is already closed, we don't want a second exception
+        # crashing the receive loop -- the client will reconnect on its own.
+        socket = MagicMock()
+        socket.send_json = AsyncMock(side_effect=RuntimeError("socket closed"))
+
+        message_validator = MagicMock()
+        message_validator.create_system_response_token_message = AsyncMock(return_value=MagicMock())
+
+        handler = _make_handler(
+            authenticated_user={"exp": time.time() - 1},
+            socket=socket,
+            message_validator=message_validator,
+        )
+
+        # Must not raise.
+        await handler._send_auth_expired_error("conv-1")

--- a/frontends/ui/src/adapters/api/websocket-client.spec.ts
+++ b/frontends/ui/src/adapters/api/websocket-client.spec.ts
@@ -6,6 +6,7 @@ import { NATMessageType, NATWebSocketClient } from './websocket-client'
 
 class MockWebSocket {
   static readonly OPEN = 1
+  static readonly CLOSED = 3
   static instances: MockWebSocket[] = []
 
   readonly url: string
@@ -21,7 +22,9 @@ class MockWebSocket {
   }
 
   send = vi.fn()
-  close = vi.fn()
+  close = vi.fn(() => {
+    this.readyState = MockWebSocket.CLOSED
+  })
 }
 
 describe('NATWebSocketClient auth observability', () => {
@@ -78,6 +81,67 @@ describe('NATWebSocketClient auth observability', () => {
         details: 'Token expired',
       })
     )
+  })
+
+  test('rotate() ignores late onclose from the rotated-out socket', async () => {
+    // Regression: NATWebSocketClient.rotate() must atomically detach the
+    // old socket so a delayed `onclose` from it cannot be reclassified as
+    // an unintentional disconnect on the freshly-opened socket. Without
+    // this guarantee, the hook would see onConnectionChange('disconnected'
+    // | 'error') seconds after a silent token rotation -- clobbering
+    // streaming/loading state and potentially scheduling another reconnect.
+    const onConnectionChange = vi.fn()
+    const onError = vi.fn()
+    const client = new NATWebSocketClient({
+      conversationId: 'conv-1',
+      websocketUrl: 'ws://localhost/websocket',
+      callbacks: { onConnectionChange, onError },
+    })
+
+    // Open socket A and bring it to the connected state.
+    await client.connect()
+    const socketA = MockWebSocket.instances[0]
+    socketA.onopen?.(new Event('open'))
+    expect(onConnectionChange).toHaveBeenCalledWith('connected')
+    onConnectionChange.mockClear()
+
+    // Capture A's onclose BEFORE rotate() detaches it, then rotate.
+    // Real browsers fire onclose asynchronously after close(); we
+    // capture the reference so we can simulate that delayed event.
+    const staleOnCloseA = socketA.onclose
+    await client.rotate()
+
+    // After rotate(): a brand new socket B exists, A's handlers are
+    // detached (so calling staleOnCloseA directly is the only way the
+    // old code path could be reached -- this is the worst case the
+    // socket-instance guard protects against).
+    expect(MockWebSocket.instances).toHaveLength(2)
+    const socketB = MockWebSocket.instances[1]
+    expect(socketB).not.toBe(socketA)
+    // rotate() detaches A's handlers so the live A.onclose is now null
+    // even though the browser would still hold a reference somewhere.
+    expect(socketA.onclose).toBeNull()
+
+    // Bring socket B to connected.
+    socketB.onopen?.(new Event('open'))
+    expect(onConnectionChange).toHaveBeenCalledWith('connected')
+    onConnectionChange.mockClear()
+
+    // Simulate the browser firing the LATE close on A (via the captured
+    // handler reference -- mimicking the worst case where some polyfill
+    // or stale reference still has it). The socket-instance guard inside
+    // setupEventHandlers must drop this event silently: it must NOT push
+    // 'disconnected' or 'error' through to the hook, must NOT touch
+    // streaming/loading state, must NOT schedule an extra reconnect.
+    staleOnCloseA?.(new CloseEvent('close'))
+
+    expect(onConnectionChange).not.toHaveBeenCalled()
+    expect(onError).not.toHaveBeenCalled()
+
+    // And a late onmessage on A is dropped too (defense in depth: if
+    // some buffered frame surfaces on the old socket after rotate, it
+    // must not be parsed against the new conversation context).
+    socketA.onmessage = null // already detached by rotate, double-check
   })
 
   test('does not emit RUM error for non-auth websocket errors', async () => {

--- a/frontends/ui/src/adapters/api/websocket-client.spec.ts
+++ b/frontends/ui/src/adapters/api/websocket-client.spec.ts
@@ -144,6 +144,45 @@ describe('NATWebSocketClient auth observability', () => {
     socketA.onmessage = null // already detached by rotate, double-check
   })
 
+  test('rotate() coalesces concurrent calls -- only one new socket is created', async () => {
+    // Regression: if a second rotate() is fired while one is already in
+    // flight (e.g. the soft-rotation timer fires the same tick the
+    // hook receives auth_expired), each call must NOT independently
+    // detach handlers and start its own connect(). Worst case there is
+    // two parallel `new WebSocket(...)` opens racing for `this.ws` --
+    // exactly the kind of mid-rotation chaos the rotate() primitive
+    // was introduced to prevent.
+    const onConnectionChange = vi.fn()
+    const client = new NATWebSocketClient({
+      conversationId: 'conv-1',
+      websocketUrl: 'ws://localhost/websocket',
+      callbacks: { onConnectionChange },
+    })
+
+    await client.connect()
+    expect(MockWebSocket.instances).toHaveLength(1)
+    const socketA = MockWebSocket.instances[0]
+    socketA.onopen?.(new Event('open'))
+
+    // Fire two rotate() calls without awaiting the first.
+    const r1 = client.rotate()
+    const r2 = client.rotate()
+
+    // The second call must coalesce into the first's in-flight promise,
+    // not start its own rotation. Identity check is the strictest
+    // possible assertion -- it proves we returned the cached promise,
+    // not just a structurally-equivalent one.
+    expect(r1).toBe(r2)
+
+    await Promise.all([r1, r2])
+
+    // Exactly one new socket B (total 2). If the second rotate() had
+    // run independently, we would see THREE MockWebSocket instances:
+    // the original A, the B opened by the first rotate(), and a third
+    // C opened by the second rotate() after it tore B's handlers off.
+    expect(MockWebSocket.instances).toHaveLength(2)
+  })
+
   test('does not emit RUM error for non-auth websocket errors', async () => {
     const addError = vi.fn()
     ;(window as unknown as Record<string, unknown>).DD_RUM = { addError }

--- a/frontends/ui/src/adapters/api/websocket-client.ts
+++ b/frontends/ui/src/adapters/api/websocket-client.ts
@@ -59,6 +59,17 @@ export interface NATWebSocketClientOptions {
   reconnectDelay?: number
   /** Override WebSocket URL (uses same-origin by default, proxied through UI server) */
   websocketUrl?: string
+  /**
+   * Hook invoked before opening a new WebSocket (initial or reconnect).
+   *
+   * Used to refresh auth credentials so the upgrade request carries an up-to-date
+   * httpOnly idToken cookie. The WebSocket handshake is the only point where the
+   * backend (re)reads auth, so a stale cookie can leave a long-lived connection
+   * authenticated by an expired token.
+   *
+   * Errors are swallowed -- the connect attempt proceeds regardless.
+   */
+  onBeforeReconnect?: () => Promise<void>
 }
 
 /**
@@ -104,6 +115,15 @@ export class NATWebSocketClient {
     this.options.callbacks.onConnectionChange?.('connecting')
 
     try {
+      if (this.options.onBeforeReconnect) {
+        try {
+          await this.options.onBeforeReconnect()
+        } catch (err) {
+          // Auth refresh is best-effort; the upgrade still happens with whatever
+          // cookie the browser has. The backend will close the socket if it's bad.
+          console.warn('[WS] onBeforeReconnect failed, proceeding with current auth', err)
+        }
+      }
       const wsUrl = this.options.websocketUrl || (await getWebSocketUrl())
       this.ws = new WebSocket(wsUrl)
       this.setupEventHandlers()
@@ -291,8 +311,15 @@ export class NATWebSocketClient {
 
         case NATMessageType.ERROR: {
           // Auth errors carry the specific error_code in `message`
-          // (e.g. "token_expired", "token_invalid", "auth_error").
-          const authCodes = new Set(['auth_error', 'token_expired', 'token_invalid'])
+          // (e.g. "token_expired", "token_invalid", "auth_error",
+          // "auth_expired"). `auth_expired` is the per-message re-auth
+          // gate -- the hook turns it into a silent reconnect + auto-resend.
+          const authCodes = new Set([
+            'auth_error',
+            'token_expired',
+            'token_invalid',
+            'auth_expired',
+          ])
           const errorMsg = message.content?.message
           if (errorMsg && authCodes.has(errorMsg)) {
             trackAuthEvent(errorMsg, {

--- a/frontends/ui/src/adapters/api/websocket-client.ts
+++ b/frontends/ui/src/adapters/api/websocket-client.ts
@@ -149,6 +149,49 @@ export class NATWebSocketClient {
   }
 
   /**
+   * Atomically swap the underlying WebSocket for a fresh one.
+   *
+   * Done as a single client-side operation (rather than `disconnect()` +
+   * `connect()` interleaved from the caller) because of an `onclose` race:
+   *   1. `disconnect()` sets `isIntentionallyClosed = true` and calls
+   *      `ws.close()`, but the browser fires `onclose` asynchronously.
+   *   2. `connect()` immediately flips `isIntentionallyClosed = false`.
+   *   3. The old socket's `onclose` then arrives, sees the flag is now
+   *      false, classifies the close as unintentional, and drives
+   *      `onConnectionChange('disconnected' | 'error')` -- clobbering the
+   *      streaming/loading UX of the freshly-opened socket and potentially
+   *      scheduling a redundant reconnect via `handleReconnect()`.
+   *
+   * Two-layer defense:
+   *   - Detach handlers from the old socket BEFORE closing it, so any
+   *     late event the browser still tries to deliver hits a no-op.
+   *   - Belt-and-braces: `setupEventHandlers()` also captures the source
+   *     socket in each handler and early-returns unless `this.ws ===
+   *     socket`, protecting against any other reordering we can't control.
+   */
+  rotate = async (): Promise<void> => {
+    const oldSocket = this.ws
+    if (oldSocket) {
+      oldSocket.onopen = null
+      oldSocket.onclose = null
+      oldSocket.onerror = null
+      oldSocket.onmessage = null
+      try {
+        oldSocket.close()
+      } catch {
+        // close() can throw in test or polyfill environments; the rotation
+        // doesn't depend on a clean close because handlers are already
+        // detached.
+      }
+      if (this.ws === oldSocket) this.ws = null
+    }
+    this.isIntentionallyClosed = false
+    this.reconnectCount = 0
+    this.errorBeforeClose = false
+    await this.connect()
+  }
+
+  /**
    * Send a user chat message
    * @param content - The message text content (query)
    * @param enabledDataSources - Optional array of enabled data source IDs to include in the query
@@ -220,22 +263,30 @@ export class NATWebSocketClient {
   }
 
   private setupEventHandlers = (): void => {
-    if (!this.ws) return
+    // Capture the socket instance in each handler closure. If `this.ws` is
+    // swapped (rotate(), reconnect, etc.), late events from the old socket
+    // hit `this.ws !== socket` and are dropped before they can drive any
+    // connection-state side effects on the new socket.
+    const socket = this.ws
+    if (!socket) return
 
-    this.ws.onopen = () => {
+    socket.onopen = () => {
+      if (this.ws !== socket) return
       this.reconnectCount = 0
       this.errorBeforeClose = false
       this.options.callbacks.onConnectionChange?.('connected')
     }
 
-    this.ws.onerror = () => {
+    socket.onerror = () => {
+      if (this.ws !== socket) return
       // Flag that an error preceded the close event.
       // Don't fire onConnectionChange here -- onclose always follows onerror
       // in the browser WebSocket API. This prevents double-firing.
       this.errorBeforeClose = true
     }
 
-    this.ws.onclose = () => {
+    socket.onclose = () => {
+      if (this.ws !== socket) return
       const hadError = this.errorBeforeClose
       this.errorBeforeClose = false
 
@@ -259,7 +310,8 @@ export class NATWebSocketClient {
       this.handleReconnect()
     }
 
-    this.ws.onmessage = (event) => {
+    socket.onmessage = (event) => {
+      if (this.ws !== socket) return
       this.handleMessage(event.data)
     }
   }

--- a/frontends/ui/src/adapters/api/websocket-client.ts
+++ b/frontends/ui/src/adapters/api/websocket-client.ts
@@ -84,6 +84,15 @@ export class NATWebSocketClient {
   private isIntentionallyClosed = false
   private errorBeforeClose = false
   private messageIdCounter = 0
+  /**
+   * In-flight rotation promise, set for the duration of `rotate()`.
+   * Subsequent rotate() calls await the same promise instead of each
+   * one independently detaching handlers from a socket that the previous
+   * rotate() already replaced -- the worst case there is two parallel
+   * `new WebSocket(...)` opens with the second one orphaning the first.
+   * See the `rotate()` docstring.
+   */
+  private rotationInFlight: Promise<void> | null = null
   /** ID of the last user message sent -- used by callbacks to detect stale responses */
   activeParentId: string | null = null
 
@@ -162,33 +171,52 @@ export class NATWebSocketClient {
    *      streaming/loading UX of the freshly-opened socket and potentially
    *      scheduling a redundant reconnect via `handleReconnect()`.
    *
-   * Two-layer defense:
+   * Three layers of defense:
    *   - Detach handlers from the old socket BEFORE closing it, so any
    *     late event the browser still tries to deliver hits a no-op.
    *   - Belt-and-braces: `setupEventHandlers()` also captures the source
    *     socket in each handler and early-returns unless `this.ws ===
    *     socket`, protecting against any other reordering we can't control.
+   *   - Idempotency: if a rotation is already in flight (e.g. soft-timer
+   *     fires while an `auth_expired` rotation is mid-handshake),
+   *     subsequent callers await the same in-flight promise instead of
+   *     each independently ripping handlers off whatever `this.ws`
+   *     currently is. Without this, the second rotate() would detach
+   *     handlers from the brand-new (still `connecting`) socket and could
+   *     leave two parallel `new WebSocket(...)` opens racing for the
+   *     `this.ws` slot.
    */
-  rotate = async (): Promise<void> => {
-    const oldSocket = this.ws
-    if (oldSocket) {
-      oldSocket.onopen = null
-      oldSocket.onclose = null
-      oldSocket.onerror = null
-      oldSocket.onmessage = null
-      try {
-        oldSocket.close()
-      } catch {
-        // close() can throw in test or polyfill environments; the rotation
-        // doesn't depend on a clean close because handlers are already
-        // detached.
-      }
-      if (this.ws === oldSocket) this.ws = null
+  rotate = (): Promise<void> => {
+    if (this.rotationInFlight) {
+      // Coalesce: every concurrent caller observes the same outcome.
+      return this.rotationInFlight
     }
-    this.isIntentionallyClosed = false
-    this.reconnectCount = 0
-    this.errorBeforeClose = false
-    await this.connect()
+    this.rotationInFlight = (async () => {
+      try {
+        const oldSocket = this.ws
+        if (oldSocket) {
+          oldSocket.onopen = null
+          oldSocket.onclose = null
+          oldSocket.onerror = null
+          oldSocket.onmessage = null
+          try {
+            oldSocket.close()
+          } catch {
+            // close() can throw in test or polyfill environments; the
+            // rotation doesn't depend on a clean close because handlers
+            // are already detached.
+          }
+          if (this.ws === oldSocket) this.ws = null
+        }
+        this.isIntentionallyClosed = false
+        this.reconnectCount = 0
+        this.errorBeforeClose = false
+        await this.connect()
+      } finally {
+        this.rotationInFlight = null
+      }
+    })()
+    return this.rotationInFlight
   }
 
   /**

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { renderHook, act, waitFor } from '@testing-library/react'
-import { vi, describe, test, expect, beforeEach } from 'vitest'
+import { vi, describe, test, expect, beforeEach, afterEach } from 'vitest'
 import { useWebSocketChat } from './use-websocket-chat'
+import { useAuth } from '@/adapters/auth'
 
 // Mock store actions
 const mockAddUserMessage = vi.fn()
@@ -64,42 +65,54 @@ let mockStoreState: {
   planMessages: [],
 }
 
+/**
+ * Build the default selector-based useChatStore mock body.
+ *
+ * Extracted as a helper so suites that override useChatStore with their own
+ * mockImplementation (e.g. the deep-research escalation test) can restore
+ * the default in afterEach without duplicating the action wiring.
+ */
+const defaultUseChatStoreImpl = (selector?: (s: any) => any) => {
+  const state = {
+    ...mockStoreState,
+    addUserMessage: mockAddUserMessage,
+    addAgentResponse: mockAddAgentResponse,
+    addAgentResponseWithMeta: mockAddAgentResponseWithMeta,
+    addThinkingStep: mockAddThinkingStep,
+    appendToThinkingStep: mockAppendToThinkingStep,
+    completeThinkingStep: mockCompleteThinkingStep,
+    updateThinkingStepByFunctionName: mockUpdateThinkingStepByFunctionName,
+    findThinkingStepByFunctionName: mockFindThinkingStepByFunctionName,
+    setReportContent: mockSetReportContent,
+    addStatusCard: mockAddStatusCard,
+    addAgentPrompt: mockAddAgentPrompt,
+    addErrorCard: mockAddErrorCard,
+    setCurrentStatus: mockSetCurrentStatus,
+    setPendingInteraction: mockSetPendingInteraction,
+    clearPendingInteraction: mockClearPendingInteraction,
+    setLoading: mockSetLoading,
+    setStreaming: mockSetStreaming,
+    clearThinkingSteps: mockClearThinkingSteps,
+    clearReportContent: mockClearReportContent,
+    createConversation: mockCreateConversation,
+    setCurrentUser: mockSetCurrentUser,
+    getUserConversations: mockGetUserConversations,
+    selectConversation: mockSelectConversation,
+    respondToPrompt: mockRespondToPrompt,
+    addPlanMessage: mockAddPlanMessage,
+    updatePlanMessageResponse: mockUpdatePlanMessageResponse,
+    addDeepResearchBanner: mockAddDeepResearchBanner,
+    dismissConnectionErrors: mockDismissConnectionErrors,
+  }
+  return selector ? selector(state) : state
+}
+
 vi.mock('../store', () => ({
   useChatStore: Object.assign(
-    vi.fn((selector?: (s: any) => any) => {
-      const state = {
-        ...mockStoreState,
-        addUserMessage: mockAddUserMessage,
-        addAgentResponse: mockAddAgentResponse,
-        addAgentResponseWithMeta: mockAddAgentResponseWithMeta,
-        addThinkingStep: mockAddThinkingStep,
-        appendToThinkingStep: mockAppendToThinkingStep,
-        completeThinkingStep: mockCompleteThinkingStep,
-        updateThinkingStepByFunctionName: mockUpdateThinkingStepByFunctionName,
-        findThinkingStepByFunctionName: mockFindThinkingStepByFunctionName,
-        setReportContent: mockSetReportContent,
-        addStatusCard: mockAddStatusCard,
-        addAgentPrompt: mockAddAgentPrompt,
-        addErrorCard: mockAddErrorCard,
-        setCurrentStatus: mockSetCurrentStatus,
-        setPendingInteraction: mockSetPendingInteraction,
-        clearPendingInteraction: mockClearPendingInteraction,
-        setLoading: mockSetLoading,
-        setStreaming: mockSetStreaming,
-        clearThinkingSteps: mockClearThinkingSteps,
-        clearReportContent: mockClearReportContent,
-        createConversation: mockCreateConversation,
-        setCurrentUser: mockSetCurrentUser,
-        getUserConversations: mockGetUserConversations,
-        selectConversation: mockSelectConversation,
-        respondToPrompt: mockRespondToPrompt,
-        addPlanMessage: mockAddPlanMessage,
-        updatePlanMessageResponse: mockUpdatePlanMessageResponse,
-        addDeepResearchBanner: mockAddDeepResearchBanner,
-        dismissConnectionErrors: mockDismissConnectionErrors,
-      }
-      return selector ? selector(state) : state
-    }),
+    // Wrap in lambda so the reference to `defaultUseChatStoreImpl` is
+    // resolved at call time (not at vi.mock hoist time). Without the
+    // lambda, vi.fn would read the const eagerly and hit TDZ.
+    vi.fn((selector?: (s: any) => any) => defaultUseChatStoreImpl(selector)),
     {
       getState: vi.fn(() => ({
         ...mockStoreState,
@@ -109,12 +122,21 @@ vi.mock('../store', () => ({
   selectHasConnectionError: () => false,
 }))
 
-// Mock auth hook
+// Mock auth hook (per-test override via vi.mocked(useAuth).mockReturnValue(...))
 vi.mock('@/adapters/auth', () => ({
   useAuth: vi.fn(() => ({
     user: { id: 'user-1', email: 'test@example.com' },
     idToken: 'mock-id-token',
+    authRequired: false,
+    error: undefined,
   })),
+}))
+
+// Mock next-auth/react getSession so the token-rotation logic in
+// useWebSocketChat doesn't try to talk to a real /api/auth/session endpoint.
+const mockGetSession = vi.fn<() => Promise<{ idTokenExpiresAt?: number } | null>>()
+vi.mock('next-auth/react', () => ({
+  getSession: () => mockGetSession(),
 }))
 
 // Mock connection recovery hook (tested separately)
@@ -182,9 +204,17 @@ let capturedCallbacks: {
   onConnectionChange?: (status: string) => void
 } = {}
 
+// Captured separately so token-rotation tests can drive it directly without
+// depending on React state propagation timing.
+let capturedOnBeforeReconnect: (() => Promise<void>) | undefined
+
 vi.mock('@/adapters/api/websocket-client', () => ({
-  createNATWebSocketClient: vi.fn((options: { callbacks: typeof capturedCallbacks }) => {
+  createNATWebSocketClient: vi.fn((options: {
+    callbacks: typeof capturedCallbacks
+    onBeforeReconnect?: () => Promise<void>
+  }) => {
     capturedCallbacks = options.callbacks
+    capturedOnBeforeReconnect = options.onBeforeReconnect
     return mockWsClient
   }),
   NATWebSocketClient: vi.fn(),
@@ -210,6 +240,12 @@ describe('useWebSocketChat', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     capturedCallbacks = {}
+    capturedOnBeforeReconnect = undefined
+    mockGetSession.mockReset()
+    // Restore default useChatStore mock so a previous test's
+    // mockImplementation override (e.g. deep-research escalation) doesn't
+    // leak into this one.
+    vi.mocked(useChatStore).mockImplementation(defaultUseChatStoreImpl)
     mockStoreState = {
       currentUserId: 'user-1',
       currentConversation: { id: 'conv-1', messages: [], userId: 'user-1' },
@@ -867,5 +903,433 @@ describe('useWebSocketChat', () => {
       })
     )
     expect(mockStartDeepResearch).toHaveBeenCalledWith('abc123-def456', 'msg-1')
+  })
+})
+
+/**
+ * Token rotation lifecycle.
+ *
+ * The hook must close + reopen the WebSocket before the token that
+ * authenticated it expires. The backend only validates auth at the WS
+ * upgrade, so a long-lived socket otherwise keeps trusting an expired token
+ * forever. One timer + a deferred-rotation effect:
+ *   - soft (-60s): if idle, rotate immediately. If streaming, mark
+ *     `pendingRotationRef = true` and let the in-flight response finish.
+ *   - deferred: when `isStreaming` transitions back to false, drain the
+ *     pending flag and rotate. No banner, no resend -- silent refresh.
+ *
+ * Tests below drive `onBeforeReconnect` directly to seed the rotation
+ * deadline (which mirrors what the real client would do during connect()),
+ * then advance fake timers / mutate `isStreaming` to assert the policy.
+ */
+describe('useWebSocketChat -- token rotation', () => {
+  const NOW_MS = 1_700_000_000_000 // arbitrary fixed wall clock
+  /** Token expires 10 minutes from "now" -- soft fires at +9m. */
+  const EXP_AT_S = Math.floor(NOW_MS / 1000) + 600
+  const SOFT_DELAY_MS = 540_000 // 600s - 60s
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW_MS)
+    // Restore default useChatStore mock impl in case a sibling test
+    // overrode it (mockImplementation persists across tests, only
+    // call counts are cleared by vi.clearAllMocks).
+    vi.mocked(useChatStore).mockImplementation(defaultUseChatStoreImpl)
+    vi.mocked(useAuth).mockReturnValue({
+      user: { id: 'user-1', email: 'test@example.com' },
+      idToken: 'mock-id-token',
+      authRequired: true,
+      isAuthenticated: true,
+      isLoading: false,
+      accessToken: undefined,
+      error: undefined,
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+    })
+    mockGetSession.mockResolvedValue({ idTokenExpiresAt: EXP_AT_S })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    // Restore default useAuth so subsequent suites aren't affected.
+    vi.mocked(useAuth).mockReturnValue({
+      user: { id: 'user-1', email: 'test@example.com' },
+      idToken: 'mock-id-token',
+      authRequired: false,
+      isAuthenticated: true,
+      isLoading: false,
+      accessToken: undefined,
+      error: undefined,
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+    })
+  })
+
+  /**
+   * Mounts the hook, drives `onBeforeReconnect` (which the real client invokes
+   * inside connect()), and waits for the rotation timers to be armed.
+   */
+  async function mountAndArmTimers() {
+    const rendered = renderWebSocketHook()
+    // The real client calls onBeforeReconnect during connect(); the mock
+    // doesn't, so do it manually to seed activeSocketTokenExpiresAt.
+    await act(async () => {
+      await capturedOnBeforeReconnect?.()
+    })
+    return rendered
+  }
+
+  test('soft timer rotates the socket when the chat is idle', async () => {
+    await mountAndArmTimers()
+    mockStoreState.isStreaming = false
+    mockWsClient.disconnect.mockClear()
+    mockWsClient.connect.mockClear()
+
+    await act(async () => {
+      vi.advanceTimersByTime(SOFT_DELAY_MS)
+    })
+
+    expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.connect).toHaveBeenCalledTimes(1)
+    // Idle rotation must be silent -- no error/banner is shown to the user.
+    expect(mockAddErrorCard).not.toHaveBeenCalled()
+    expect(mockSetStreaming).not.toHaveBeenCalledWith(false)
+  })
+
+  test('soft timer does NOT rotate when a stream is in flight (defer until done)', async () => {
+    const { rerender } = await mountAndArmTimers()
+
+    // Mark streaming and rerender so the hook's deferred-rotation effect
+    // observes the true -> false transition later. Without this rerender
+    // the hook's local `isStreaming` selector value never flips to true,
+    // so the eventual flip back to false wouldn't be a transition either.
+    mockStoreState.isStreaming = true
+    await act(async () => {
+      rerender()
+    })
+
+    mockWsClient.disconnect.mockClear()
+    mockWsClient.connect.mockClear()
+
+    await act(async () => {
+      vi.advanceTimersByTime(SOFT_DELAY_MS)
+    })
+
+    // Soft timer fired and was deferred -- in-flight stream is preserved.
+    // Critically, no banner: the user should not see a "session expired"
+    // message just because the rotation timer fired.
+    expect(mockWsClient.disconnect).not.toHaveBeenCalled()
+    expect(mockWsClient.connect).not.toHaveBeenCalled()
+    expect(mockAddErrorCard).not.toHaveBeenCalled()
+    // No premature stream cleanup either: setStreaming(false) must NOT have
+    // been called as a side-effect of the rotation timer.
+    expect(mockSetStreaming).not.toHaveBeenCalledWith(false)
+
+    // Stream finishes -> the deferred rotation effect picks up the flag
+    // and rotates silently.
+    mockStoreState.isStreaming = false
+    await act(async () => {
+      rerender()
+    })
+
+    expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.connect).toHaveBeenCalledTimes(1)
+    expect(mockAddErrorCard).not.toHaveBeenCalled()
+  })
+
+  test('rotation cycle invokes getSession exactly once (no SessionProvider race)', async () => {
+    await mountAndArmTimers()
+    // Initial mount counts as one getSession call (the connect path's
+    // refreshAuthBeforeReconnect). Reset and verify a single rotation cycle
+    // adds exactly one more call -- proving we don't accidentally fan out
+    // refreshes (which would cause invalid_grant with rotating refresh tokens).
+    mockGetSession.mockClear()
+    mockStoreState.isStreaming = false
+
+    await act(async () => {
+      vi.advanceTimersByTime(SOFT_DELAY_MS)
+    })
+
+    // The mocked client.connect() is a no-op -- it does NOT re-invoke
+    // onBeforeReconnect like the real one would. So we manually drive the
+    // post-rotation refresh here and assert getSession was only called once.
+    await act(async () => {
+      await capturedOnBeforeReconnect?.()
+    })
+
+    expect(mockGetSession).toHaveBeenCalledTimes(1)
+  })
+
+  test('updated idTokenExpiresAt re-arms timers; old timers do not double-fire', async () => {
+    await mountAndArmTimers()
+    mockStoreState.isStreaming = false
+    mockWsClient.disconnect.mockClear()
+    mockWsClient.connect.mockClear()
+
+    // Refresh returns a NEW expiry far in the future. This should re-run the
+    // effect, clear the old timers, and arm new ones.
+    const NEW_EXP_AT_S = Math.floor(NOW_MS / 1000) + 1200
+    mockGetSession.mockResolvedValue({ idTokenExpiresAt: NEW_EXP_AT_S })
+    await act(async () => {
+      await capturedOnBeforeReconnect?.()
+    })
+
+    // Original soft deadline -- old timer would have fired here, but it was
+    // cleaned up by the effect's cleanup function. The new soft deadline is
+    // 1140s from NOW.
+    await act(async () => {
+      vi.advanceTimersByTime(SOFT_DELAY_MS)
+    })
+
+    expect(mockWsClient.disconnect).not.toHaveBeenCalled()
+    expect(mockWsClient.connect).not.toHaveBeenCalled()
+
+    // Advance to the new soft deadline; rotation should fire exactly once.
+    const NEW_SOFT_DELAY_MS = 1_140_000 - SOFT_DELAY_MS
+    await act(async () => {
+      vi.advanceTimersByTime(NEW_SOFT_DELAY_MS)
+    })
+
+    expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.connect).toHaveBeenCalledTimes(1)
+  })
+
+  test('failed getSession does not crash and leaves prior timers intact', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await mountAndArmTimers()
+    mockStoreState.isStreaming = false
+    mockWsClient.disconnect.mockClear()
+    mockWsClient.connect.mockClear()
+
+    // Subsequent refresh fails (e.g. transient network blip).
+    mockGetSession.mockRejectedValueOnce(new Error('network down'))
+    await act(async () => {
+      await capturedOnBeforeReconnect?.()
+    })
+
+    // Old timers were armed against the FIRST successful getSession's expiry.
+    // They should still fire on schedule even though the second refresh failed.
+    await act(async () => {
+      vi.advanceTimersByTime(SOFT_DELAY_MS)
+    })
+
+    expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.connect).toHaveBeenCalledTimes(1)
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('getSession before WS reconnect failed'),
+      expect.any(Error)
+    )
+    consoleWarnSpy.mockRestore()
+  })
+
+  test('does not arm rotation timer when authRequired is false', async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { id: 'user-1', email: 'test@example.com' },
+      idToken: undefined,
+      authRequired: false,
+      isAuthenticated: true,
+      isLoading: false,
+      accessToken: undefined,
+      error: undefined,
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+    })
+    renderWebSocketHook()
+    await act(async () => {
+      await capturedOnBeforeReconnect?.()
+    })
+    mockWsClient.disconnect.mockClear()
+    mockWsClient.connect.mockClear()
+
+    await act(async () => {
+      vi.advanceTimersByTime(SOFT_DELAY_MS + 60_000)
+    })
+
+    expect(mockWsClient.disconnect).not.toHaveBeenCalled()
+    expect(mockWsClient.connect).not.toHaveBeenCalled()
+    // refreshAuthBeforeReconnect short-circuits when !authRequired, so
+    // getSession should never be called.
+    expect(mockGetSession).not.toHaveBeenCalled()
+  })
+
+  test('cleanup on unmount cancels the pending soft timer', async () => {
+    const { unmount } = await mountAndArmTimers()
+    mockStoreState.isStreaming = false
+    mockWsClient.disconnect.mockClear()
+    mockWsClient.connect.mockClear()
+
+    unmount()
+
+    await act(async () => {
+      vi.advanceTimersByTime(SOFT_DELAY_MS + 60_000)
+    })
+
+    // The unmount-triggered conversation-cleanup useEffect calls disconnect()
+    // exactly once. Crucially, NO additional connect/disconnect should fire
+    // from the rotation timer after unmount.
+    expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.connect).not.toHaveBeenCalled()
+  })
+
+  /**
+   * Pre-flight check: a long-idle socket may technically be connected, but
+   * if the JWT that authenticated it has already expired (e.g. after a
+   * laptop sleep), `sendMessage` must NOT push the message through that
+   * socket. Instead, it should buffer the outgoing payload, rotate the
+   * socket, and have the new `onConnectionChange('connected')` handler
+   * drain the buffer once the fresh handshake completes.
+   */
+  test('sendMessage with stale token rotates socket and drains buffer on connect', async () => {
+    // mountAndArmTimers seeds activeSocketTokenExpiresAt to EXP_AT_S via
+    // the captured onBeforeReconnect call.
+    const { result } = await mountAndArmTimers()
+
+    // Move the wall clock past expiry. The soft timer was armed for SOFT_DELAY_MS
+    // from NOW_MS, so it has NOT fired yet -- but the token is already dead
+    // because real time advanced (e.g. the tab was suspended).
+    vi.setSystemTime(EXP_AT_S * 1000 + 1)
+
+    // Socket is "connected" but the underlying token is already past `exp`.
+    mockWsClient.isConnected.mockReturnValue(true)
+    mockWsClient.sendMessage.mockClear()
+    mockWsClient.disconnect.mockClear()
+    mockWsClient.connect.mockClear()
+
+    act(() => {
+      result.current.sendMessage('Hello after long idle')
+    })
+
+    // Pre-flight: must NOT send through the stale socket. Instead,
+    // rotate the connection so the new handshake carries a fresh cookie.
+    expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
+    expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.connect).toHaveBeenCalledTimes(1)
+
+    // Simulate the handshake completing: the captured onConnectionChange
+    // is invoked with 'connected' and should drain the buffered message.
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('connected')
+    })
+
+    expect(mockWsClient.sendMessage).toHaveBeenCalledWith(
+      'Hello after long idle',
+      expect.any(Array)
+    )
+    // No banner -- the rotation was completely silent for the user.
+    expect(mockAddErrorCard).not.toHaveBeenCalled()
+  })
+
+  test('sendMessage with valid token sends directly without rotating', async () => {
+    const { result } = await mountAndArmTimers()
+    // Token still valid (10min in the future). No pre-flight rotation.
+    mockWsClient.isConnected.mockReturnValue(true)
+    mockWsClient.sendMessage.mockClear()
+    mockWsClient.disconnect.mockClear()
+    mockWsClient.connect.mockClear()
+
+    act(() => {
+      result.current.sendMessage('Hello')
+    })
+
+    expect(mockWsClient.sendMessage).toHaveBeenCalledWith('Hello', expect.any(Array))
+    expect(mockWsClient.disconnect).not.toHaveBeenCalled()
+  })
+
+  /**
+   * `auth_expired` from the backend (per-message JWT re-auth on the WS
+   * handler) must NOT bubble up to the user as an error. The hook should:
+   *   1. NOT show a banner (no addErrorCard call)
+   *   2. Buffer the just-sent payload (lastSentMessageRef -> pendingOutgoingRef)
+   *   3. Rotate the socket so the new handshake reads a fresh idToken
+   *   4. On 'connected', drain the buffer and re-issue the original message
+   * Net effect for the user: brief reconnect, then their answer arrives.
+   */
+  test('auth_expired error triggers silent reconnect + auto-resend of last message', async () => {
+    const { result } = await mountAndArmTimers()
+    mockWsClient.isConnected.mockReturnValue(true)
+
+    // Send a message so lastSentMessageRef is populated. doSend() captures
+    // both the content and the resolved data sources, mirroring what the
+    // user actually saw on the wire.
+    act(() => {
+      result.current.sendMessage('What is the weather?')
+    })
+    expect(mockWsClient.sendMessage).toHaveBeenLastCalledWith('What is the weather?', expect.any(Array))
+
+    mockWsClient.sendMessage.mockClear()
+    mockWsClient.disconnect.mockClear()
+    mockWsClient.connect.mockClear()
+    mockAddErrorCard.mockClear()
+    // Reset streaming/loading mocks so we only assert on post-error calls
+    // (sendMessage already drove them through their normal start-of-request
+    // sequence).
+    mockSetStreaming.mockClear()
+    mockSetLoading.mockClear()
+
+    // Backend rejects mid-workflow with auth_expired (handshake JWT past exp).
+    act(() => {
+      capturedCallbacks.onError?.({
+        code: 'user_auth_error',
+        message: 'auth_expired',
+        details: 'Handshake token has expired',
+      })
+    })
+
+    // No banner: this is the whole point -- silent for the user.
+    expect(mockAddErrorCard).not.toHaveBeenCalled()
+    // Streaming/loading state must NOT be reset by onError -- the user's
+    // "request in progress" UX should bridge the rotation seamlessly.
+    // (The drain on 'connected' will eventually clear loading; for the
+    // onError step itself nothing should fire.)
+    expect(mockSetStreaming).not.toHaveBeenCalled()
+    expect(mockSetLoading).not.toHaveBeenCalled()
+    // Rotation kicked off.
+    expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.connect).toHaveBeenCalledTimes(1)
+
+    // Simulate the new handshake completing -> drain buffered message.
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('connected')
+    })
+
+    expect(mockWsClient.sendMessage).toHaveBeenCalledWith(
+      'What is the weather?',
+      expect.any(Array)
+    )
+  })
+
+  test('non-auth_expired error still surfaces an error card and clears resend buffer', async () => {
+    const { result } = await mountAndArmTimers()
+    mockWsClient.isConnected.mockReturnValue(true)
+
+    act(() => {
+      result.current.sendMessage('Hello')
+    })
+
+    mockWsClient.sendMessage.mockClear()
+    mockWsClient.disconnect.mockClear()
+    mockWsClient.connect.mockClear()
+    mockAddErrorCard.mockClear()
+
+    // Generic backend error (NOT auth_expired) -- must show a banner
+    // and must NOT trigger a silent rotation.
+    act(() => {
+      capturedCallbacks.onError?.({
+        code: 'workflow_error',
+        message: 'Something broke in the agent',
+      })
+    })
+
+    expect(mockAddErrorCard).toHaveBeenCalled()
+    expect(mockWsClient.disconnect).not.toHaveBeenCalled()
+    expect(mockWsClient.connect).not.toHaveBeenCalled()
+
+    // After this generic error, an unrelated 'connected' event (e.g. a
+    // routine soft rotation) must NOT replay the message: that would be
+    // a phantom resend the user never asked for.
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('connected')
+    })
+    expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
   })
 })

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
@@ -1385,4 +1385,105 @@ describe('useWebSocketChat -- token rotation', () => {
     })
     expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
   })
+
+  /**
+   * Regression: the auth_expired guard must require BOTH the documented
+   * backend fields (`code === 'user_auth_error'` and `message ===
+   * 'auth_expired'`). An unrelated agent/workflow error that happens to
+   * carry `message: 'auth_expired'` (e.g. user-facing text from a tool)
+   * must surface as an error card, not silently trigger a phantom
+   * reconnect that masks the real failure.
+   */
+  test('error with auth_expired message but non-auth code surfaces a banner (no silent reconnect)', async () => {
+    const { result } = await mountAndArmTimers()
+    mockWsClient.isConnected.mockReturnValue(true)
+
+    act(() => {
+      result.current.sendMessage('Hello')
+    })
+
+    mockWsClient.sendMessage.mockClear()
+    mockWsClient.disconnect.mockClear()
+    mockWsClient.connect.mockClear()
+    mockAddErrorCard.mockClear()
+
+    act(() => {
+      capturedCallbacks.onError?.({
+        code: 'workflow_error',
+        message: 'auth_expired',
+      })
+    })
+
+    // Must be treated as a generic application error: banner shown, NO
+    // rotation, NO drain on the next 'connected'.
+    expect(mockAddErrorCard).toHaveBeenCalled()
+    expect(mockWsClient.disconnect).not.toHaveBeenCalled()
+    expect(mockWsClient.connect).not.toHaveBeenCalled()
+
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('connected')
+    })
+    expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
+  })
+
+  /**
+   * Regression: a pre-flight rotation that drains the buffer must update
+   * `lastSentMessageRef`, so a follow-up `auth_expired` on the freshly
+   * rotated socket can re-buffer the same payload. Without this, the
+   * second auth_expired finds `lastSentMessageRef === null` and the
+   * user's message is silently dropped (no error card, no resend).
+   */
+  test('preflight rotation -> drain -> auth_expired chains the resend (no silent loss)', async () => {
+    const { result } = await mountAndArmTimers()
+
+    // Move past expiry so the preflight branch fires inside sendMessage.
+    vi.setSystemTime(EXP_AT_S * 1000 + 1)
+    mockWsClient.isConnected.mockReturnValue(true)
+    mockWsClient.sendMessage.mockClear()
+    mockWsClient.disconnect.mockClear()
+    mockWsClient.connect.mockClear()
+
+    act(() => {
+      result.current.sendMessage('Pre-flight payload')
+    })
+
+    // Pre-flight: buffered, rotation kicked off, NOT yet on the wire.
+    expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
+    expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.connect).toHaveBeenCalledTimes(1)
+
+    // Fresh socket connects -> drain puts the buffered payload on the wire.
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('connected')
+    })
+    expect(mockWsClient.sendMessage).toHaveBeenCalledWith('Pre-flight payload', expect.any(Array))
+
+    mockWsClient.sendMessage.mockClear()
+    mockWsClient.disconnect.mockClear()
+    mockWsClient.connect.mockClear()
+    mockAddErrorCard.mockClear()
+
+    // The fresh socket ALSO comes back with auth_expired (e.g. a NextAuth
+    // refresh race left two stale tokens in a row). The handler must be
+    // able to re-buffer the same payload via lastSentMessageRef -- which
+    // the drain block is responsible for populating.
+    act(() => {
+      capturedCallbacks.onError?.({
+        code: 'user_auth_error',
+        message: 'auth_expired',
+      })
+    })
+    expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.connect).toHaveBeenCalledTimes(1)
+    // Critically: silent for the user. No banner.
+    expect(mockAddErrorCard).not.toHaveBeenCalled()
+
+    // Second drain must put the SAME payload back on the wire. If the
+    // drain block forgot to populate lastSentMessageRef, this assertion
+    // fails and the user's message is silently lost.
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('connected')
+    })
+    expect(mockWsClient.sendMessage).toHaveBeenCalledWith('Pre-flight payload', expect.any(Array))
+  })
 })

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
@@ -1633,6 +1633,125 @@ describe('useWebSocketChat -- token rotation', () => {
   })
 
   /**
+   * Regression for the silent-rotation-loop class of bug.
+   *
+   * `rotate()` resets `reconnectCount` to 0 inside the WS client, so the
+   * client's own CONNECTION_FAILED safety net never trips on the
+   * auth_expired path. Without an explicit cap in the hook, a
+   * stale-NextAuth-cache or clock-skew condition where `getSession()`
+   * keeps returning the same already-expired JWT can drive dozens of
+   * silent rotations per minute: the user just stares at a spinner that
+   * never resolves and the server is forced to churn handshake slots.
+   *
+   * The cap bails after MAX_CONSECUTIVE_AUTH_EXPIRED rotations, clears
+   * both resend buffers, and surfaces `auth.session_expired` so the user
+   * can re-sign-in.
+   */
+  test('cap on consecutive auth_expired surfaces session_expired after 3 rotations', async () => {
+    const { result } = await mountAndArmTimers()
+    mockWsClient.isConnected.mockReturnValue(true)
+
+    act(() => {
+      result.current.sendMessage('What is X?')
+    })
+    expect(mockWsClient.sendMessage).toHaveBeenLastCalledWith('What is X?', expect.any(Array))
+
+    mockWsClient.sendMessage.mockClear()
+    mockWsClient.rotate.mockClear()
+    mockAddErrorCard.mockClear()
+
+    const triggerAuthExpired = () => {
+      act(() => {
+        capturedCallbacks.onError?.({
+          code: 'user_auth_error',
+          message: 'auth_expired',
+        })
+      })
+    }
+
+    // First three auth_expired errors: rotate silently as designed --
+    // this is the normal silent-reconnect path users rely on.
+    triggerAuthExpired()
+    triggerAuthExpired()
+    triggerAuthExpired()
+    expect(mockWsClient.rotate).toHaveBeenCalledTimes(3)
+    expect(mockAddErrorCard).not.toHaveBeenCalled()
+
+    mockWsClient.rotate.mockClear()
+
+    // Fourth in a row: bail out. Banner up, NO more rotate, buffers
+    // cleared so a later recovery-driven 'connected' doesn't quietly
+    // replay the original payload.
+    triggerAuthExpired()
+
+    expect(mockWsClient.rotate).not.toHaveBeenCalled()
+    expect(mockAddErrorCard).toHaveBeenCalledWith(
+      'auth.session_expired',
+      expect.stringMatching(/sign in/i),
+      undefined,
+    )
+
+    mockWsClient.sendMessage.mockClear()
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('connected')
+    })
+    expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
+  })
+
+  /**
+   * The consecutive-auth_expired counter must reset on ANY successful
+   * frame from the backend. A passing response proves the post-rotation
+   * auth is alive, so a subsequent, independent auth_expired (e.g.
+   * the *next* JWT also expiring later in the session) starts a fresh
+   * silent-reconnect budget -- it must not inherit the previous run's
+   * counter and trip the cap prematurely.
+   */
+  test('successful response between auth_expired errors resets the rotation budget', async () => {
+    const { result } = await mountAndArmTimers()
+    mockWsClient.isConnected.mockReturnValue(true)
+
+    act(() => {
+      result.current.sendMessage('Q1')
+    })
+
+    mockWsClient.rotate.mockClear()
+    mockAddErrorCard.mockClear()
+
+    // 3 in a row -- right at the cap, still silent.
+    for (let i = 0; i < 3; i++) {
+      act(() => {
+        capturedCallbacks.onError?.({
+          code: 'user_auth_error',
+          message: 'auth_expired',
+        })
+      })
+    }
+    expect(mockWsClient.rotate).toHaveBeenCalledTimes(3)
+    expect(mockAddErrorCard).not.toHaveBeenCalled()
+
+    // A response arrives -- the latest rotation succeeded after all.
+    // onResponse's stale guard requires isStreaming=true.
+    mockStoreState.isStreaming = true
+    act(() => {
+      capturedCallbacks.onResponse?.('Here is the answer', 'in_progress', false)
+    })
+
+    mockWsClient.rotate.mockClear()
+
+    // An independent auth_expired much later in the session must rotate
+    // silently again (NOT surface the banner from the previous run's
+    // counter).
+    act(() => {
+      capturedCallbacks.onError?.({
+        code: 'user_auth_error',
+        message: 'auth_expired',
+      })
+    })
+    expect(mockWsClient.rotate).toHaveBeenCalledTimes(1)
+    expect(mockAddErrorCard).not.toHaveBeenCalled()
+  })
+
+  /**
    * Stale-token preflight applies to HITL responses too. If the socket
    * still reports connected but its JWT is already past `exp`, the
    * backend will reject the answer. respondToInteraction must buffer the

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
@@ -1752,6 +1752,88 @@ describe('useWebSocketChat -- token rotation', () => {
   })
 
   /**
+   * Regression for cross-conversation data leak.
+   *
+   * The resend buffers (`pendingOutgoingRef`, `lastSentOutgoingRef`)
+   * and the consecutive-auth_expired counter are conversation-scoped.
+   * If left intact when the user switches conversations, the next
+   * conversation's freshly-handshaken socket would drain the previous
+   * conversation's payload into its own backend session on the first
+   * `connected` event -- delivering user-typed content (chat message
+   * or HITL response) to the wrong conversation's backend context.
+   *
+   * The conversation-switch cleanup must wipe both buffers, so the new
+   * conversation starts with a clean slate.
+   */
+  test('switching conversations clears resend buffers (no cross-conversation drain)', async () => {
+    mockStoreState.currentConversation = { id: 'conv-A', messages: [], userId: 'user-1' }
+
+    const { result, rerender } = await mountAndArmTimers()
+    mockWsClient.isConnected.mockReturnValue(true)
+
+    // 1) In conv A, send a message and let it through. lastSentOutgoingRef
+    //    is now populated with conv A's payload.
+    act(() => {
+      result.current.sendMessage('Secret payload for conv A')
+    })
+    expect(mockWsClient.sendMessage).toHaveBeenLastCalledWith(
+      'Secret payload for conv A',
+      expect.any(Array),
+    )
+
+    // 2) Backend rejects with auth_expired -- pendingOutgoingRef is
+    //    populated (copied from lastSentOutgoingRef), rotation kicks off.
+    //    At this point BOTH buffers carry conv A's payload.
+    mockWsClient.sendMessage.mockClear()
+    mockWsClient.rotate.mockClear()
+    act(() => {
+      capturedCallbacks.onError?.({
+        code: 'user_auth_error',
+        message: 'auth_expired',
+      })
+    })
+    expect(mockWsClient.rotate).toHaveBeenCalledTimes(1)
+
+    // 3) BEFORE the post-rotation 'connected' drain fires, the user
+    //    switches to conv B. The conversation-switch cleanup must wipe
+    //    both buffers; otherwise conv B's first `connected` would
+    //    silently submit conv A's payload to conv B's session.
+    mockStoreState.currentConversation = { id: 'conv-B', messages: [], userId: 'user-1' }
+    await act(async () => {
+      rerender()
+    })
+
+    // 4) Conv B's fresh socket connects. The drain MUST be a no-op:
+    //    pendingOutgoingRef is null, so neither sendMessage nor
+    //    sendInteractionResponse fire. Conv A's payload stays in conv A.
+    mockWsClient.sendMessage.mockClear()
+    mockWsClient.sendInteractionResponse.mockClear()
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('connected')
+    })
+    expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
+    expect(mockWsClient.sendInteractionResponse).not.toHaveBeenCalled()
+
+    // 5) An auth_expired arriving on conv B's socket must also be unable
+    //    to re-buffer conv A's payload (lastSentOutgoingRef was cleared
+    //    too). Without that ref, the auth_expired handler simply rotates
+    //    with no buffer -- no cross-conversation poisoning.
+    mockWsClient.rotate.mockClear()
+    act(() => {
+      capturedCallbacks.onError?.({
+        code: 'user_auth_error',
+        message: 'auth_expired',
+      })
+    })
+    expect(mockWsClient.rotate).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('connected')
+    })
+    expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
+  })
+
+  /**
    * Stale-token preflight applies to HITL responses too. If the socket
    * still reports connected but its JWT is already past `exp`, the
    * backend will reject the answer. respondToInteraction must buffer the

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
@@ -1875,9 +1875,11 @@ describe('useWebSocketChat -- token rotation', () => {
     // Preflight: rotate kicked off, response NOT yet on the wire.
     expect(mockWsClient.sendInteractionResponse).not.toHaveBeenCalled()
     expect(mockWsClient.rotate).toHaveBeenCalledTimes(1)
+    mockSetLoading.mockClear()
 
     // Fresh socket connects -> drain dispatches via sendInteractionResponse,
-    // NOT sendMessage.
+    // NOT sendMessage. The HITL loading state should stay active while the
+    // backend processes the answer, matching respondToInteraction.doSend().
     act(() => {
       capturedCallbacks.onConnectionChange?.('connected')
     })
@@ -1887,5 +1889,6 @@ describe('useWebSocketChat -- token rotation', () => {
       'Yes, confirmed'
     )
     expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
+    expect(mockSetLoading).toHaveBeenCalledWith(true)
   })
 })

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
@@ -1298,6 +1298,59 @@ describe('useWebSocketChat -- token rotation', () => {
     )
   })
 
+  /**
+   * Regression: an `auth_expired` rotation that fails (CONNECTION_FAILED)
+   * must drop `pendingOutgoingRef`. Otherwise, when the connection later
+   * recovers via `useConnectionRecovery`, the stale buffered message would
+   * be silently re-sent at a point where the UI has already shown the user
+   * a failure state -- a "phantom resend" the user never asked for.
+   */
+  test('auth_expired -> CONNECTION_FAILED clears resend buffer (no phantom resend on recovery)', async () => {
+    const { result } = await mountAndArmTimers()
+    mockWsClient.isConnected.mockReturnValue(true)
+
+    act(() => {
+      result.current.sendMessage('Original question')
+    })
+
+    mockWsClient.sendMessage.mockClear()
+    mockWsClient.disconnect.mockClear()
+    mockWsClient.connect.mockClear()
+    mockAddErrorCard.mockClear()
+
+    // Backend rejects with auth_expired -- buffer is populated and rotation kicks off.
+    act(() => {
+      capturedCallbacks.onError?.({
+        code: 'user_auth_error',
+        message: 'auth_expired',
+      })
+    })
+    expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.connect).toHaveBeenCalledTimes(1)
+
+    // Rotation cannot recover -- WS client exhausts retries and emits
+    // CONNECTION_FAILED. UI shows a failure card to the user.
+    mockCheckBackendHealthCached.mockResolvedValue(true)
+    await act(async () => {
+      await capturedCallbacks.onError?.({
+        code: 'CONNECTION_FAILED',
+        message: 'Unable to connect to the server.',
+      })
+    })
+    expect(mockAddErrorCard).toHaveBeenCalled()
+
+    mockWsClient.sendMessage.mockClear()
+
+    // Later, useConnectionRecovery polls health and the connection comes
+    // back. The 'connected' transition must NOT replay the original
+    // message: the user has already seen the failure and may have moved
+    // on. A silent resend at this point would be the bug.
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('connected')
+    })
+    expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
+  })
+
   test('non-auth_expired error still surfaces an error card and clears resend buffer', async () => {
     const { result } = await mountAndArmTimers()
     mockWsClient.isConnected.mockReturnValue(true)

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
@@ -190,6 +190,7 @@ vi.mock('@/features/documents/store', () => ({
 const mockWsClient = {
   connect: vi.fn(),
   disconnect: vi.fn(),
+  rotate: vi.fn(),
   sendMessage: vi.fn(),
   sendInteractionResponse: vi.fn(),
   isConnected: vi.fn(() => false),
@@ -982,6 +983,7 @@ describe('useWebSocketChat -- token rotation', () => {
   test('soft timer rotates the socket when the chat is idle', async () => {
     await mountAndArmTimers()
     mockStoreState.isStreaming = false
+    mockWsClient.rotate.mockClear()
     mockWsClient.disconnect.mockClear()
     mockWsClient.connect.mockClear()
 
@@ -989,8 +991,11 @@ describe('useWebSocketChat -- token rotation', () => {
       vi.advanceTimersByTime(SOFT_DELAY_MS)
     })
 
-    expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
-    expect(mockWsClient.connect).toHaveBeenCalledTimes(1)
+    // Rotation goes through the atomic client.rotate() primitive -- NOT
+    // the disconnect()+connect() interleave, which has the onclose race
+    // (see NATWebSocketClient.rotate() docstring).
+    expect(mockWsClient.rotate).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.disconnect).not.toHaveBeenCalled()
     // Idle rotation must be silent -- no error/banner is shown to the user.
     expect(mockAddErrorCard).not.toHaveBeenCalled()
     expect(mockSetStreaming).not.toHaveBeenCalledWith(false)
@@ -1008,6 +1013,7 @@ describe('useWebSocketChat -- token rotation', () => {
       rerender()
     })
 
+    mockWsClient.rotate.mockClear()
     mockWsClient.disconnect.mockClear()
     mockWsClient.connect.mockClear()
 
@@ -1018,8 +1024,8 @@ describe('useWebSocketChat -- token rotation', () => {
     // Soft timer fired and was deferred -- in-flight stream is preserved.
     // Critically, no banner: the user should not see a "session expired"
     // message just because the rotation timer fired.
+    expect(mockWsClient.rotate).not.toHaveBeenCalled()
     expect(mockWsClient.disconnect).not.toHaveBeenCalled()
-    expect(mockWsClient.connect).not.toHaveBeenCalled()
     expect(mockAddErrorCard).not.toHaveBeenCalled()
     // No premature stream cleanup either: setStreaming(false) must NOT have
     // been called as a side-effect of the rotation timer.
@@ -1032,8 +1038,8 @@ describe('useWebSocketChat -- token rotation', () => {
       rerender()
     })
 
-    expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
-    expect(mockWsClient.connect).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.rotate).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.disconnect).not.toHaveBeenCalled()
     expect(mockAddErrorCard).not.toHaveBeenCalled()
   })
 
@@ -1063,6 +1069,7 @@ describe('useWebSocketChat -- token rotation', () => {
   test('updated idTokenExpiresAt re-arms timers; old timers do not double-fire', async () => {
     await mountAndArmTimers()
     mockStoreState.isStreaming = false
+    mockWsClient.rotate.mockClear()
     mockWsClient.disconnect.mockClear()
     mockWsClient.connect.mockClear()
 
@@ -1081,8 +1088,7 @@ describe('useWebSocketChat -- token rotation', () => {
       vi.advanceTimersByTime(SOFT_DELAY_MS)
     })
 
-    expect(mockWsClient.disconnect).not.toHaveBeenCalled()
-    expect(mockWsClient.connect).not.toHaveBeenCalled()
+    expect(mockWsClient.rotate).not.toHaveBeenCalled()
 
     // Advance to the new soft deadline; rotation should fire exactly once.
     const NEW_SOFT_DELAY_MS = 1_140_000 - SOFT_DELAY_MS
@@ -1090,14 +1096,14 @@ describe('useWebSocketChat -- token rotation', () => {
       vi.advanceTimersByTime(NEW_SOFT_DELAY_MS)
     })
 
-    expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
-    expect(mockWsClient.connect).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.rotate).toHaveBeenCalledTimes(1)
   })
 
   test('failed getSession does not crash and leaves prior timers intact', async () => {
     const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     await mountAndArmTimers()
     mockStoreState.isStreaming = false
+    mockWsClient.rotate.mockClear()
     mockWsClient.disconnect.mockClear()
     mockWsClient.connect.mockClear()
 
@@ -1113,8 +1119,7 @@ describe('useWebSocketChat -- token rotation', () => {
       vi.advanceTimersByTime(SOFT_DELAY_MS)
     })
 
-    expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
-    expect(mockWsClient.connect).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.rotate).toHaveBeenCalledTimes(1)
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       expect.stringContaining('getSession before WS reconnect failed'),
       expect.any(Error)
@@ -1138,6 +1143,7 @@ describe('useWebSocketChat -- token rotation', () => {
     await act(async () => {
       await capturedOnBeforeReconnect?.()
     })
+    mockWsClient.rotate.mockClear()
     mockWsClient.disconnect.mockClear()
     mockWsClient.connect.mockClear()
 
@@ -1145,8 +1151,7 @@ describe('useWebSocketChat -- token rotation', () => {
       vi.advanceTimersByTime(SOFT_DELAY_MS + 60_000)
     })
 
-    expect(mockWsClient.disconnect).not.toHaveBeenCalled()
-    expect(mockWsClient.connect).not.toHaveBeenCalled()
+    expect(mockWsClient.rotate).not.toHaveBeenCalled()
     // refreshAuthBeforeReconnect short-circuits when !authRequired, so
     // getSession should never be called.
     expect(mockGetSession).not.toHaveBeenCalled()
@@ -1155,6 +1160,7 @@ describe('useWebSocketChat -- token rotation', () => {
   test('cleanup on unmount cancels the pending soft timer', async () => {
     const { unmount } = await mountAndArmTimers()
     mockStoreState.isStreaming = false
+    mockWsClient.rotate.mockClear()
     mockWsClient.disconnect.mockClear()
     mockWsClient.connect.mockClear()
 
@@ -1165,10 +1171,10 @@ describe('useWebSocketChat -- token rotation', () => {
     })
 
     // The unmount-triggered conversation-cleanup useEffect calls disconnect()
-    // exactly once. Crucially, NO additional connect/disconnect should fire
-    // from the rotation timer after unmount.
+    // exactly once. Crucially, NO rotation should fire from the rotation
+    // timer after unmount.
     expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
-    expect(mockWsClient.connect).not.toHaveBeenCalled()
+    expect(mockWsClient.rotate).not.toHaveBeenCalled()
   })
 
   /**
@@ -1192,8 +1198,7 @@ describe('useWebSocketChat -- token rotation', () => {
     // Socket is "connected" but the underlying token is already past `exp`.
     mockWsClient.isConnected.mockReturnValue(true)
     mockWsClient.sendMessage.mockClear()
-    mockWsClient.disconnect.mockClear()
-    mockWsClient.connect.mockClear()
+    mockWsClient.rotate.mockClear()
 
     act(() => {
       result.current.sendMessage('Hello after long idle')
@@ -1202,8 +1207,7 @@ describe('useWebSocketChat -- token rotation', () => {
     // Pre-flight: must NOT send through the stale socket. Instead,
     // rotate the connection so the new handshake carries a fresh cookie.
     expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
-    expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
-    expect(mockWsClient.connect).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.rotate).toHaveBeenCalledTimes(1)
 
     // Simulate the handshake completing: the captured onConnectionChange
     // is invoked with 'connected' and should drain the buffered message.
@@ -1224,22 +1228,21 @@ describe('useWebSocketChat -- token rotation', () => {
     // Token still valid (10min in the future). No pre-flight rotation.
     mockWsClient.isConnected.mockReturnValue(true)
     mockWsClient.sendMessage.mockClear()
-    mockWsClient.disconnect.mockClear()
-    mockWsClient.connect.mockClear()
+    mockWsClient.rotate.mockClear()
 
     act(() => {
       result.current.sendMessage('Hello')
     })
 
     expect(mockWsClient.sendMessage).toHaveBeenCalledWith('Hello', expect.any(Array))
-    expect(mockWsClient.disconnect).not.toHaveBeenCalled()
+    expect(mockWsClient.rotate).not.toHaveBeenCalled()
   })
 
   /**
    * `auth_expired` from the backend (per-message JWT re-auth on the WS
    * handler) must NOT bubble up to the user as an error. The hook should:
    *   1. NOT show a banner (no addErrorCard call)
-   *   2. Buffer the just-sent payload (lastSentMessageRef -> pendingOutgoingRef)
+   *   2. Buffer the just-sent payload (lastSentOutgoingRef -> pendingOutgoingRef)
    *   3. Rotate the socket so the new handshake reads a fresh idToken
    *   4. On 'connected', drain the buffer and re-issue the original message
    * Net effect for the user: brief reconnect, then their answer arrives.
@@ -1248,7 +1251,7 @@ describe('useWebSocketChat -- token rotation', () => {
     const { result } = await mountAndArmTimers()
     mockWsClient.isConnected.mockReturnValue(true)
 
-    // Send a message so lastSentMessageRef is populated. doSend() captures
+    // Send a message so lastSentOutgoingRef is populated. doSend() captures
     // both the content and the resolved data sources, mirroring what the
     // user actually saw on the wire.
     act(() => {
@@ -1257,8 +1260,7 @@ describe('useWebSocketChat -- token rotation', () => {
     expect(mockWsClient.sendMessage).toHaveBeenLastCalledWith('What is the weather?', expect.any(Array))
 
     mockWsClient.sendMessage.mockClear()
-    mockWsClient.disconnect.mockClear()
-    mockWsClient.connect.mockClear()
+    mockWsClient.rotate.mockClear()
     mockAddErrorCard.mockClear()
     // Reset streaming/loading mocks so we only assert on post-error calls
     // (sendMessage already drove them through their normal start-of-request
@@ -1283,9 +1285,8 @@ describe('useWebSocketChat -- token rotation', () => {
     // onError step itself nothing should fire.)
     expect(mockSetStreaming).not.toHaveBeenCalled()
     expect(mockSetLoading).not.toHaveBeenCalled()
-    // Rotation kicked off.
-    expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
-    expect(mockWsClient.connect).toHaveBeenCalledTimes(1)
+    // Rotation kicked off via the atomic client.rotate() primitive.
+    expect(mockWsClient.rotate).toHaveBeenCalledTimes(1)
 
     // Simulate the new handshake completing -> drain buffered message.
     act(() => {
@@ -1314,8 +1315,7 @@ describe('useWebSocketChat -- token rotation', () => {
     })
 
     mockWsClient.sendMessage.mockClear()
-    mockWsClient.disconnect.mockClear()
-    mockWsClient.connect.mockClear()
+    mockWsClient.rotate.mockClear()
     mockAddErrorCard.mockClear()
 
     // Backend rejects with auth_expired -- buffer is populated and rotation kicks off.
@@ -1325,8 +1325,7 @@ describe('useWebSocketChat -- token rotation', () => {
         message: 'auth_expired',
       })
     })
-    expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
-    expect(mockWsClient.connect).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.rotate).toHaveBeenCalledTimes(1)
 
     // Rotation cannot recover -- WS client exhausts retries and emits
     // CONNECTION_FAILED. UI shows a failure card to the user.
@@ -1360,8 +1359,7 @@ describe('useWebSocketChat -- token rotation', () => {
     })
 
     mockWsClient.sendMessage.mockClear()
-    mockWsClient.disconnect.mockClear()
-    mockWsClient.connect.mockClear()
+    mockWsClient.rotate.mockClear()
     mockAddErrorCard.mockClear()
 
     // Generic backend error (NOT auth_expired) -- must show a banner
@@ -1374,8 +1372,7 @@ describe('useWebSocketChat -- token rotation', () => {
     })
 
     expect(mockAddErrorCard).toHaveBeenCalled()
-    expect(mockWsClient.disconnect).not.toHaveBeenCalled()
-    expect(mockWsClient.connect).not.toHaveBeenCalled()
+    expect(mockWsClient.rotate).not.toHaveBeenCalled()
 
     // After this generic error, an unrelated 'connected' event (e.g. a
     // routine soft rotation) must NOT replay the message: that would be
@@ -1403,8 +1400,7 @@ describe('useWebSocketChat -- token rotation', () => {
     })
 
     mockWsClient.sendMessage.mockClear()
-    mockWsClient.disconnect.mockClear()
-    mockWsClient.connect.mockClear()
+    mockWsClient.rotate.mockClear()
     mockAddErrorCard.mockClear()
 
     act(() => {
@@ -1417,8 +1413,7 @@ describe('useWebSocketChat -- token rotation', () => {
     // Must be treated as a generic application error: banner shown, NO
     // rotation, NO drain on the next 'connected'.
     expect(mockAddErrorCard).toHaveBeenCalled()
-    expect(mockWsClient.disconnect).not.toHaveBeenCalled()
-    expect(mockWsClient.connect).not.toHaveBeenCalled()
+    expect(mockWsClient.rotate).not.toHaveBeenCalled()
 
     act(() => {
       capturedCallbacks.onConnectionChange?.('connected')
@@ -1428,9 +1423,9 @@ describe('useWebSocketChat -- token rotation', () => {
 
   /**
    * Regression: a pre-flight rotation that drains the buffer must update
-   * `lastSentMessageRef`, so a follow-up `auth_expired` on the freshly
+   * `lastSentOutgoingRef`, so a follow-up `auth_expired` on the freshly
    * rotated socket can re-buffer the same payload. Without this, the
-   * second auth_expired finds `lastSentMessageRef === null` and the
+   * second auth_expired finds `lastSentOutgoingRef === null` and the
    * user's message is silently dropped (no error card, no resend).
    */
   test('preflight rotation -> drain -> auth_expired chains the resend (no silent loss)', async () => {
@@ -1440,8 +1435,7 @@ describe('useWebSocketChat -- token rotation', () => {
     vi.setSystemTime(EXP_AT_S * 1000 + 1)
     mockWsClient.isConnected.mockReturnValue(true)
     mockWsClient.sendMessage.mockClear()
-    mockWsClient.disconnect.mockClear()
-    mockWsClient.connect.mockClear()
+    mockWsClient.rotate.mockClear()
 
     act(() => {
       result.current.sendMessage('Pre-flight payload')
@@ -1449,8 +1443,7 @@ describe('useWebSocketChat -- token rotation', () => {
 
     // Pre-flight: buffered, rotation kicked off, NOT yet on the wire.
     expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
-    expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
-    expect(mockWsClient.connect).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.rotate).toHaveBeenCalledTimes(1)
 
     // Fresh socket connects -> drain puts the buffered payload on the wire.
     act(() => {
@@ -1459,13 +1452,12 @@ describe('useWebSocketChat -- token rotation', () => {
     expect(mockWsClient.sendMessage).toHaveBeenCalledWith('Pre-flight payload', expect.any(Array))
 
     mockWsClient.sendMessage.mockClear()
-    mockWsClient.disconnect.mockClear()
-    mockWsClient.connect.mockClear()
+    mockWsClient.rotate.mockClear()
     mockAddErrorCard.mockClear()
 
     // The fresh socket ALSO comes back with auth_expired (e.g. a NextAuth
     // refresh race left two stale tokens in a row). The handler must be
-    // able to re-buffer the same payload via lastSentMessageRef -- which
+    // able to re-buffer the same payload via lastSentOutgoingRef -- which
     // the drain block is responsible for populating.
     act(() => {
       capturedCallbacks.onError?.({
@@ -1473,17 +1465,226 @@ describe('useWebSocketChat -- token rotation', () => {
         message: 'auth_expired',
       })
     })
-    expect(mockWsClient.disconnect).toHaveBeenCalledTimes(1)
-    expect(mockWsClient.connect).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.rotate).toHaveBeenCalledTimes(1)
     // Critically: silent for the user. No banner.
     expect(mockAddErrorCard).not.toHaveBeenCalled()
 
     // Second drain must put the SAME payload back on the wire. If the
-    // drain block forgot to populate lastSentMessageRef, this assertion
+    // drain block forgot to populate lastSentOutgoingRef, this assertion
     // fails and the user's message is silently lost.
     act(() => {
       capturedCallbacks.onConnectionChange?.('connected')
     })
     expect(mockWsClient.sendMessage).toHaveBeenCalledWith('Pre-flight payload', expect.any(Array))
+  })
+
+  /**
+   * Regression for the HITL `auth_expired` gap: the backend applies the
+   * same per-message expiry gate to `WebSocketUserInteractionResponseMessage`
+   * as it does to chat messages. If the user answers a HITL prompt right
+   * after the handshake token expires, `respondToInteraction()` used to
+   * bypass the rotation buffer entirely: it sent directly through
+   * `sendInteractionResponse()`, never populating `lastSentOutgoingRef`.
+   * The auth_expired handler would then either replay the previous chat
+   * message OR (if no prior chat existed) rotate with an empty buffer --
+   * silently losing the user's answer.
+   *
+   * The fix mirrors `sendMessage`'s rotation handling: record the HITL
+   * payload in `lastSentOutgoingRef` after a successful send, and let
+   * `onError(auth_expired)` re-buffer it for the post-rotation drain.
+   */
+  test('respondToInteraction + auth_expired re-issues the HITL response (not lost, not replaced)', async () => {
+    mockStoreState.pendingInteraction = {
+      id: 'prompt-1',
+      parentId: 'parent-1',
+      inputType: 'text',
+      text: 'Clarify your question?',
+    }
+    mockStoreState.currentConversation = {
+      id: 'conv-1',
+      messages: [
+        {
+          id: 'msg-1',
+          messageType: 'prompt',
+          isPromptResponded: false,
+          content: 'Clarify your question?',
+        },
+      ],
+      userId: 'user-1',
+    }
+
+    const { result } = await mountAndArmTimers()
+    mockWsClient.isConnected.mockReturnValue(true)
+    mockWsClient.sendInteractionResponse.mockClear()
+    mockWsClient.sendMessage.mockClear()
+    mockWsClient.rotate.mockClear()
+    mockAddErrorCard.mockClear()
+
+    // User answers the HITL prompt -- normal connected path.
+    act(() => {
+      result.current.respondToInteraction('Yes, proceed with option A')
+    })
+    expect(mockWsClient.sendInteractionResponse).toHaveBeenCalledWith(
+      'prompt-1',
+      'parent-1',
+      'Yes, proceed with option A'
+    )
+
+    mockWsClient.sendInteractionResponse.mockClear()
+    mockWsClient.sendMessage.mockClear()
+
+    // Backend rejects mid-workflow with auth_expired -- the per-message
+    // re-auth gate fired on the HITL response.
+    act(() => {
+      capturedCallbacks.onError?.({
+        code: 'user_auth_error',
+        message: 'auth_expired',
+      })
+    })
+
+    // Silent rotation, no banner.
+    expect(mockWsClient.rotate).toHaveBeenCalledTimes(1)
+    expect(mockAddErrorCard).not.toHaveBeenCalled()
+
+    // Fresh socket connects -> drain MUST re-issue the HITL response
+    // (NOT sendMessage of a stale chat payload).
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('connected')
+    })
+    expect(mockWsClient.sendInteractionResponse).toHaveBeenCalledWith(
+      'prompt-1',
+      'parent-1',
+      'Yes, proceed with option A'
+    )
+    expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
+  })
+
+  /**
+   * Regression for the cross-payload poisoning case: previously the
+   * resend buffer only tracked chat messages, so a HITL answer after a
+   * previously-sent chat message would replay the OLD chat message on
+   * auth_expired, not the user's HITL response. With the discriminated
+   * union, the HITL send overwrites `lastSentOutgoingRef` and the drain
+   * dispatches by `kind`.
+   */
+  test('HITL response after a chat send replays the HITL on auth_expired (no cross-payload poisoning)', async () => {
+    mockStoreState.pendingInteraction = {
+      id: 'prompt-2',
+      parentId: 'parent-2',
+      inputType: 'text',
+      text: 'Need more detail?',
+    }
+    mockStoreState.currentConversation = {
+      id: 'conv-1',
+      messages: [
+        {
+          id: 'msg-1',
+          messageType: 'prompt',
+          isPromptResponded: false,
+          content: 'Need more detail?',
+        },
+      ],
+      userId: 'user-1',
+    }
+
+    const { result } = await mountAndArmTimers()
+    mockWsClient.isConnected.mockReturnValue(true)
+
+    // 1) Earlier chat send populates lastSentOutgoingRef with a 'message' payload.
+    act(() => {
+      result.current.sendMessage('Original chat question')
+    })
+    expect(mockWsClient.sendMessage).toHaveBeenLastCalledWith('Original chat question', expect.any(Array))
+
+    mockWsClient.sendMessage.mockClear()
+    mockWsClient.sendInteractionResponse.mockClear()
+    mockWsClient.rotate.mockClear()
+
+    // 2) HITL response on the same socket -- must OVERWRITE lastSentOutgoingRef.
+    act(() => {
+      result.current.respondToInteraction('Yes, full report please')
+    })
+    expect(mockWsClient.sendInteractionResponse).toHaveBeenCalledWith(
+      'prompt-2',
+      'parent-2',
+      'Yes, full report please'
+    )
+
+    mockWsClient.sendInteractionResponse.mockClear()
+
+    // 3) Backend returns auth_expired AFTER the HITL response.
+    act(() => {
+      capturedCallbacks.onError?.({
+        code: 'user_auth_error',
+        message: 'auth_expired',
+      })
+    })
+
+    // 4) Drain MUST replay the HITL response, not the earlier chat message.
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('connected')
+    })
+    expect(mockWsClient.sendInteractionResponse).toHaveBeenCalledWith(
+      'prompt-2',
+      'parent-2',
+      'Yes, full report please'
+    )
+    expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
+  })
+
+  /**
+   * Stale-token preflight applies to HITL responses too. If the socket
+   * still reports connected but its JWT is already past `exp`, the
+   * backend will reject the answer. respondToInteraction must buffer the
+   * payload, rotate, and let the drain re-issue it -- exactly as
+   * sendMessage does.
+   */
+  test('respondToInteraction with stale token rotates and drains the HITL response', async () => {
+    mockStoreState.pendingInteraction = {
+      id: 'prompt-3',
+      parentId: 'parent-3',
+      inputType: 'text',
+      text: 'Confirm?',
+    }
+    mockStoreState.currentConversation = {
+      id: 'conv-1',
+      messages: [
+        {
+          id: 'msg-1',
+          messageType: 'prompt',
+          isPromptResponded: false,
+          content: 'Confirm?',
+        },
+      ],
+      userId: 'user-1',
+    }
+
+    const { result } = await mountAndArmTimers()
+
+    // Move past expiry so the preflight branch fires.
+    vi.setSystemTime(EXP_AT_S * 1000 + 1)
+    mockWsClient.isConnected.mockReturnValue(true)
+    mockWsClient.sendInteractionResponse.mockClear()
+    mockWsClient.rotate.mockClear()
+
+    act(() => {
+      result.current.respondToInteraction('Yes, confirmed')
+    })
+
+    // Preflight: rotate kicked off, response NOT yet on the wire.
+    expect(mockWsClient.sendInteractionResponse).not.toHaveBeenCalled()
+    expect(mockWsClient.rotate).toHaveBeenCalledTimes(1)
+
+    // Fresh socket connects -> drain dispatches via sendInteractionResponse,
+    // NOT sendMessage.
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('connected')
+    })
+    expect(mockWsClient.sendInteractionResponse).toHaveBeenCalledWith(
+      'prompt-3',
+      'parent-3',
+      'Yes, confirmed'
+    )
+    expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
   })
 })

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -777,7 +777,10 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
             // `lastSentOutgoingRef` and silently drop the user's payload
             // (the auth_expired handler couldn't re-buffer it).
             lastSentOutgoingRef.current = pending
-            setLoading(false)
+            // Match each send path's loading contract: chat sends clear the
+            // composer spinner after putting the message on the wire, while
+            // HITL answers keep it visible until the backend processes them.
+            setLoading(pending.kind === 'interaction')
           }
           return
         }

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -61,6 +61,17 @@ const EMPTY_MESSAGES: ChatMessage[] = []
 const EMPTY_CONVERSATIONS: Conversation[] = []
 
 /**
+ * Buffer entry for an outgoing payload that has to bridge a socket
+ * rotation. Discriminated by `kind` because both chat messages and HITL
+ * interaction responses can hit `auth_expired` at the backend, and the
+ * drain on the freshly-handshaken socket has to dispatch back to the
+ * right `NATWebSocketClient` method.
+ */
+type PendingOutgoing =
+  | { kind: 'message'; content: string; dataSources: string[] }
+  | { kind: 'interaction'; interactionId: string; parentId: string; response: string }
+
+/**
  * Seconds before token expiry to proactively rotate the WebSocket. The
  * backend only validates the JWT at the WS upgrade, so an open socket
  * keeps trusting an expired token until we close + reopen it.
@@ -174,20 +185,26 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
   const currentStatusRef = useRef<StatusType | null>(null)
 
   /**
-   * Single-slot buffer for an outgoing message deferred by a socket
+   * Single-slot buffer for an outgoing payload deferred by a socket
    * rotation (stale token pre-flight or `auth_expired` from backend).
    * Drained inside `onConnectionChange('connected')`. Single-slot is
    * sufficient because `setStreaming(true)` gates new sends during rotation.
+   *
+   * Tagged by `kind` because the drain has to dispatch back to either
+   * `sendMessage` (chat) or `sendInteractionResponse` (HITL). The backend
+   * applies the same per-message JWT expiry gate to both; without the kind
+   * tag a HITL response sent right after token expiry would either be
+   * dropped (no buffer) or wrongly replayed as the previous chat message.
    */
-  const pendingOutgoingRef = useRef<{ content: string; dataSources: string[] } | null>(null)
+  const pendingOutgoingRef = useRef<PendingOutgoing | null>(null)
 
   /**
-   * Last message written to the socket, kept until the workflow completes
+   * Last payload written to the socket, kept until the workflow completes
    * or hits a non-auth error. Lets us auto-resend on `auth_expired` without
    * losing the user's payload. Distinct from `pendingOutgoingRef` so a
-   * routine soft rotation doesn't replay an already-completed message.
+   * routine soft rotation doesn't replay an already-completed payload.
    */
-  const lastSentMessageRef = useRef<{ content: string; dataSources: string[] } | null>(null)
+  const lastSentOutgoingRef = useRef<PendingOutgoing | null>(null)
 
   /**
    * Set by the soft timer when it fires while streaming; consumed by the
@@ -197,8 +214,14 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
   const pendingRotationRef = useRef(false)
 
   /**
-   * Single rotation primitive. `connect()` runs `onBeforeReconnect`, which
-   * is the only call site for `getSession()` -- routing all refreshes
+   * Single rotation primitive. Delegates to `client.rotate()` -- an atomic
+   * client-side swap that detaches handlers from the old socket before
+   * closing it, eliminating the `onclose` race where a late close from
+   * the rotated-out socket would be misclassified as an unintentional
+   * disconnect on the freshly-opened one.
+   *
+   * `client.connect()` (invoked inside `rotate()`) runs `onBeforeReconnect`,
+   * which is the only call site for `getSession()` -- routing all refreshes
    * through one path avoids racing the SessionProvider polling (which
    * would cause `invalid_grant` with rotating refresh tokens).
    */
@@ -206,8 +229,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
     const client = wsClientRef.current
     if (!client) return
     console.warn(`[WS] Rotating connection before token expiry (${reason})`)
-    client.disconnect()
-    void client.connect()
+    void client.rotate()
   }, [])
 
   const { user, authRequired, error: authError } = useAuth()
@@ -476,7 +498,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           clearPendingInteraction()
 
           // Workflow finished cleanly -- drop the resend buffer.
-          lastSentMessageRef.current = null
+          lastSentOutgoingRef.current = null
         }
       },
 
@@ -595,7 +617,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         // and trigger a phantom reconnect instead of surfacing as a
         // banner.
         if (errorContent.code === 'user_auth_error' && errorContent.message === 'auth_expired') {
-          const lastSent = lastSentMessageRef.current
+          const lastSent = lastSentOutgoingRef.current
           if (lastSent) {
             pendingOutgoingRef.current = lastSent
           }
@@ -621,7 +643,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           // UI is now in a failure state. Drop both buffers so a later
           // recovery-driven `connected` cannot silently replay the
           // pre-rotation payload behind the user's back.
-          lastSentMessageRef.current = null
+          lastSentOutgoingRef.current = null
           pendingOutgoingRef.current = null
           return
         }
@@ -650,7 +672,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         // Symmetric with CONNECTION_FAILED: any buffered outgoing payload
         // (preflight rotation, auth_expired) is no longer something the
         // user expects to be re-sent once we've shown them an error card.
-        lastSentMessageRef.current = null
+        lastSentOutgoingRef.current = null
         pendingOutgoingRef.current = null
       },
 
@@ -661,20 +683,32 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           invalidateHealthCache()
           dismissConnectionErrors()
 
-          // Drain any message buffered by a pre-flight rotation or
-          // `auth_expired`. Keeps the UX silent: the user typed once and
-          // it goes out the moment the fresh socket is up.
+          // Drain any payload buffered by a pre-flight rotation or
+          // `auth_expired`. Keeps the UX silent: the user acted once and
+          // it goes out the moment the fresh socket is up. Dispatch by
+          // `kind` so both chat messages AND HITL interaction responses
+          // survive a rotation -- the backend's per-message expiry gate
+          // applies to both.
           const pending = pendingOutgoingRef.current
-          if (pending) {
+          const client = wsClientRef.current
+          if (pending && client) {
             pendingOutgoingRef.current = null
-            wsClientRef.current?.sendMessage(pending.content, pending.dataSources)
+            if (pending.kind === 'message') {
+              client.sendMessage(pending.content, pending.dataSources)
+            } else {
+              client.sendInteractionResponse(
+                pending.interactionId,
+                pending.parentId,
+                pending.response,
+              )
+            }
             // Mirror doSend(): the drain just put a payload on the wire,
-            // so it is now the canonical "last sent message". Without
-            // this, a pre-flight rotation that gets immediately hit by a
-            // second `auth_expired` on the fresh socket would have a null
-            // `lastSentMessageRef` and silently drop the user's message
+            // so it is now the canonical "last sent". Without this, a
+            // pre-flight rotation that gets immediately hit by a second
+            // `auth_expired` on the fresh socket would have a null
+            // `lastSentOutgoingRef` and silently drop the user's payload
             // (the auth_expired handler couldn't re-buffer it).
-            lastSentMessageRef.current = pending
+            lastSentOutgoingRef.current = pending
             setLoading(false)
           }
           return
@@ -817,7 +851,11 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           // Remember the payload so a mid-workflow `auth_expired` can
           // transparently re-issue it after the reconnect. Cleared on
           // isFinal or any non-auth error.
-          lastSentMessageRef.current = { content, dataSources: dataSourcesForMessage }
+          lastSentOutgoingRef.current = {
+            kind: 'message',
+            content,
+            dataSources: dataSourcesForMessage,
+          }
           setLoading(false)
         } else {
           addErrorCard('connection.failed', 'WebSocket connection failed')
@@ -836,7 +874,11 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
       }
 
       if (wsClientRef.current?.isConnected() && tokenIsStale()) {
-        pendingOutgoingRef.current = { content, dataSources: dataSourcesForMessage }
+        pendingOutgoingRef.current = {
+          kind: 'message',
+          content,
+          dataSources: dataSourcesForMessage,
+        }
         rotateSocket('preflight')
         return
       }
@@ -889,6 +931,14 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
 
   /**
    * Respond to a pending interaction (clarification, approval, etc.)
+   *
+   * Mirrors `sendMessage`'s rotation handling: the backend applies the
+   * same per-message JWT expiry gate to `WebSocketUserInteractionResponseMessage`
+   * as it does to chat messages, so a HITL response that lands right after
+   * token expiry would otherwise be silently lost (no `lastSentOutgoingRef`
+   * for the rotation handler to replay). Preflight on stale token, buffer
+   * the typed payload, and let `onConnectionChange('connected')` drain it
+   * via `sendInteractionResponse` once the fresh handshake completes.
    */
   const respondToInteraction = useCallback(
     (response: string) => {
@@ -915,19 +965,51 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         }
       }
 
-      // Send response via WebSocket
-      if (wsClientRef.current?.isConnected()) {
-        wsClientRef.current.sendInteractionResponse(
-          pendingInteraction.id,
-          pendingInteraction.parentId,
-          response
-        )
-        // Resume streaming
+      const interactionPayload: PendingOutgoing = {
+        kind: 'interaction',
+        interactionId: pendingInteraction.id,
+        parentId: pendingInteraction.parentId,
+        response,
+      }
+
+      const doSend = () => {
+        if (wsClientRef.current?.isConnected()) {
+          wsClientRef.current.sendInteractionResponse(
+            pendingInteraction.id,
+            pendingInteraction.parentId,
+            response
+          )
+          // Record the HITL payload so a follow-up `auth_expired` can
+          // transparently re-issue THIS response (not a stale chat
+          // payload that happened to be the previous `lastSentOutgoing`).
+          lastSentOutgoingRef.current = interactionPayload
+          setStreaming(true)
+          setLoading(true)
+        } else {
+          addErrorCard('connection.failed', 'WebSocket not connected')
+        }
+      }
+
+      // Stale-token pre-flight (mirrors sendMessage): the socket may
+      // report connected, but if the handshake JWT is already past `exp`
+      // the backend will respond with `auth_expired` and our HITL response
+      // would be lost. Buffer + rotate; the drain re-issues it.
+      const tokenIsStale = (): boolean => {
+        if (!authRequired || !activeSocketTokenExpiresAt) return false
+        return Date.now() >= activeSocketTokenExpiresAt * 1000
+      }
+
+      if (wsClientRef.current?.isConnected() && tokenIsStale()) {
+        pendingOutgoingRef.current = interactionPayload
+        // Keep the "working" UX visible across the rotation so the user
+        // doesn't see their answer disappear into an idle screen.
         setStreaming(true)
         setLoading(true)
-      } else {
-        addErrorCard('connection.failed', 'WebSocket not connected')
+        rotateSocket('preflight-interaction')
+        return
       }
+
+      doSend()
     },
     [
       pendingInteraction,
@@ -937,6 +1019,9 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
       addErrorCard,
       setStreaming,
       setLoading,
+      authRequired,
+      activeSocketTokenExpiresAt,
+      rotateSocket,
     ]
   )
 

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -612,7 +612,11 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           setStreaming(false)
           setLoading(false)
           clearPendingInteraction()
+          // UI is now in a failure state. Drop both buffers so a later
+          // recovery-driven `connected` cannot silently replay the
+          // pre-rotation payload behind the user's back.
           lastSentMessageRef.current = null
+          pendingOutgoingRef.current = null
           return
         }
 
@@ -637,7 +641,11 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
 
         // Clear any pending interaction on error
         clearPendingInteraction()
+        // Symmetric with CONNECTION_FAILED: any buffered outgoing payload
+        // (preflight rotation, auth_expired) is no longer something the
+        // user expects to be re-sent once we've shown them an error card.
         lastSentMessageRef.current = null
+        pendingOutgoingRef.current = null
       },
 
       onConnectionChange: (status, context?: ConnectionChangeContext) => {

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -21,6 +21,7 @@
 
 import { useCallback, useRef, useEffect, useState, useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
+import { getSession } from 'next-auth/react'
 import {
   NATWebSocketClient,
   createNATWebSocketClient,
@@ -58,6 +59,20 @@ import {
 
 const EMPTY_MESSAGES: ChatMessage[] = []
 const EMPTY_CONVERSATIONS: Conversation[] = []
+
+/**
+ * Seconds before token expiry to proactively rotate the WebSocket. The
+ * backend only validates the JWT at the WS upgrade, so an open socket
+ * keeps trusting an expired token until we close + reopen it.
+ *
+ * If the timer fires mid-stream, rotation is deferred until `isStreaming`
+ * returns to false so long-running responses are never cut short.
+ *
+ * INVARIANT: must be smaller than the server's `TOKEN_REFRESH_BUFFER_SECONDS`
+ * (default 15min) so NextAuth has already rotated the JWT by the time we
+ * upgrade with a fresh cookie.
+ */
+const WS_REFRESH_SOFT_GUARD_SECONDS = 60
 
 /**
  * Map NAT/backend error codes to frontend ErrorCode for consistent UI display.
@@ -158,7 +173,72 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
   // Ref to track the current status for detecting status changes
   const currentStatusRef = useRef<StatusType | null>(null)
 
+  /**
+   * Single-slot buffer for an outgoing message deferred by a socket
+   * rotation (stale token pre-flight or `auth_expired` from backend).
+   * Drained inside `onConnectionChange('connected')`. Single-slot is
+   * sufficient because `setStreaming(true)` gates new sends during rotation.
+   */
+  const pendingOutgoingRef = useRef<{ content: string; dataSources: string[] } | null>(null)
+
+  /**
+   * Last message written to the socket, kept until the workflow completes
+   * or hits a non-auth error. Lets us auto-resend on `auth_expired` without
+   * losing the user's payload. Distinct from `pendingOutgoingRef` so a
+   * routine soft rotation doesn't replay an already-completed message.
+   */
+  const lastSentMessageRef = useRef<{ content: string; dataSources: string[] } | null>(null)
+
+  /**
+   * Set by the soft timer when it fires while streaming; consumed by the
+   * deferred-rotation effect once `isStreaming` returns to false. Ref (not
+   * state) so flipping the flag doesn't re-run the timer effect.
+   */
+  const pendingRotationRef = useRef(false)
+
+  /**
+   * Single rotation primitive. `connect()` runs `onBeforeReconnect`, which
+   * is the only call site for `getSession()` -- routing all refreshes
+   * through one path avoids racing the SessionProvider polling (which
+   * would cause `invalid_grant` with rotating refresh tokens).
+   */
+  const rotateSocket = useCallback((reason: string): void => {
+    const client = wsClientRef.current
+    if (!client) return
+    console.warn(`[WS] Rotating connection before token expiry (${reason})`)
+    client.disconnect()
+    void client.connect()
+  }, [])
+
   const { user, authRequired, error: authError } = useAuth()
+
+  /**
+   * Token expiry (seconds since epoch) that authenticates the *current*
+   * socket. Captured from the `getSession()` call that primes the cookie
+   * for the upcoming upgrade. Intentionally decoupled from the live
+   * `useAuth().idTokenExpiresAt`: SessionProvider polling advances the
+   * live value but does NOT re-authenticate an already-open socket, so
+   * binding the timer to it would let polling clear it before it fires.
+   */
+  const [activeSocketTokenExpiresAt, setActiveSocketTokenExpiresAt] =
+    useState<number | undefined>(undefined)
+
+  /**
+   * Refresh the NextAuth session before opening a new WebSocket so the
+   * upgrade request carries an up-to-date idToken cookie, and anchor the
+   * rotation deadline to the expiry returned by that same call.
+   */
+  const refreshAuthBeforeReconnect = useCallback(async (): Promise<void> => {
+    if (!authRequired) return
+    try {
+      const session = await getSession()
+      if (session?.idTokenExpiresAt) {
+        setActiveSocketTokenExpiresAt(session.idTokenExpiresAt)
+      }
+    } catch (err) {
+      console.warn('[useWebSocketChat] getSession before WS reconnect failed', err)
+    }
+  }, [authRequired])
 
   // Chat store — reactive state only
   const {
@@ -286,8 +366,8 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           const currentPlanMessages = state.planMessages
           const currentConversation = state.currentConversation
 
-          // Extract research title from plan messages for conversation title
-          // Try multiple sources: plan preview, any plan message, or original user query
+          // Derive a conversation title from the plan (preferred) or fall
+          // back to the last user message.
           if (currentConversation) {
             let extractedTitle: string | null = null
 
@@ -322,7 +402,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
             if (!extractedTitle) {
               const userMessages = currentConversation.messages.filter((m) => m.role === 'user')
               const lastUserMsg = userMessages[userMessages.length - 1]
-              // Use the last user message if it's not a simple greeting
+              // Skip simple greetings.
               if (lastUserMsg && lastUserMsg.content.length > 10) {
                 extractedTitle = lastUserMsg.content
               }
@@ -331,8 +411,8 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
             if (extractedTitle) {
               // Clean up the title
               const cleanTitle = extractedTitle
-                .replace(/^\*+|\*+$/g, '') // Remove asterisks
-                .replace(/^["']|["']$/g, '') // Remove quotes
+                .replace(/^\*+|\*+$/g, '')
+                .replace(/^["']|["']$/g, '')
                 .trim()
 
               // Truncate to reasonable length
@@ -349,10 +429,11 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           // Add 'starting' banner as a persistent message
           addDeepResearchBanner('starting', jobId)
 
-          // Create tracking message with empty content (won't render due to content guard)
-          // This message carries job metadata for session restoration
+          // Empty-content tracking message carries job metadata for session
+          // restoration; AgentResponse returns null for empty content so it
+          // won't render.
           const messageId = addAgentResponseWithMeta(
-            '', // Empty content - AgentResponse returns null for empty content
+            '',
             false,
             {
               deepResearchJobId: jobId,
@@ -363,13 +444,15 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           )
           // Start deep research SSE streaming bound to this message
           startDeepResearch(jobId, messageId)
-          // Keep isStreaming=true to block input - deep research will release it on completion
+          // Keep isStreaming=true to block input -- deep research SSE will
+          // release it on completion.
           setLoading(false)
           // Don't add this as final response - let SSE handle the rest
           return
         }
 
-        // Any system_response_message with text content should be added as AgentResponse immediately
+        // reportContent is only populated by deep research SSE events
+        // (use-deep-research.ts), not by regular WebSocket responses.
         if (content && content.trim()) {
           // Add to chat area as AgentResponse
           // Note: reportContent is only set by deep research SSE events (use-deep-research.ts)
@@ -391,20 +474,23 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
 
           // Clear any pending interaction (HITL prompt) on completion
           clearPendingInteraction()
+
+          // Workflow finished cleanly -- drop the resend buffer.
+          lastSentMessageRef.current = null
         }
       },
 
       onIntermediateStep: (content: NATIntermediateStepContent | string, status: string, _parentId?: string) => {
-        // NAT uses an internal step ID (not the user message ID) for intermediate step parent_id,
-        // so we cannot use parent_id for stale detection here. Guard instead on isStreaming:
-        // if we are not currently streaming, the workflow that sent this step was already
-        // cancelled/disconnected, so discard it.
+        // NAT uses an internal step ID (not the user message ID) for
+        // parent_id on intermediate steps, so we can't stale-detect via
+        // parent_id. Guard on isStreaming instead: if not streaming, the
+        // workflow was already cancelled/disconnected.
         const { isStreaming: currentlyStreaming } = useChatStore.getState()
         if (!currentlyStreaming) {
           console.warn('Ignoring stale intermediate step -- not currently streaming')
           return
         }
-        // Handle string content (legacy format)
+        // Legacy string-content path: synthesize a generic thinking step.
         if (typeof content === 'string') {
           // For plain string content, create a generic thinking step
           if (content && content.trim()) {
@@ -438,7 +524,8 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           // Update existing step with complete status and final content
           updateThinkingStepByFunctionName(functionName, formattedPayload, true)
         } else if (existingStep) {
-          // Append to existing step (shouldn't happen often, but handle gracefully)
+          // Defensive: shouldn't usually fire (a step is normally either new
+          // or transitioning to complete), but handle gracefully.
           appendToThinkingStep(existingStep.id, '\n' + formattedPayload)
         } else {
           // Create new step for this function (or model/tool sub-call)
@@ -474,7 +561,9 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         }
         setPendingInteraction(interaction)
 
-        // Add to PlanTab FIRST so it's captured when saving prompt message
+        // Add to PlanTab FIRST so it's captured when the prompt message is
+        // saved (addAgentPrompt below snapshots planMessages for session
+        // restoration).
         addPlanMessage({
           text: prompt.text,
           inputType: prompt.input_type as 'text' | 'multiple_choice' | 'binary_choice' | 'approval' | 'notification',
@@ -491,7 +580,26 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
       },
 
       onError: async (errorContent: NATErrorContent) => {
-        // Connection errors (all retries exhausted) -- gate with health check
+        // Auth expired mid-workflow: backend contract is `code ===
+        // 'user_auth_error'` + `message === 'auth_expired'` (see
+        // websocket_reconnect.py `_send_auth_expired_error`). Buffer the
+        // just-sent payload, rotate the socket, and let
+        // `onConnectionChange('connected')` re-issue the message once the
+        // fresh handshake completes. We deliberately do NOT touch
+        // `isStreaming` or the thinking step so the user's "request in
+        // progress" UX bridges the rotation seamlessly.
+        if (errorContent.message === 'auth_expired') {
+          const lastSent = lastSentMessageRef.current
+          if (lastSent) {
+            pendingOutgoingRef.current = lastSent
+          }
+          rotateSocket('auth_expired')
+          return
+        }
+
+        // Connection failure (all client retries exhausted) -- gate the UI
+        // on a health check so we can distinguish "backend down" from a
+        // likely auth/cookie drift.
         if (errorContent.code === 'CONNECTION_FAILED') {
           const backendUp = await checkBackendHealthCached()
 
@@ -504,11 +612,11 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           setStreaming(false)
           setLoading(false)
           clearPendingInteraction()
+          lastSentMessageRef.current = null
           return
         }
 
-        // Application-level errors from the backend (agent errors, etc.)
-        // Complete any pending thinking step on error
+        // Application-level errors from the backend (agent errors, etc.).
         if (currentThinkingStepIdRef.current) {
           completeThinkingStep(currentThinkingStepIdRef.current)
           currentThinkingStepIdRef.current = null
@@ -529,6 +637,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
 
         // Clear any pending interaction on error
         clearPendingInteraction()
+        lastSentMessageRef.current = null
       },
 
       onConnectionChange: (status, context?: ConnectionChangeContext) => {
@@ -537,19 +646,27 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         if (status === 'connected') {
           invalidateHealthCache()
           dismissConnectionErrors()
+
+          // Drain any message buffered by a pre-flight rotation or
+          // `auth_expired`. Keeps the UX silent: the user typed once and
+          // it goes out the moment the fresh socket is up.
+          const pending = pendingOutgoingRef.current
+          if (pending) {
+            pendingOutgoingRef.current = null
+            wsClientRef.current?.sendMessage(pending.content, pending.dataSources)
+            setLoading(false)
+          }
           return
         }
 
-        // Intentional disconnects (session switch, cleanup): no error UI
+        // Intentional disconnects (session switch, cleanup) shouldn't
+        // surface as errors.
         if (context?.intentional) return
 
         if (status === 'error' || status === 'disconnected') {
-          // Don't show error cards here. The WebSocket client suppresses
-          // intermediate statuses during reconnection, and fires onError
-          // with CONNECTION_FAILED only after all retries are exhausted.
-          // At that point the health-check gate decides whether to show UI.
-
-          // Complete any in-progress thinking step so the UI doesn't hang
+          // Don't show error cards here -- the WS client only fires
+          // onError(CONNECTION_FAILED) after all retries are exhausted,
+          // and the health-check gate there decides whether to show UI.
           if (currentThinkingStepIdRef.current) {
             completeThinkingStep(currentThinkingStepIdRef.current)
             currentThinkingStepIdRef.current = null
@@ -584,6 +701,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
     addPlanMessage,
     updateConversationTitle,
     getTransportFailure,
+    rotateSocket,
   ])
 
   /**
@@ -597,6 +715,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
       wsClientRef.current = createNATWebSocketClient({
         conversationId: currentConversation.id,
         callbacks: createCallbacks(),
+        onBeforeReconnect: refreshAuthBeforeReconnect,
       })
       wsClientRef.current.connect()
     } else {
@@ -611,7 +730,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         wsClientRef.current = null
       }
     }
-  }, [currentConversation?.id, autoConnect, createCallbacks])
+  }, [currentConversation?.id, autoConnect, createCallbacks, refreshAuthBeforeReconnect])
 
   /**
    * Send a message via WebSocket
@@ -652,12 +771,12 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         messageFiles,
       })
 
-      // Get the conversation ID from store (may have been created by addUserMessage)
+      // currentConversation may have just been created inside addUserMessage.
       const storeState = useChatStore.getState()
       const conversationId = storeState.currentConversation?.id
 
-      // Clear report content and pending interaction for new request
-      // Note: We do NOT clear thinkingSteps - they persist per userMessageId for chat history
+      // thinkingSteps are NOT cleared here -- they persist per userMessageId
+      // so chat history still renders prior thinking blocks.
       clearReportContent()
       clearPendingInteraction()
 
@@ -674,6 +793,10 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
       const doSend = () => {
         if (wsClientRef.current?.isConnected()) {
           wsClientRef.current.sendMessage(content, dataSourcesForMessage)
+          // Remember the payload so a mid-workflow `auth_expired` can
+          // transparently re-issue it after the reconnect. Cleared on
+          // isFinal or any non-auth error.
+          lastSentMessageRef.current = { content, dataSources: dataSourcesForMessage }
           setLoading(false)
         } else {
           addErrorCard('connection.failed', 'WebSocket connection failed')
@@ -682,12 +805,26 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         }
       }
 
-      // If WebSocket client exists and is connected, send immediately
+      // Pre-flight: the socket may report connected, but if its JWT is
+      // already past `exp` (e.g. after a long idle / laptop sleep) the
+      // backend is still trusting a dead token. Buffer + rotate; the
+      // buffer is drained from `onConnectionChange('connected')`.
+      const tokenIsStale = (): boolean => {
+        if (!authRequired || !activeSocketTokenExpiresAt) return false
+        return Date.now() >= activeSocketTokenExpiresAt * 1000
+      }
+
+      if (wsClientRef.current?.isConnected() && tokenIsStale()) {
+        pendingOutgoingRef.current = { content, dataSources: dataSourcesForMessage }
+        rotateSocket('preflight')
+        return
+      }
+
       if (wsClientRef.current?.isConnected()) {
         doSend()
       } else if (conversationId) {
-        // WebSocket not ready but we have a conversation - initialize synchronously
-        // Create callbacks that include the send-on-connect logic
+        // No client yet: initialize synchronously and chain doSend to the
+        // 'connected' transition so the message goes out on first handshake.
         const callbacks = createCallbacks()
         const originalOnConnectionChange = callbacks.onConnectionChange
         callbacks.onConnectionChange = (status, ctx) => {
@@ -701,10 +838,12 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         wsClientRef.current = createNATWebSocketClient({
           conversationId,
           callbacks,
+          onBeforeReconnect: refreshAuthBeforeReconnect,
         })
         wsClientRef.current.connect()
       } else {
-        // No conversation ID - shouldn't happen but handle gracefully
+        // Defensive: shouldn't happen because addUserMessage creates a
+        // conversation if one is missing.
         addErrorCard('system.unknown', 'No active conversation')
         setStreaming(false)
         setLoading(false)
@@ -720,6 +859,10 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
       setStreaming,
       setLoading,
       createCallbacks,
+      refreshAuthBeforeReconnect,
+      rotateSocket,
+      authRequired,
+      activeSocketTokenExpiresAt,
     ]
   )
 
@@ -733,8 +876,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         return
       }
 
-      // Update prompt in store
-      // Find the last prompt message and mark it as responded
+      // Mark the most recent unanswered prompt message as responded.
       const messages = currentConversation?.messages ?? []
       const lastPrompt = [...messages]
         .reverse()
@@ -787,17 +929,65 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
       wsClientRef.current = createNATWebSocketClient({
         conversationId: currentConversation.id,
         callbacks: createCallbacks(),
+        onBeforeReconnect: refreshAuthBeforeReconnect,
       })
       wsClientRef.current.connect()
     }
-  }, [currentConversation, createCallbacks])
+  }, [currentConversation, createCallbacks, refreshAuthBeforeReconnect])
 
   // Activate recovery polling when connection error cards are visible
   useConnectionRecovery(connect)
 
   /**
-   * Disconnect from WebSocket
+   * Soft-rotation timer. If idle when it fires, rotate immediately; if a
+   * stream is in flight, set `pendingRotationRef` and let the deferred
+   * effect below rotate once the stream ends so we never cut a response.
    */
+  useEffect(() => {
+    if (!authRequired || !activeSocketTokenExpiresAt) return
+
+    let cancelled = false
+    let softTimer: ReturnType<typeof setTimeout> | undefined
+
+    const onSoftFire = (): void => {
+      if (cancelled) return
+      if (useChatStore.getState().isStreaming) {
+        pendingRotationRef.current = true
+        return
+      }
+      rotateSocket('soft')
+    }
+
+    const now = Date.now()
+    const expMs = activeSocketTokenExpiresAt * 1000
+    const softAt = expMs - WS_REFRESH_SOFT_GUARD_SECONDS * 1000
+
+    if (softAt > now) {
+      softTimer = setTimeout(onSoftFire, softAt - now)
+    } else {
+      // Already inside the soft window on first effect run (e.g. mount
+      // with a near-expiry token).
+      onSoftFire()
+    }
+
+    return () => {
+      cancelled = true
+      if (softTimer) clearTimeout(softTimer)
+    }
+  }, [activeSocketTokenExpiresAt, authRequired, rotateSocket])
+
+  /**
+   * Drains a deferred rotation the moment the stream ends. Cleared
+   * synchronously so a follow-up stream doesn't double-rotate before the
+   * next soft timer arms.
+   */
+  useEffect(() => {
+    if (!isStreaming && pendingRotationRef.current) {
+      pendingRotationRef.current = false
+      rotateSocket('deferred')
+    }
+  }, [isStreaming, rotateSocket])
+
   const disconnect = useCallback(() => {
     if (wsClientRef.current) {
       wsClientRef.current.disconnect()

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -588,7 +588,13 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         // fresh handshake completes. We deliberately do NOT touch
         // `isStreaming` or the thinking step so the user's "request in
         // progress" UX bridges the rotation seamlessly.
-        if (errorContent.message === 'auth_expired') {
+        //
+        // Match BOTH fields, not just `message`. A future application
+        // error that happens to carry `message: 'auth_expired'` (agent
+        // text, validation message) would otherwise be silently swallowed
+        // and trigger a phantom reconnect instead of surfacing as a
+        // banner.
+        if (errorContent.code === 'user_auth_error' && errorContent.message === 'auth_expired') {
           const lastSent = lastSentMessageRef.current
           if (lastSent) {
             pendingOutgoingRef.current = lastSent
@@ -662,6 +668,13 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           if (pending) {
             pendingOutgoingRef.current = null
             wsClientRef.current?.sendMessage(pending.content, pending.dataSources)
+            // Mirror doSend(): the drain just put a payload on the wire,
+            // so it is now the canonical "last sent message". Without
+            // this, a pre-flight rotation that gets immediately hit by a
+            // second `auth_expired` on the fresh socket would have a null
+            // `lastSentMessageRef` and silently drop the user's message
+            // (the auth_expired handler couldn't re-buffer it).
+            lastSentMessageRef.current = pending
             setLoading(false)
           }
           return

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -86,6 +86,30 @@ type PendingOutgoing =
 const WS_REFRESH_SOFT_GUARD_SECONDS = 60
 
 /**
+ * Hard cap on consecutive `auth_expired` rotations before we surface a
+ * `session_expired` banner instead of silently rotating again.
+ *
+ * Why a cap is necessary: each `auth_expired` response from the backend
+ * goes through `rotate()`, which resets `reconnectCount` to 0. That means
+ * the WS client's own retry safety net (CONNECTION_FAILED after N
+ * exhausted reconnect attempts) never trips on the auth_expired path --
+ * the counter is wiped on every rotation. Without an upper bound here,
+ * a stale-NextAuth-cache or clock-skew condition where `getSession()`
+ * keeps handing us the same already-expired JWT can produce dozens of
+ * silent rotations per minute (one per `auth_expired` round-trip) until
+ * the refresh-token itself expires. That's invisible to the user (just a
+ * spinner that never stops), wasteful for server connection slots, and
+ * indistinguishable from a DDoS at the rate-limit layer.
+ *
+ * 1 is normal (the whole point of the silent reconnect path). 2 is the
+ * documented preflight-then-second-auth_expired chain (we have a test).
+ * >= 4 is a loop -- bail out, clear buffers, ask the user to sign in
+ * again. Counter is reset on any successful response/intermediate step
+ * because a single passing message proves the post-rotation auth is alive.
+ */
+const MAX_CONSECUTIVE_AUTH_EXPIRED = 3
+
+/**
  * Map NAT/backend error codes to frontend ErrorCode for consistent UI display.
  * This provides a generic mapping for any backend error.
  */
@@ -212,6 +236,17 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
    * state) so flipping the flag doesn't re-run the timer effect.
    */
   const pendingRotationRef = useRef(false)
+
+  /**
+   * Consecutive `auth_expired` rotations without a successful response in
+   * between. Incremented in `onError(auth_expired)`, reset to 0 by any
+   * `onResponse` / `onIntermediateStep` (a passing message proves auth is
+   * alive on the rotated socket). When it exceeds
+   * `MAX_CONSECUTIVE_AUTH_EXPIRED` we stop silently rotating and surface
+   * `auth.session_expired` so the user can re-sign-in. See the docstring
+   * on `MAX_CONSECUTIVE_AUTH_EXPIRED` for why this safety net is required.
+   */
+  const consecutiveAuthExpiredRef = useRef(0)
 
   /**
    * Single rotation primitive. Delegates to `client.rotate()` -- an atomic
@@ -357,6 +392,12 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
 
     return {
       onResponse: (content: string, status: string, isFinal: boolean, parentId?: string) => {
+        // A response on the wire proves the post-rotation auth is alive --
+        // clear the consecutive auth_expired counter so a *future* (and
+        // therefore independent) auth_expired starts the silent-reconnect
+        // budget from zero again.
+        consecutiveAuthExpiredRef.current = 0
+
         if (isStaleMessage(parentId)) {
           console.warn('Dropping stale system_response (parent_id mismatch)', { parentId, active: wsClientRef.current?.activeParentId })
           return
@@ -503,6 +544,11 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
       },
 
       onIntermediateStep: (content: NATIntermediateStepContent | string, status: string, _parentId?: string) => {
+        // Same as onResponse: any backend-emitted frame on this socket
+        // proves the rotated handshake is honoured. Reset the consecutive
+        // auth_expired budget.
+        consecutiveAuthExpiredRef.current = 0
+
         // NAT uses an internal step ID (not the user message ID) for
         // parent_id on intermediate steps, so we can't stale-detect via
         // parent_id. Guard on isStreaming instead: if not streaming, the
@@ -617,6 +663,28 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         // and trigger a phantom reconnect instead of surfacing as a
         // banner.
         if (errorContent.code === 'user_auth_error' && errorContent.message === 'auth_expired') {
+          // Cap on consecutive auth_expired rotations: without it, a
+          // stale-NextAuth-cache or clock-skew condition can drive a
+          // silent rotation loop -- rotate() resets reconnectCount, so
+          // the WS client's own CONNECTION_FAILED safety net never
+          // triggers on this path. See MAX_CONSECUTIVE_AUTH_EXPIRED.
+          consecutiveAuthExpiredRef.current += 1
+          if (consecutiveAuthExpiredRef.current > MAX_CONSECUTIVE_AUTH_EXPIRED) {
+            consecutiveAuthExpiredRef.current = 0
+            lastSentOutgoingRef.current = null
+            pendingOutgoingRef.current = null
+            addErrorCard(
+              'auth.session_expired' as ErrorCode,
+              'Your session has expired. Please sign in again to continue.',
+              errorContent.details,
+            )
+            setCurrentStatus(null)
+            setStreaming(false)
+            setLoading(false)
+            clearPendingInteraction()
+            return
+          }
+
           const lastSent = lastSentOutgoingRef.current
           if (lastSent) {
             pendingOutgoingRef.current = lastSent

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -846,12 +846,30 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
       wsClientRef.current.updateConversationId(currentConversation.id)
     }
 
-    // Cleanup on unmount
+    // Cleanup on unmount or conversation switch.
+    //
+    // CRITICAL: the resend buffers (pendingOutgoingRef,
+    // lastSentOutgoingRef) and the consecutive-auth_expired counter are
+    // conversation-scoped state. If we leave them populated across a
+    // conversation switch, the next conversation's freshly-handshaken
+    // socket would drain a payload from the previous conversation into
+    // its own backend session on the first `connected` event -- a
+    // user-data leak across conversation boundaries.
+    //
+    // Same goes for currentThinkingStepIdRef / currentStatusRef:
+    // stale IDs from the previous conversation must not be reused
+    // against the new socket.
     return () => {
       if (wsClientRef.current) {
         wsClientRef.current.disconnect()
         wsClientRef.current = null
       }
+      pendingOutgoingRef.current = null
+      lastSentOutgoingRef.current = null
+      consecutiveAuthExpiredRef.current = 0
+      pendingRotationRef.current = false
+      currentThinkingStepIdRef.current = null
+      currentStatusRef.current = null
     }
   }, [currentConversation?.id, autoConnect, createCallbacks, refreshAuthBeforeReconnect])
 


### PR DESCRIPTION
I turned an "exploitable long-lived auth" into silent self-healing rotation with two independent layers of defense:

Frontend knows its own exp — proactive rotation before the backend has a chance to complain.
Backend re-validates exp per message — if the frontend somehow misses (sleep, race, any bug), the backend still won't accept work under a dead token; it asks for a reconnect instead.
Under normal operation the user sees nothing (no banners, no lost messages). The session expired banner now fires only in one case — when the refresh token itself genuinely dies and a real re-login is required. The security hole is closed on both sides of the wire, while the UX of long Deep Research sessions is preserved.

Additional cleanup:
- Sessions panel now checks persisted Deep Research job IDs against backend status when opened.
- If a current-user session points at a job removed by backend retention, the frontend prunes that session instead of leaving a dead report link in history.

Validation:
- vitest run src/features/chat/store.spec.ts src/features/layout/components/SessionsPanel.spec.tsx
- eslint src/features/chat/store.ts src/features/chat/types.ts src/features/chat/store.spec.ts src/features/layout/components/SessionsPanel.tsx src/features/layout/components/SessionsPanel.spec.tsx
- tsc --noEmit