### PR TITLE
Upgrade Python runtime to 3.13 and distroless to v4.0.5

### DIFF
--- a/configs/config_skills.yml
+++ b/configs/config_skills.yml
@@ -229,7 +229,7 @@ functions:
     sandbox:
       provider: modal
       app_name: aiq-deep-research
-      image: python:3.12-slim
+      image: python:3.13-slim
       python_packages:
         - matplotlib
         - numpy

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -26,7 +26,7 @@
 # =============================================================================
 # Stage 1: Builder (shared between dev and release)
 # =============================================================================
-FROM nvcr.io/nvidia/base/ubuntu:jammy-20251013 AS builder
+FROM nvcr.io/nvidia/base/ubuntu:jammy-20260217 AS builder
 
 WORKDIR /app
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -30,7 +30,7 @@ FROM nvcr.io/nvidia/base/ubuntu:jammy-20251013 AS builder
 
 WORKDIR /app
 
-# Install system dependencies and Python 3.12
+# Install system dependencies and Python 3.13
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     tzdata \
     build-essential \
@@ -40,15 +40,15 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     && add-apt-repository ppa:deadsnakes/ppa \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    python3.12 \
-    python3.12-dev \
-    python3.12-venv \
+    python3.13 \
+    python3.13-dev \
+    python3.13-venv \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python3.12 -m ensurepip --upgrade \
-    && python3.12 -m pip install --no-cache-dir uv \
-    && ln -sf /usr/bin/python3.12 /usr/local/bin/python \
-    && ln -sf /usr/bin/python3.12 /usr/local/bin/python3
+RUN python3.13 -m ensurepip --upgrade \
+    && python3.13 -m pip install --no-cache-dir uv \
+    && ln -sf /usr/bin/python3.13 /usr/local/bin/python \
+    && ln -sf /usr/bin/python3.13 /usr/local/bin/python3
 
 RUN uv venv /app/.venv --python /usr/local/bin/python
 
@@ -102,7 +102,7 @@ RUN /app/.venv/bin/python -c "import aiq_api; import aiq_research_cli; import ai
 # =============================================================================
 # Stage 3: Development runtime
 # =============================================================================
-FROM nvcr.io/nvidia/distroless/python:3.12-v4.0.4 AS dev
+FROM nvcr.io/nvidia/distroless/python:3.13-v4.0.5 AS dev
 
 WORKDIR /app
 
@@ -121,7 +121,7 @@ ENTRYPOINT ["python", "/app/deploy/entrypoint.py"]
 # =============================================================================
 # Stage 4: Release (production - no CLI)
 # =============================================================================
-FROM nvcr.io/nvidia/distroless/python:3.12-v4.0.4 AS release
+FROM nvcr.io/nvidia/distroless/python:3.13-v4.0.5 AS release
 
 WORKDIR /app
 

--- a/frontends/ui/deploy/Dockerfile
+++ b/frontends/ui/deploy/Dockerfile
@@ -83,8 +83,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://www.npmjs.com/install.sh | sh
+    && rm -rf /var/lib/apt/lists/*
 
 # =============================================================================
 # Stage 2: Dependencies
@@ -130,7 +129,8 @@ ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
 RUN groupadd --system --gid 1001 nodejs \
-    && useradd --system --uid 1001 --gid nodejs nextjs
+    && useradd --system --uid 1001 --gid nodejs nextjs \
+    && rm -rf /usr/lib/node_modules/npm /usr/bin/npm /usr/bin/npx
 
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
@@ -146,4 +146,4 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
     CMD curl -f http://localhost:3000/ || exit 1
 
-CMD ["npm", "start"]
+CMD ["node", "server.js"]

--- a/frontends/ui/deploy/Dockerfile
+++ b/frontends/ui/deploy/Dockerfile
@@ -74,7 +74,7 @@
 # =============================================================================
 # Stage 1: Base with Node.js
 # =============================================================================
-FROM nvcr.io/nvidia/base/ubuntu:jammy-20251013 AS base
+FROM nvcr.io/nvidia/base/ubuntu:jammy-20260217 AS base
 
 RUN apt-get update && apt-get install -y \
     curl \

--- a/frontends/ui/deploy/Dockerfile
+++ b/frontends/ui/deploy/Dockerfile
@@ -83,7 +83,8 @@ RUN apt-get update && apt-get install -y \
 
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://www.npmjs.com/install.sh | sh
 
 # =============================================================================
 # Stage 2: Dependencies


### PR DESCRIPTION
## Summary

Bump the builder stage and both distroless runtime stages in `deploy/Dockerfile`
from Python 3.12 / distroless v4.0.4 to Python 3.13 / distroless v4.0.5, the Ubuntu base from
`jammy-20251013` to `jammy-20260217`, and drop `npm` from the UI runtime (use `node server.js`
directly). Also updates the Modal sandbox image in `configs/config_skills.yml`
to `python:3.13-slim`.

## CVEs Resolved

Picks up **15 additional HIGH CVEs** beyond [#229](https://github.com/NVIDIA-AI-Blueprints/aiq/pull/229),
including 13 of the 16 items #229 flagged as "Out of Scope".

### Distroless runtime — Go stdlib (`v1.26.2` → `v1.26.3+`)

Baked into the `shelless_ulimit_arm64` and `sleep_arm64` binaries; cleared by the distroless v4.0.4 → v4.0.5 bump.

| # | CVE | Severity | Component |
|---|-----|----------|-----------|
| 1 | CVE-2026-33811 | HIGH | Go stdlib (×2 binaries) |
| 2 | CVE-2026-33814 | HIGH | Go stdlib (×2 binaries) |
| 3 | CVE-2026-39820 | HIGH | Go stdlib (×2 binaries) |
| 4 | CVE-2026-39836 | HIGH | Go stdlib (×2 binaries) |
| 5 | CVE-2026-42499 | HIGH | Go stdlib (×2 binaries) |

### Distroless runtime — CPython (3.12.13 → 3.13.13)

| # | CVE | Severity | Component |
|---|-----|----------|-----------|
| 6 | CVE-2026-6100 | HIGH | CPython lzma/bz2/gzip use-after-free |
| 7 | CVE-2026-4786 | HIGH | CPython webbrowser module injection |
| 8 | CVE-2026-3298 | HIGH | CPython asyncio OOB (Windows-only; not exploitable on this Linux image, fixed anyway) |

### Ubuntu builder + UI base (`jammy-20251013` → `jammy-20260217`)

| # | CVE | Severity | Component |
|---|-----|----------|-----------|
| 9 | CVE-2025-68973 | HIGH | (per commit `0ee1a4a`) |

### UI runtime — drop `npm`/`picomatch` from the final image

| # | CVE | Severity | Component |
|---|-----|----------|-----------|
| 10 | CVE-2026-33671 | HIGH | `picomatch` shipped via `npm` in the UI base image; `npm`/`npx` removed from the runtime stage, `CMD` switched to `node server.js` |

## Changes

- `deploy/Dockerfile`: builder bumps Python 3.12 → 3.13 and Ubuntu base to `jammy-20260217`; both dev and release runtime stages move to `nvcr.io/nvidia/distroless/python:3.13-v4.0.5`.
- `frontends/ui/deploy/Dockerfile`: base Ubuntu bumped to `jammy-20260217`; runtime stage deletes `/usr/lib/node_modules/npm`, `/usr/bin/npm`, `/usr/bin/npx`; entrypoint switches from `npm start` to `node server.js`.
- `configs/config_skills.yml`: Modal sandbox image `python:3.12-slim` → `python:3.13-slim`.