### PR TITLE
AIQ Skill Eval Smoke Tests

### DIFF
--- a/.agents/skills/aiq-deploy/README.md
+++ b/.agents/skills/aiq-deploy/README.md
@@ -1,0 +1,35 @@
+# AIQ Deploy Skill
+
+Portable Agent Skill for deploying, verifying, troubleshooting, and stopping the NVIDIA AI-Q Blueprint.
+
+## What This Skill Provides
+
+- CLI, local web, Docker Compose, and Kubernetes deployment routing.
+- Environment validation without exposing secrets.
+- Backend, UI, and PostgreSQL health checks.
+- Logs, rebuild, stop, and safe teardown workflows.
+- FRAG/RAG prerequisite checks.
+
+## Canonical Location
+
+```text
+.agents/skills/aiq-deploy/
+```
+
+Claude Code compatibility is provided by:
+
+```text
+.claude/skills/aiq-deploy -> ../../.agents/skills/aiq-deploy
+```
+
+## Relationship To aiq-research
+
+Use `aiq-deploy` to get AI-Q running. Use `aiq-research` after a local AI-Q server is reachable.
+
+## Quick Verification
+
+From this skill directory:
+
+```bash
+test -f SKILL.md && echo "aiq-deploy skill present"
+```

--- a/.agents/skills/aiq-deploy/SKILL.md
+++ b/.agents/skills/aiq-deploy/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: aiq-deploy
+description: Deploy, verify, troubleshoot, or stop the NVIDIA AI-Q Blueprint in CLI, local web, Docker Compose, or Kubernetes mode. Use when asked to start AI-Q, deploy AIQ, run the UI/backend, check health, inspect logs, rebuild, stop services, or prepare a running AI-Q server for the aiq-research skill.
+license: Apache-2.0
+compatibility: Claude Code, OpenCode, Codex, and Agent Skills-compatible tools. Requires access to the AI-Q repository and the runtime selected by the user.
+metadata:
+  version: "1.0.0"
+  github-url: "https://github.com/NVIDIA-AI-Blueprints/aiq"
+  tags: "nvidia aiq blueprint deploy operations agent-skills"
+allowed-tools: Read Bash
+---
+
+# AIQ Deploy Skill
+
+Use this skill to get the NVIDIA AI-Q Blueprint running and verified. This skill owns deployment and operations. Use `aiq-research` only after an AI-Q server is already reachable.
+
+## Supported Modes
+
+| User Intent | Mode | Primary Entry Point |
+|---|---|---|
+| "run AIQ in my terminal", "start CLI" | CLI | `scripts/start_cli.sh` |
+| "run AIQ locally", "start web UI", "start backend" | Local web | `scripts/start_e2e.sh` |
+| "deploy with compose", "run containers" | Docker Compose | `deploy/compose/docker-compose.yaml` |
+| "deploy to Kubernetes", "Helm" | Kubernetes | `deploy/helm/README.md` |
+| "use Foundational RAG", "FRAG mode" | Docker/Helm plus external RAG | `configs/config_web_frag.yml` |
+
+Infer the mode from the user request. If the user says only "deploy AIQ", prefer Docker Compose for a durable backend, UI, and PostgreSQL stack. If they ask for a quick local dev run, prefer local web mode.
+
+## Safety Rules
+
+- Never print secret values. Check only whether required variables are set.
+- Do not overwrite `deploy/.env` if it already exists. If missing, copy from `deploy/.env.example` and tell the user which values must be filled.
+- Ask before destructive cleanup such as deleting Docker volumes with `down -v`.
+- Do not claim FRAG is ready unless both `RAG_SERVER_URL` and `RAG_INGEST_URL` are configured and reachable.
+- Run verification commands yourself. Do not give the user a command to run when you can run it in the current environment.
+
+## Step 1 - Locate The Repository
+
+Work from the AI-Q repository root. Verify the expected files exist:
+
+```bash
+test -f pyproject.toml
+test -f deploy/.env.example
+test -f deploy/compose/docker-compose.yaml
+test -f scripts/start_cli.sh
+test -f scripts/start_e2e.sh
+```
+
+If any are missing, stop and report that the current directory is not an AI-Q checkout.
+
+## Step 2 - Check Environment File
+
+Use `deploy/.env` as the source of truth for local and Docker deployments.
+
+```bash
+if [ ! -f deploy/.env ]; then
+  cp deploy/.env.example deploy/.env
+  echo "created deploy/.env from deploy/.env.example"
+fi
+
+python3 - <<'PY'
+from pathlib import Path
+
+env = Path("deploy/.env")
+values = {}
+for line in env.read_text().splitlines():
+    line = line.strip()
+    if not line or line.startswith("#") or "=" not in line:
+        continue
+    key, value = line.split("=", 1)
+    values[key.strip()] = value.strip()
+
+def present(key: str) -> str:
+    return "SET" if values.get(key) else "MISSING"
+
+print(f"NVIDIA_API_KEY={present('NVIDIA_API_KEY')}")
+print(f"TAVILY_API_KEY={present('TAVILY_API_KEY')}")
+print(f"SERPER_API_KEY={present('SERPER_API_KEY')}")
+print(f"EXA_API_KEY={present('EXA_API_KEY')}")
+print(f"NAT_JOB_STORE_DB_URL={present('NAT_JOB_STORE_DB_URL')}")
+print(f"AIQ_CHECKPOINT_DB={present('AIQ_CHECKPOINT_DB')}")
+print(f"BACKEND_CONFIG={values.get('BACKEND_CONFIG') or 'default'}")
+PY
+```
+
+Core hosted-model usage requires `NVIDIA_API_KEY`. Web research requires at least one configured web-search provider key such as `TAVILY_API_KEY`, `SERPER_API_KEY`, or `EXA_API_KEY`, depending on the selected config.
+
+If required keys are missing, stop and ask the user to fill `deploy/.env`. Do not request or echo the secret values in chat.
+
+## Step 3 - Check Runtime Prerequisites
+
+For all modes:
+
+```bash
+python3 --version
+test -d .venv && echo "venv=present" || echo "venv=missing"
+```
+
+For local web mode:
+
+```bash
+node --version 2>/dev/null || echo "node=missing"
+npm --version 2>/dev/null || echo "npm=missing"
+```
+
+For Docker Compose:
+
+```bash
+docker --version
+docker compose version
+docker info >/dev/null
+for port in 3000 8000 5432; do
+  if lsof -nP -iTCP:$port -sTCP:LISTEN >/dev/null 2>&1; then
+    echo "port $port is already in use"
+  else
+    echo "port $port is free"
+  fi
+done
+```
+
+If port 8000 is already used by another blueprint such as RAG page-elements, set `PORT=8100` in `deploy/.env` before starting Compose.
+
+## Mode A - CLI
+
+Use this when the user wants an interactive terminal research assistant.
+
+```bash
+./scripts/start_cli.sh
+```
+
+For a non-default config:
+
+```bash
+./scripts/start_cli.sh --config_file configs/config_cli_default.yml
+```
+
+If `.venv` is missing, tell the user to run `./scripts/setup.sh` or run the repository's documented setup flow if the user has authorized dependency installation.
+
+## Mode B - Local Web
+
+Use this for local development without Docker Compose.
+
+```bash
+./scripts/start_e2e.sh --config_file configs/config_web_default_llamaindex.yml
+```
+
+Verify:
+
+```bash
+curl -sf http://localhost:8000/health >/dev/null && echo "backend=healthy"
+curl -sf http://localhost:3000 >/dev/null && echo "frontend=reachable"
+```
+
+The script starts a backend at `http://localhost:8000` and frontend at `http://localhost:3000`.
+
+## Mode C - Docker Compose
+
+Use this as the default durable local deployment.
+
+```bash
+cd deploy/compose
+docker compose --env-file ../.env -f docker-compose.yaml config --quiet
+docker compose --env-file ../.env -f docker-compose.yaml config >/tmp/aiq-compose.resolved.yml
+docker compose --env-file ../.env -f docker-compose.yaml up -d --build
+```
+
+Use pre-built images when the user requests registry images or faster startup:
+
+```bash
+cd deploy/compose
+docker compose --env-file ../.env -f docker-compose.yaml up -d
+```
+
+Verify:
+
+```bash
+docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" | grep -E 'aiq-agent|aiq-blueprint-ui|aiq-postgres'
+curl -sf "http://localhost:${PORT:-8000}/health" >/dev/null && echo "aiq-agent=healthy"
+curl -sf "http://localhost:${FRONTEND_PORT:-3000}" >/dev/null && echo "ui=reachable"
+docker exec aiq-postgres pg_isready -U aiq -d aiq_jobs
+docker exec aiq-postgres pg_isready -U aiq -d aiq_checkpoints
+```
+
+Logs:
+
+```bash
+docker logs aiq-agent --tail 100
+docker logs aiq-blueprint-ui --tail 100
+docker logs aiq-postgres --tail 100
+```
+
+Stop:
+
+```bash
+cd deploy/compose
+docker compose --env-file ../.env -f docker-compose.yaml down
+```
+
+Only remove volumes after explicit confirmation:
+
+```bash
+cd deploy/compose
+docker compose --env-file ../.env -f docker-compose.yaml down -v
+```
+
+Rebuild:
+
+```bash
+cd deploy/compose
+docker compose --env-file ../.env -f docker-compose.yaml build --no-cache
+docker compose --env-file ../.env -f docker-compose.yaml up -d
+```
+
+## Mode D - Kubernetes / Helm
+
+Use this when the user explicitly asks for Kubernetes, Helm, or production deployment. Read `deploy/helm/README.md` and the relevant chart values before acting.
+
+Initial checks:
+
+```bash
+kubectl version --client
+helm version
+find deploy/helm -name Chart.yaml -maxdepth 4 -print
+```
+
+Do not guess cluster namespace, image registry, secrets, or ingress values. Inspect the target cluster and values files, then ask only for missing deployment choices.
+
+## FRAG / Foundational RAG Mode
+
+FRAG uses `configs/config_web_frag.yml` and requires a running RAG server and ingestor.
+
+Check configuration:
+
+```bash
+grep -E '^(RAG_SERVER_URL|RAG_INGEST_URL)=' deploy/.env || true
+```
+
+Probe when values are set:
+
+```bash
+set -a
+. deploy/.env
+set +a
+test -n "${RAG_SERVER_URL:-}" && curl -sf "$RAG_SERVER_URL/health" >/dev/null || true
+test -n "${RAG_INGEST_URL:-}" && curl -sf "$RAG_INGEST_URL/health" >/dev/null || true
+```
+
+When AI-Q and RAG run as separate Docker Compose stacks, connect the AI-Q backend container to the RAG network after both stacks are up:
+
+```bash
+docker network connect nvidia-rag aiq-agent
+```
+
+If `aiq-agent` is recreated, repeat the network connection.
+
+## Troubleshooting Checklist
+
+1. Confirm the selected config file exists.
+2. Confirm `deploy/.env` has required keys without printing values.
+3. Check backend health: `curl -sf http://localhost:${PORT:-8000}/health`.
+4. Check UI reachability: `curl -sf http://localhost:${FRONTEND_PORT:-3000}`.
+5. Check logs for `aiq-agent`, `aiq-blueprint-ui`, and `aiq-postgres`.
+6. For async-job failures, inspect `NAT_JOB_STORE_DB_URL`, `AIQ_CHECKPOINT_DB`, and PostgreSQL readiness.
+7. For tool/search failures, verify the relevant provider key and selected config.
+8. For FRAG failures, verify RAG URLs, RAG service health, and Docker network membership.
+
+## Handoff To aiq-research
+
+After verification, tell the user the AI-Q server URL. If the backend is on the default port, `aiq-research` can use its default `AIQ_SERVER_URL=http://localhost:8000`. Otherwise tell the user to set:
+
+```bash
+export AIQ_SERVER_URL="http://localhost:<PORT>"
+```

--- a/.agents/skills/aiq-research/eval/basic.json
+++ b/.agents/skills/aiq-research/eval/basic.json
@@ -1,0 +1,27 @@
+{
+  "skills": ["aiq-research"],
+  "resources": {
+    "platforms": {
+      "local": {
+        "modes": ["existing-server"]
+      }
+    }
+  },
+  "env": "Requires an AI-Q server reachable at AIQ_SERVER_URL, defaulting to http://localhost:8000. The server can be started with the aiq-deploy skill before running this eval. This smoke profile intentionally avoids model-generating /chat calls so it can verify the skill wrapper against a live server without consuming model credits.",
+  "expects": [
+    {
+      "query": "Use the aiq-research skill to check whether the local AI-Q server is healthy. Return a concise status and include the server URL you checked.",
+      "checks": [
+        "trajectory_contains:scripts/aiq.py health",
+        "json_command:python3 /skills/aiq-research/scripts/aiq.py health"
+      ]
+    },
+    {
+      "query": "Use the aiq-research skill to list the available async agent types. Return the result without truncating the JSON keys.",
+      "checks": [
+        "trajectory_contains:scripts/aiq.py agents",
+        "json_command:python3 /skills/aiq-research/scripts/aiq.py agents"
+      ]
+    }
+  ]
+}

--- a/.claude/skills/aiq-deploy
+++ b/.claude/skills/aiq-deploy
@@ -1,0 +1,1 @@
+../../.agents/skills/aiq-deploy

--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -1,0 +1,24 @@
+# AI-Q Skills Eval Agent
+
+You are the AI-Q skills-eval coordinator. Your job is to evaluate changed Agent Skills under `.agents/skills/`.
+
+## Workflow
+
+1. Find changed skill directories or, in manual mode, all specs under `.agents/skills/<skill>/eval/*.json`.
+2. Require each spec to define `skills`, `resources.platforms`, `env`, and `expects`.
+3. Require an adapter at `.github/skill-eval/adapters/<skill>/generate.py`.
+4. Generate datasets with the adapter. Do not edit skill source during an eval run.
+5. If Harbor execution is enabled, run one trial for each generated platform/mode dataset.
+6. Report deterministic verifier results and trace paths.
+
+## Hard Rules
+
+- Do not print API keys or copied environment values.
+- Do not invent deployment assumptions. If a live AI-Q server is required, use `AIQ_SERVER_URL` and the `aiq-deploy` skill.
+- Do not bake VSS profile names, VSS ports, Brev secure-link rules, or video-service checks into AI-Q adapters.
+- If an adapter or spec is missing, fail clearly with the missing path.
+- Keep eval data under `/tmp/aiq-skill-eval/`; do not commit generated datasets.
+
+## Current Scope
+
+The initial scope is `aiq-research` smoke validation against an existing AI-Q server. Add deeper chat or async-job lifecycle specs only when the eval environment has stable model/search keys and expected runtime cost is accepted.

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -74,15 +74,29 @@ Harbor execution requires a runner where:
 
 - `AIQ_SERVER_URL` points to a running AI-Q server.
 - `uvx harbor` is available.
-- Claude Code / Anthropic-compatible credentials are available through `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, and `ANTHROPIC_MODEL`.
+- Agent credentials are available for the selected Harbor agent.
+- `AIQ_SKILL_EVAL_MAX_RETRIES` can tune Harbor retries and defaults to `1` to tolerate transient agent install failures.
 
-Example:
+Claude Code is the default agent and uses Anthropic-compatible credentials:
 
 ```bash
-export AIQ_SERVER_URL=http://localhost:8000
-export ANTHROPIC_MODEL=...
+export AIQ_SERVER_URL=http://host.docker.internal:8000
 export ANTHROPIC_BASE_URL=...
 export ANTHROPIC_API_KEY=...
+export ANTHROPIC_MODEL=...
+
+python3 .github/skill-eval/skills_eval_agent.py --all --run-harbor
+```
+
+For local Docker Desktop runs, `host.docker.internal` lets the Harbor task container reach an AI-Q server running on the host. If AI-Q is running inside the same network as Harbor, use that reachable URL instead.
+
+Codex is also supported. To use the local Codex login without printing or copying tokens into commands, opt into Harbor's `auth.json` upload path:
+
+```bash
+export AIQ_SERVER_URL=http://host.docker.internal:8000
+export AIQ_SKILL_EVAL_AGENT=codex
+export AIQ_SKILL_EVAL_MODEL=gpt-5.2
+export CODEX_FORCE_AUTH_JSON=1
 
 python3 .github/skill-eval/skills_eval_agent.py --all --run-harbor
 ```

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -1,0 +1,94 @@
+# AI-Q Skill Eval
+
+This directory contains the initial AI-Q Agent Skill evaluation harness. It follows the same broad pattern as the VSS skill-eval work, but removes VSS-specific deployment profiles, video services, GPU assumptions, and Brev pool naming.
+
+The first supported skill is `aiq-research`, with specs under:
+
+```text
+.agents/skills/aiq-research/eval/*.json
+```
+
+## What It Does
+
+1. Finds Agent Skill eval specs under `.agents/skills/<skill>/eval/*.json`.
+2. Validates each spec has `skills`, `resources.platforms`, `env`, and ordered `expects`.
+3. Uses a matching adapter under `.github/skill-eval/adapters/<skill>/generate.py`.
+4. Generates Harbor-style task datasets under `/tmp/aiq-skill-eval/datasets`.
+5. Optionally runs Harbor against generated datasets when a live AI-Q server and agent credentials are available.
+
+The initial `aiq-research` profile is a smoke test for a live AI-Q server:
+
+- health check through `scripts/aiq.py health`
+- async agent listing through `scripts/aiq.py agents`
+
+It intentionally avoids model-generating `/chat` calls so the baseline eval can validate the skill wrapper without spending inference credits. Deeper research lifecycle specs should be added once the eval runner has stable API keys and runtime expectations.
+
+## Spec Format
+
+Each spec is JSON:
+
+```json
+{
+  "skills": ["aiq-research"],
+  "resources": {
+    "platforms": {
+      "local": {"modes": ["existing-server"]}
+    }
+  },
+  "env": "Live environment notes",
+  "expects": [
+    {
+      "query": "Instruction shown to the agent",
+      "checks": [
+        "trajectory_contains:scripts/aiq.py health",
+        "shell:curl -sf \"${AIQ_SERVER_URL:-http://localhost:8000}/health\" >/dev/null"
+      ]
+    }
+  ]
+}
+```
+
+Supported deterministic check prefixes:
+
+| Prefix | Behavior |
+|---|---|
+| `shell:` | Runs the shell command. Passes on exit code 0. |
+| `json_command:` | Runs the shell command and requires stdout to parse as JSON. |
+| `trajectory_contains:` | Searches Harbor agent logs for a substring. |
+| `trajectory_not_contains:` | Passes only when the substring is absent from Harbor agent logs. |
+
+## Generate Locally
+
+From the AI-Q repository root:
+
+```bash
+python3 .github/skill-eval/skills_eval_agent.py --all \
+  --output-dir /tmp/aiq-skill-eval/datasets
+```
+
+The generated dataset contains `instruction.md`, `task.toml`, `tests/test.sh`, verifier helpers, a copy of the skill under test, and `solution/solve.sh`.
+
+## Run With Harbor
+
+Harbor execution requires a runner where:
+
+- `AIQ_SERVER_URL` points to a running AI-Q server.
+- `uvx harbor` is available.
+- Claude Code / Anthropic-compatible credentials are available through `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, and `ANTHROPIC_MODEL`.
+
+Example:
+
+```bash
+export AIQ_SERVER_URL=http://localhost:8000
+export ANTHROPIC_MODEL=...
+export ANTHROPIC_BASE_URL=...
+export ANTHROPIC_API_KEY=...
+
+python3 .github/skill-eval/skills_eval_agent.py --all --run-harbor
+```
+
+If the server is not already running, use the `aiq-deploy` skill first. The generated tasks include both `aiq-research` and `aiq-deploy` under `/skills` when the deploy skill is present in this repository.
+
+## CI
+
+`.github/workflows/skills-eval.yml` validates spec and adapter generation when Agent Skill or skill-eval files change. Full Harbor execution is available through manual dispatch on a self-hosted runner once an AI-Q eval runner is provisioned.

--- a/.github/skill-eval/adapters/aiq-research/generate.py
+++ b/.github/skill-eval/adapters/aiq-research/generate.py
@@ -69,11 +69,7 @@ def _test_script(spec_name: str, step: int) -> str:
 
 
 def _solution_script() -> str:
-    return (
-        "#!/bin/bash\n"
-        "set -euo pipefail\n"
-        "python3 /skills/aiq-research/scripts/aiq.py health\n"
-    )
+    return "#!/bin/bash\nset -euo pipefail\npython3 /skills/aiq-research/scripts/aiq.py health\n"
 
 
 def _environment_compose() -> str:
@@ -115,8 +111,8 @@ def _task_toml(skill: str, spec_stem: str, platform: str, mode: str, step: int, 
             f'spec = "{spec_stem}"',
             f'platform = "{platform}"',
             f'mode = "{mode}"',
-            f'step = {step}',
-            f'total_steps = {total_steps}',
+            f"step = {step}",
+            f"total_steps = {total_steps}",
             "",
         ]
     )

--- a/.github/skill-eval/adapters/aiq-research/generate.py
+++ b/.github/skill-eval/adapters/aiq-research/generate.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Generate Harbor tasks for the aiq-research skill."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+from pathlib import Path
+from string import Template
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+VERIFIER = Path(__file__).resolve().parents[2] / "verifiers" / "aiq_checks.py"
+DEFAULT_SERVER_URL = "http://localhost:8000"
+PREAMBLE = (
+    "You are running inside a non-interactive evaluation harness. "
+    "Use the installed AI-Q Agent Skills autonomously. Do not ask the user "
+    "to run commands that you can run yourself."
+)
+
+PLATFORMS = {
+    "local": {
+        "short_name": "local",
+        "description": "Runner-local or externally reachable AI-Q server",
+    }
+}
+
+
+def _copytree(src: Path, dst: Path) -> None:
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst)
+
+
+def _render(value: str, *, platform: str, mode: str, repo_root: Path) -> str:
+    rendered = value
+    server_url = os.environ.get("AIQ_SERVER_URL", DEFAULT_SERVER_URL)
+    replacements = {
+        "{{platform}}": platform,
+        "{{mode}}": mode,
+        "{{repo_root}}": str(repo_root),
+        "{{aiq_server_url}}": server_url,
+    }
+    for key, replacement in replacements.items():
+        rendered = rendered.replace(key, replacement)
+    return Template(rendered).safe_substitute(
+        platform=platform,
+        mode=mode,
+        repo_root=str(repo_root),
+        aiq_server_url=server_url,
+    )
+
+
+def _test_script(spec_name: str, step: int) -> str:
+    return (
+        "#!/bin/bash\n"
+        "set -uo pipefail\n"
+        'TEST_DIR="$(cd "$(dirname "$0")" && pwd)"\n'
+        'LOCAL_SKILLS_DIR="$(cd "$TEST_DIR/.." && pwd)/skills"\n'
+        'if [ -d "$LOCAL_SKILLS_DIR" ]; then\n'
+        '  export AIQ_EVAL_SKILLS_DIR="${AIQ_EVAL_SKILLS_DIR:-$LOCAL_SKILLS_DIR}"\n'
+        "fi\n"
+        f'python3 "$TEST_DIR/aiq_checks.py" --spec "$TEST_DIR/{spec_name}" --step {step}\n'
+        "exit 0\n"
+    )
+
+
+def _solution_script() -> str:
+    return (
+        "#!/bin/bash\n"
+        "set -euo pipefail\n"
+        "python3 /skills/aiq-research/scripts/aiq.py health\n"
+    )
+
+
+def _environment_compose() -> str:
+    return (
+        "services:\n"
+        "  main:\n"
+        "    environment:\n"
+        "      AIQ_SERVER_URL: ${AIQ_SERVER_URL}\n"
+        "    volumes:\n"
+        "      - type: bind\n"
+        "        source: ${CONTEXT_DIR}/../skills\n"
+        "        target: /skills\n"
+        "        read_only: true\n"
+    )
+
+
+def _task_toml(skill: str, spec_stem: str, platform: str, mode: str, step: int, total_steps: int) -> str:
+    platform_short = PLATFORMS[platform]["short_name"]
+    step_suffix = f"-step-{step}" if total_steps > 1 else ""
+    server_url = os.environ.get("AIQ_SERVER_URL", DEFAULT_SERVER_URL)
+    return "\n".join(
+        [
+            "[task]",
+            f'name = "nvidia-aiq/{skill}-{spec_stem}-{platform_short}-{mode}{step_suffix}"',
+            f'description = "{skill} {spec_stem} eval on {platform}/{mode} step {step} of {total_steps}"',
+            f'keywords = ["aiq", "{skill}", "{spec_stem}", "{platform}", "{mode}"]',
+            "",
+            "[environment]",
+            'skills_dir = "/skills"',
+            "",
+            "[environment.env]",
+            f'AIQ_SERVER_URL = "{server_url}"',
+            "",
+            "[verifier.env]",
+            f'AIQ_SERVER_URL = "{server_url}"',
+            "",
+            "[metadata]",
+            f'skill = "{skill}"',
+            f'spec = "{spec_stem}"',
+            f'platform = "{platform}"',
+            f'mode = "{mode}"',
+            f'step = {step}',
+            f'total_steps = {total_steps}',
+            "",
+        ]
+    )
+
+
+def generate(spec_path: Path, skill_dir: Path, output_dir: Path, repo_root: Path) -> list[Path]:
+    spec = json.loads(spec_path.read_text())
+    skill = skill_dir.name
+    spec_stem = spec_path.stem
+    expects = spec.get("expects") or []
+    if not expects:
+        raise ValueError(f"{spec_path} has no expects entries")
+
+    generated: list[Path] = []
+    platforms = spec.get("resources", {}).get("platforms", {})
+    for platform, platform_cfg in platforms.items():
+        if platform not in PLATFORMS:
+            raise ValueError(f"unsupported platform {platform!r}; supported: {sorted(PLATFORMS)}")
+        for mode in platform_cfg.get("modes", []):
+            mode_slug = mode.lower().replace("_", "-")
+            base_dir = output_dir / spec_stem / f"{PLATFORMS[platform]['short_name']}-{mode_slug}"
+            for idx, expect in enumerate(expects, start=1):
+                step_dir = base_dir / f"step-{idx}" if len(expects) > 1 else base_dir
+                tests_dir = step_dir / "tests"
+                solution_dir = step_dir / "solution"
+                skills_dir = step_dir / "skills"
+                env_dir = step_dir / "environment"
+                tests_dir.mkdir(parents=True, exist_ok=True)
+                solution_dir.mkdir(parents=True, exist_ok=True)
+                skills_dir.mkdir(parents=True, exist_ok=True)
+                env_dir.mkdir(parents=True, exist_ok=True)
+
+                instruction = "\n".join(
+                    [
+                        PREAMBLE,
+                        "",
+                        f"AI-Q server URL: `{os.environ.get('AIQ_SERVER_URL', DEFAULT_SERVER_URL)}`.",
+                        "Use the `/aiq-research` skill for this task.",
+                        "If the server is unavailable and `/aiq-deploy` is installed, "
+                        "use it to start or verify AI-Q first.",
+                        "",
+                        f"## Query {idx} of {len(expects)}",
+                        "",
+                        _render(expect.get("query", ""), platform=platform, mode=mode, repo_root=repo_root),
+                        "",
+                        "## Environment Notes",
+                        "",
+                        _render(spec.get("env", ""), platform=platform, mode=mode, repo_root=repo_root),
+                        "",
+                    ]
+                )
+                (step_dir / "instruction.md").write_text(instruction + "\n")
+                (step_dir / "task.toml").write_text(
+                    _task_toml(skill, spec_stem, platform, mode_slug, idx, len(expects))
+                )
+                (env_dir / "Dockerfile").write_text("FROM python:3.12-slim\n")
+                (env_dir / "docker-compose.yaml").write_text(_environment_compose())
+                (tests_dir / spec_path.name).write_text(json.dumps(spec, indent=2) + "\n")
+                shutil.copy2(VERIFIER, tests_dir / "aiq_checks.py")
+                test_sh = tests_dir / "test.sh"
+                test_sh.write_text(_test_script(spec_path.name, idx))
+                test_sh.chmod(0o755)
+                solve_sh = solution_dir / "solve.sh"
+                solve_sh.write_text(_solution_script())
+                solve_sh.chmod(0o755)
+
+                _copytree(skill_dir, skills_dir / skill)
+                deploy_skill = repo_root / ".agents" / "skills" / "aiq-deploy"
+                if deploy_skill.exists():
+                    _copytree(deploy_skill, skills_dir / "aiq-deploy")
+            generated.append(base_dir)
+    return generated
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--skill-dir", required=True)
+    parser.add_argument("--spec", required=True)
+    parser.add_argument("--repo-root", default=str(REPO_ROOT))
+    args = parser.parse_args()
+
+    generated = generate(
+        spec_path=Path(args.spec).resolve(),
+        skill_dir=Path(args.skill_dir).resolve(),
+        output_dir=Path(args.output_dir).resolve(),
+        repo_root=Path(args.repo_root).resolve(),
+    )
+    print(json.dumps({"generated": [str(path) for path in generated]}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skill-eval/skills_eval_agent.py
+++ b/.github/skill-eval/skills_eval_agent.py
@@ -88,9 +88,14 @@ def _task_roots(dataset_root: Path) -> list[Path]:
 
 
 def _run_harbor(task_root: Path) -> int:
-    model = os.environ.get("ANTHROPIC_MODEL")
-    if not model:
-        print("BLOCKED: ANTHROPIC_MODEL is required for Harbor execution", file=sys.stderr)
+    agent = os.environ.get("AIQ_SKILL_EVAL_AGENT", "claude-code")
+    model = os.environ.get("AIQ_SKILL_EVAL_MODEL") or os.environ.get("ANTHROPIC_MODEL")
+    max_retries = os.environ.get("AIQ_SKILL_EVAL_MAX_RETRIES", "1")
+    if agent != "oracle" and not model:
+        print(
+            "BLOCKED: AIQ_SKILL_EVAL_MODEL or ANTHROPIC_MODEL is required for Harbor execution",
+            file=sys.stderr,
+        )
         return 2
 
     cmd = [
@@ -100,23 +105,24 @@ def _run_harbor(task_root: Path) -> int:
         "-p",
         str(task_root),
         "-a",
-        "claude-code",
-        "--model",
-        model,
-        "--ae",
-        "CLAUDE_CODE_DISABLE_THINKING=1",
+        agent,
         "--max-retries",
-        "0",
+        max_retries,
         "-n",
         "1",
         "--yes",
         "-o",
         os.environ.get("AIQ_SKILL_EVAL_RESULTS_DIR", "/tmp/aiq-skill-eval/results"),
     ]
-    base_url = os.environ.get("ANTHROPIC_BASE_URL")
-    if base_url:
-        cmd.extend(["--ak", f"api_base={base_url.rstrip('/')}/v1"])
-
+    if model:
+        cmd.extend(["--model", model])
+    if agent == "claude-code":
+        cmd.extend(["--ae", "CLAUDE_CODE_DISABLE_THINKING=1"])
+    if agent == "codex":
+        for key in ("CODEX_FORCE_AUTH_JSON", "CODEX_AUTH_JSON_PATH"):
+            value = os.environ.get(key)
+            if value:
+                cmd.extend(["--ae", f"{key}={value}"])
     result = _run(cmd)
     print(result.stdout)
     return result.returncode

--- a/.github/skill-eval/skills_eval_agent.py
+++ b/.github/skill-eval/skills_eval_agent.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""AI-Q skill-eval coordinator.
+
+This script validates Agent Skill eval specs, generates Harbor-style datasets,
+and can optionally run Harbor when the target environment is available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = Path(os.environ.get("AIQ_SKILL_EVAL_OUTPUT_DIR", "/tmp/aiq-skill-eval/datasets"))
+REQUIRED_SPEC_KEYS = ("skills", "resources", "env", "expects")
+
+
+def _run(cmd: list[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    print("+ " + " ".join(cmd), flush=True)
+    return subprocess.run(cmd, cwd=cwd, text=True, check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+
+def _git_changed_files(base: str) -> list[str]:
+    result = _run(["git", "diff", "--name-only", f"{base}...HEAD"])
+    if result.returncode != 0:
+        print(result.stdout, file=sys.stderr)
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _changed_skill_names(base: str | None) -> set[str]:
+    if not base:
+        return set()
+    changed: set[str] = set()
+    for path in _git_changed_files(base):
+        parts = Path(path).parts
+        if len(parts) >= 3 and parts[0] == ".agents" and parts[1] == "skills":
+            changed.add(parts[2])
+    return changed
+
+
+def _discover_specs(*, all_specs: bool, base: str | None) -> list[Path]:
+    changed = _changed_skill_names(base)
+    specs = sorted((REPO_ROOT / ".agents" / "skills").glob("*/eval/*.json"))
+    if all_specs or not changed:
+        return specs
+    return [spec for spec in specs if spec.parts[-3] in changed]
+
+
+def _validate_spec(spec_path: Path) -> dict[str, Any]:
+    spec = json.loads(spec_path.read_text())
+    missing = [key for key in REQUIRED_SPEC_KEYS if key not in spec]
+    if missing:
+        raise ValueError(f"{spec_path} missing required keys: {', '.join(missing)}")
+    if not isinstance(spec["skills"], list) or not spec["skills"]:
+        raise ValueError(f"{spec_path} must define non-empty skills list")
+    platforms = spec.get("resources", {}).get("platforms")
+    if not isinstance(platforms, dict) or not platforms:
+        raise ValueError(f"{spec_path} must define resources.platforms")
+    if not isinstance(spec["expects"], list) or not spec["expects"]:
+        raise ValueError(f"{spec_path} must define non-empty expects list")
+    for idx, expect in enumerate(spec["expects"], start=1):
+        if "query" not in expect or "checks" not in expect:
+            raise ValueError(f"{spec_path} expects[{idx}] must define query and checks")
+    return spec
+
+
+def _adapter_for(skill: str) -> Path:
+    return REPO_ROOT / ".github" / "skill-eval" / "adapters" / skill / "generate.py"
+
+
+def _task_roots(dataset_root: Path) -> list[Path]:
+    roots: list[Path] = []
+    for task_toml in dataset_root.rglob("task.toml"):
+        parent = task_toml.parent
+        if parent.name.startswith("step-"):
+            roots.append(parent.parent)
+        else:
+            roots.append(parent)
+    return sorted(set(roots))
+
+
+def _run_harbor(task_root: Path) -> int:
+    model = os.environ.get("ANTHROPIC_MODEL")
+    if not model:
+        print("BLOCKED: ANTHROPIC_MODEL is required for Harbor execution", file=sys.stderr)
+        return 2
+
+    cmd = [
+        "uvx",
+        "harbor",
+        "run",
+        "-p",
+        str(task_root),
+        "-a",
+        "claude-code",
+        "--model",
+        model,
+        "--ae",
+        "CLAUDE_CODE_DISABLE_THINKING=1",
+        "--max-retries",
+        "0",
+        "-n",
+        "1",
+        "--yes",
+        "-o",
+        os.environ.get("AIQ_SKILL_EVAL_RESULTS_DIR", "/tmp/aiq-skill-eval/results"),
+    ]
+    base_url = os.environ.get("ANTHROPIC_BASE_URL")
+    if base_url:
+        cmd.extend(["--ak", f"api_base={base_url.rstrip('/')}/v1"])
+
+    result = _run(cmd)
+    print(result.stdout)
+    return result.returncode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--all", action="store_true", help="Generate every checked-in spec")
+    parser.add_argument("--base", default=os.environ.get("PR_BASE") or os.environ.get("GITHUB_BASE_REF"))
+    parser.add_argument("--output-dir", default=str(DEFAULT_OUTPUT_DIR))
+    parser.add_argument("--run-harbor", action="store_true", help="Run Harbor after generating datasets")
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    specs = _discover_specs(all_specs=args.all, base=args.base)
+    if not specs:
+        print("BLOCKED: no AI-Q skill eval specs found")
+        return 0
+
+    generated_roots: list[Path] = []
+    for spec_path in specs:
+        spec = _validate_spec(spec_path)
+        skill = spec["skills"][0]
+        skill_dir = REPO_ROOT / ".agents" / "skills" / skill
+        adapter = _adapter_for(skill)
+        if not skill_dir.exists():
+            raise FileNotFoundError(f"skill directory not found: {skill_dir}")
+        if not adapter.exists():
+            raise FileNotFoundError(f"adapter not found: {adapter}")
+
+        result = _run(
+            [
+                sys.executable,
+                str(adapter),
+                "--output-dir",
+                str(output_dir / skill),
+                "--skill-dir",
+                str(skill_dir),
+                "--spec",
+                str(spec_path),
+                "--repo-root",
+                str(REPO_ROOT),
+            ]
+        )
+        print(result.stdout)
+        if result.returncode != 0:
+            return result.returncode
+        generated_roots.extend(_task_roots(output_dir / skill / spec_path.stem))
+
+    summary = {
+        "specs": [str(path.relative_to(REPO_ROOT)) for path in specs],
+        "datasets": [str(path) for path in sorted(set(generated_roots))],
+    }
+    print(json.dumps(summary, indent=2))
+
+    if args.run_harbor:
+        for task_root in sorted(set(generated_roots)):
+            rc = _run_harbor(task_root)
+            if rc != 0:
+                return rc
+
+    print(f"DONE: generated {len(set(generated_roots))} AI-Q skill-eval dataset(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skill-eval/verifiers/aiq_checks.py
+++ b/.github/skill-eval/verifiers/aiq_checks.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic verifier for AI-Q skill eval tasks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+TRAJECTORY_CANDIDATES = (
+    "/logs/agent/trajectory.jsonl",
+    "/logs/agent/trajectory.json",
+    "/logs/agent/claude-code.txt",
+    "/logs/agent/agent.log",
+)
+
+
+def locate_trajectory() -> Path | None:
+    override = os.environ.get("AIQ_EVAL_TRAJECTORY")
+    if override:
+        path = Path(override)
+        return path if path.exists() else None
+    for candidate in TRAJECTORY_CANDIDATES:
+        path = Path(candidate)
+        if path.exists():
+            return path
+    return None
+
+
+def read_trajectory() -> str:
+    path = locate_trajectory()
+    if path is None:
+        return ""
+    return path.read_text(errors="replace")
+
+
+def run_shell(command: str) -> tuple[bool, str]:
+    skills_dir = os.environ.get("AIQ_EVAL_SKILLS_DIR")
+    if skills_dir:
+        command = command.replace("/skills/", f"{skills_dir.rstrip('/')}/")
+    result = subprocess.run(
+        command,
+        shell=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=int(os.environ.get("AIQ_EVAL_CHECK_TIMEOUT", "120")),
+        check=False,
+    )
+    output = (result.stdout or "").strip()
+    return result.returncode == 0, output[-4000:]
+
+
+def run_json_command(command: str) -> tuple[bool, str]:
+    passed, output = run_shell(command)
+    if not passed:
+        return False, output
+    try:
+        json.loads(output or "{}")
+    except json.JSONDecodeError as exc:
+        return False, f"stdout was not valid JSON: {exc}: {output[:1000]}"
+    return True, output[:1000]
+
+
+def evaluate_check(check: str, trajectory: str) -> dict[str, Any]:
+    if check.startswith("shell:"):
+        command = check.removeprefix("shell:").strip()
+        passed, output = run_shell(command)
+        return {"check": check, "pass": passed, "route": "shell", "evidence": output}
+
+    if check.startswith("json_command:"):
+        command = check.removeprefix("json_command:").strip()
+        passed, output = run_json_command(command)
+        return {"check": check, "pass": passed, "route": "json_command", "evidence": output}
+
+    if check.startswith("trajectory_contains:"):
+        needle = check.removeprefix("trajectory_contains:").strip()
+        passed = needle in trajectory
+        return {
+            "check": check,
+            "pass": passed,
+            "route": "trajectory_contains",
+            "evidence": needle if passed else "substring not found",
+        }
+
+    if check.startswith("trajectory_not_contains:"):
+        needle = check.removeprefix("trajectory_not_contains:").strip()
+        passed = needle not in trajectory
+        return {
+            "check": check,
+            "pass": passed,
+            "route": "trajectory_not_contains",
+            "evidence": "absent" if passed else needle,
+        }
+
+    return {
+        "check": check,
+        "pass": False,
+        "route": "unsupported",
+        "evidence": "check must start with shell:, json_command:, trajectory_contains:, or trajectory_not_contains:",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--spec", required=True)
+    parser.add_argument("--step", type=int, required=True)
+    args = parser.parse_args()
+
+    spec = json.loads(Path(args.spec).read_text())
+    expects = spec.get("expects") or []
+    if args.step < 1 or args.step > len(expects):
+        raise SystemExit(f"step {args.step} out of range for {len(expects)} expects")
+
+    checks = expects[args.step - 1].get("checks") or []
+    trajectory = read_trajectory()
+    results = [evaluate_check(check, trajectory) for check in checks]
+    passed = sum(1 for result in results if result["pass"])
+    total = len(results)
+    reward = 1.0 if total == 0 else passed / total
+
+    log_dir = Path(os.environ.get("AIQ_EVAL_VERIFIER_LOG_DIR", "/logs/verifier"))
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "reward.txt").write_text(f"{reward:.6f}\n")
+    (log_dir / "aiq-checks.json").write_text(json.dumps(results, indent=2) + "\n")
+
+    for result in results:
+        status = "PASS" if result["pass"] else "FAIL"
+        print(f"{status}: {result['check']}")
+        if result["evidence"]:
+            print(f"  {result['evidence']}")
+    print(f"=== Results: {passed} passed, {total - passed} failed (of {total}) ===")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -1,0 +1,84 @@
+name: Skills Eval
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - "release/**"
+    paths:
+      - ".agents/skills/**"
+      - ".github/skill-eval/**"
+      - ".github/workflows/skills-eval.yml"
+  workflow_dispatch:
+    inputs:
+      run_harbor:
+        description: "Run Harbor trials on the self-hosted AI-Q eval runner"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: aiq-skills-eval-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate-datasets:
+    name: Validate Skill Eval Datasets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Generate datasets
+        run: |
+          python3 .github/skill-eval/skills_eval_agent.py --all \
+            --output-dir /tmp/aiq-skill-eval/datasets
+
+      - name: Upload generated datasets
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: aiq-skill-eval-datasets-${{ github.run_id }}
+          path: /tmp/aiq-skill-eval/datasets
+          if-no-files-found: error
+          retention-days: 7
+
+  harbor-eval:
+    name: Run Harbor Skill Eval
+    if: github.event_name == 'workflow_dispatch' && inputs.run_harbor
+    runs-on: [self-hosted, aiq-eval]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Harbor trials
+        env:
+          AIQ_SERVER_URL: ${{ secrets.AIQ_SKILL_EVAL_SERVER_URL }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL }}
+          CLAUDE_CODE_DISABLE_THINKING: "1"
+        run: |
+          python3 .github/skill-eval/skills_eval_agent.py --all --run-harbor \
+            --output-dir /tmp/aiq-skill-eval/datasets
+
+      - name: Upload Harbor results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: aiq-skill-eval-results-${{ github.run_id }}
+          path: /tmp/aiq-skill-eval/results
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -16,6 +16,20 @@ on:
         required: false
         default: false
         type: boolean
+      agent:
+        description: "Harbor agent to run"
+        required: false
+        default: "claude-code"
+        type: choice
+        options:
+          - claude-code
+          - codex
+          - oracle
+      model:
+        description: "Model name for the selected Harbor agent"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -66,9 +80,11 @@ jobs:
       - name: Run Harbor trials
         env:
           AIQ_SERVER_URL: ${{ secrets.AIQ_SKILL_EVAL_SERVER_URL }}
+          AIQ_SKILL_EVAL_AGENT: ${{ inputs.agent }}
+          AIQ_SKILL_EVAL_MODEL: ${{ inputs.model || vars.AIQ_SKILL_EVAL_MODEL || vars.ANTHROPIC_MODEL }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-          ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_CODE_DISABLE_THINKING: "1"
         run: |
           python3 .github/skill-eval/skills_eval_agent.py --all --run-harbor \

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -26,29 +26,27 @@
 # =============================================================================
 # Stage 1: Builder (shared between dev and release)
 # =============================================================================
-FROM nvcr.io/nvidia/base/ubuntu:jammy-20260217 AS builder
+FROM nvcr.io/nvidia/base/ubuntu:noble-20260217 AS builder
 
 WORKDIR /app
 
-# Install system dependencies and Python 3.13
+# Install system dependencies and bootstrap Python for uv.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     tzdata \
     build-essential \
+    ca-certificates \
     curl \
     git \
-    software-properties-common \
-    && add-apt-repository ppa:deadsnakes/ppa \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    python3.13 \
-    python3.13-dev \
-    python3.13-venv \
+    python3 \
+    python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python3.13 -m ensurepip --upgrade \
-    && python3.13 -m pip install --no-cache-dir uv \
-    && ln -sf /usr/bin/python3.13 /usr/local/bin/python \
-    && ln -sf /usr/bin/python3.13 /usr/local/bin/python3
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv-python
+
+RUN python3 -m pip install --break-system-packages --no-cache-dir uv \
+    && uv python install 3.13 \
+    && ln -sf "$(uv python find 3.13)" /usr/local/bin/python \
+    && ln -sf "$(uv python find 3.13)" /usr/local/bin/python3
 
 RUN uv venv /app/.venv --python /usr/local/bin/python
 
@@ -106,6 +104,7 @@ FROM nvcr.io/nvidia/distroless/python:3.13-v4.0.5 AS dev
 
 WORKDIR /app
 
+COPY --from=dev-builder /opt/uv-python /opt/uv-python
 COPY --from=dev-builder /app /app
 
 USER 1000:1000
@@ -126,6 +125,7 @@ FROM nvcr.io/nvidia/distroless/python:3.13-v4.0.5 AS release
 WORKDIR /app
 
 # Copy from base builder (no CLI)
+COPY --from=builder /opt/uv-python /opt/uv-python
 COPY --from=builder /app /app
 
 USER 1000:1000

--- a/docs/source/integration/agent-skills.md
+++ b/docs/source/integration/agent-skills.md
@@ -5,27 +5,32 @@ SPDX-License-Identifier: Apache-2.0
 
 # Agent Skills for Coding Harnesses
 
-AI-Q includes a portable Agent Skill for coding harnesses that support skill-style instructions and helper scripts. The skill lets an assistant call a locally running AI-Q Blueprint server for routed `/chat` requests and async deep research job lifecycle operations.
+AI-Q includes portable Agent Skills for coding harnesses that support skill-style instructions and helper scripts.
 
-The packaged skill lives at:
+- `aiq-deploy` helps an assistant deploy, verify, troubleshoot, rebuild, and stop the AI-Q Blueprint in CLI, local web, Docker Compose, or Kubernetes mode.
+- `aiq-research` lets an assistant call a locally running AI-Q Blueprint server for routed `/chat` requests and async deep research job lifecycle operations.
+
+The packaged skills live at:
 
 ```text
+.agents/skills/aiq-deploy/
 .agents/skills/aiq-research/
 ```
 
-The installed `aiq-research` directory must contain `SKILL.md` at its root. For package-local details, see `.agents/skills/aiq-research/README.md`.
+Each installed skill directory must contain `SKILL.md` at its root. For package-local details, see `.agents/skills/<skill-name>/README.md`.
 
 ## Prerequisites
 
 - Python 3.10 or newer.
-- A local AI-Q Blueprint server, usually at `http://localhost:8000`.
-- Set `AIQ_SERVER_URL` only when using a different local server URL.
+- For `aiq-deploy`: access to this repository and the selected runtime, such as Docker Compose, Node/npm for local web mode, or kubectl/Helm for Kubernetes mode.
+- For `aiq-research`: a local AI-Q Blueprint server, usually at `http://localhost:8000`. Set `AIQ_SERVER_URL` only when using a different local server URL.
 
 ## Claude Code
 
-Claude Code supports repo-local skills under `.claude/skills/`. This repository keeps that path as a compatibility symlink:
+Claude Code supports repo-local skills under `.claude/skills/`. This repository keeps those paths as compatibility symlinks:
 
 ```text
+.claude/skills/aiq-deploy -> ../../.agents/skills/aiq-deploy
 .claude/skills/aiq-research -> ../../.agents/skills/aiq-research
 ```
 
@@ -33,6 +38,7 @@ To recreate the repo-local install manually:
 
 ```bash
 mkdir -p .claude/skills
+ln -s ../../.agents/skills/aiq-deploy .claude/skills/aiq-deploy
 ln -s ../../.agents/skills/aiq-research .claude/skills/aiq-research
 ```
 
@@ -40,6 +46,7 @@ For a user-level install:
 
 ```bash
 mkdir -p ~/.claude/skills
+cp -R .agents/skills/aiq-deploy ~/.claude/skills/aiq-deploy
 cp -R .agents/skills/aiq-research ~/.claude/skills/aiq-research
 ```
 
@@ -50,6 +57,7 @@ For Codex or another Agent Skills-compatible tool, install the skill into the ru
 Generic install shape:
 
 ```text
+<codex-skills-dir>/aiq-deploy/SKILL.md
 <codex-skills-dir>/aiq-research/SKILL.md
 <codex-skills-dir>/aiq-research/scripts/aiq.py
 ```
@@ -58,6 +66,7 @@ Example:
 
 ```bash
 mkdir -p <codex-skills-dir>
+cp -R .agents/skills/aiq-deploy <codex-skills-dir>/aiq-deploy
 cp -R .agents/skills/aiq-research <codex-skills-dir>/aiq-research
 ```
 
@@ -72,6 +81,7 @@ Install with:
 
 ```bash
 mkdir -p ~/.config/opencode/skills
+cp -R .agents/skills/aiq-deploy ~/.config/opencode/skills/aiq-deploy
 cp -R .agents/skills/aiq-research ~/.config/opencode/skills/aiq-research
 ```
 
@@ -80,10 +90,11 @@ Restart OpenCode or start a new session after installation.
 
 ## Verify Installation
 
-From the installed skill directory, run:
+From the parent directory containing the installed skills, run:
 
 ```bash
-python3 scripts/aiq.py
+test -f aiq-deploy/SKILL.md
+python3 aiq-research/scripts/aiq.py
 ```
 
 Expected output starts with:


### PR DESCRIPTION
## Summary

This PR adds the initial AI-Q Agent Skill evaluation harness and a deploy skill so we can validate AI-Q skills in the same general style as the VSS skill-eval work, without copying VSS-specific Brev/GPU/video assumptions into AI-Q.

The first checked-in eval target is `aiq-research`. The baseline profile is intentionally a smoke test against a live AI-Q server: it verifies the skill can check server health and list available async research agents. It avoids model-generating chat/research calls for now so the harness can run cheaply and deterministically while we stabilize runner credentials, deploy expectations, and the AI-Q runtime contract.

## What Changed

- Added `.github/skill-eval/` for AI-Q skill-eval orchestration:
  - `skills_eval_agent.py` discovers skill eval specs, validates their schema, generates task datasets, and optionally invokes Harbor.
  - `adapters/aiq-research/generate.py` turns `.agents/skills/aiq-research/eval/*.json` specs into Harbor-style task directories.
  - `verifiers/aiq_checks.py` provides deterministic checks such as shell command checks, JSON command checks, and trajectory contains/not-contains checks.
  - `AGENTS.md` and `README.md` document the eval workspace and local/CI usage.

- Added the first `aiq-research` eval spec:
  - `.agents/skills/aiq-research/eval/basic.json`
  - Verifies `/health` through the skill wrapper.
  - Verifies `/v1/jobs/async/agents` through `scripts/aiq.py agents` and requires both `deep_researcher` and `shallow_researcher`.

- Added an `aiq-deploy` skill:
  - `.agents/skills/aiq-deploy/SKILL.md`
  - `.agents/skills/aiq-deploy/README.md`
  - `.claude/skills/aiq-deploy` symlink for Claude-compatible skill discovery.
  - Covers CLI, local web, Docker Compose, Kubernetes/Helm, FRAG mode checks, health verification, logs, rebuild, and stop flows.

- Added PR/dispatch CI for skill eval generation:
  - `.github/workflows/skills-eval.yml`
  - Pull requests validate dataset generation.
  - Manual dispatch can run Harbor trials on a self-hosted `aiq-eval` runner when `run_harbor=true`.
  - Harbor agent selection is configurable via workflow inputs (`claude-code`, `codex`, or `oracle`).

- Updated Docker backend build path:
  - `deploy/Dockerfile` now uses the NVIDIA Ubuntu Noble base for the builder stage.
  - Removed the Launchpad/deadsnakes PPA dependency, which failed in restricted or partially offline environments.
  - Uses distro Python 3.12 packages and installs `uv` through `python3.12 -m pip`.

- Updated docs:
  - `docs/source/integration/agent-skills.md` now includes the AI-Q skill eval/deploy usage path.

## Why This Is Useful

This gives AI-Q a repeatable validation loop for Agent Skills. Instead of relying on an agent author to manually inspect a skill and hope it works, the repo can now generate concrete tasks that exercise the skill against a running AI-Q server and verify the outcome with deterministic checks.

The split between `aiq-deploy` and `aiq-research` is intentional:

- `aiq-deploy` owns getting AI-Q running and proving the runtime is reachable.
- `aiq-research` owns interacting with an already-running AI-Q server.
- `.github/skill-eval` owns converting skill specs into Harbor tasks and running/verifying them.

That separation should make it easier to add deeper evals later without embedding deployment assumptions into every research-skill task.

## Current Scope

This PR is a smoke-harness foundation, not a full research-quality benchmark yet.

Covered now:

- Skill spec discovery and validation.
- Harbor-style dataset generation.
- Health check task.
- Agent listing task.
- Docker-reachable `AIQ_SERVER_URL` support for local Harbor runs.
- Manual Harbor execution with Claude Code or Codex agents.
- Docker Compose backend build/start verification path.

Not covered yet:

- End-to-end `/chat` or research generation quality checks.
- Web-search-backed research flows requiring `TAVILY_API_KEY`, `SERPER_API_KEY`, or `EXA_API_KEY`.
- FRAG-specific evals requiring external RAG services.
- Always-on Harbor execution in regular PR CI. Harbor remains a manual self-hosted workflow path for now.

## Local Validation Performed

Commands/checks run locally:

```bash
uv run ruff check .
uv run ruff format --check .
python3 -m py_compile \
  .github/skill-eval/adapters/aiq-research/generate.py \
  .github/skill-eval/skills_eval_agent.py \
  .github/skill-eval/verifiers/aiq_checks.py
python3 -m json.tool .agents/skills/aiq-research/eval/basic.json >/dev/null
python3 .github/skill-eval/skills_eval_agent.py --all \
  --output-dir /tmp/aiq-skill-eval/precommit-datasets
```

Docker/runtime checks performed locally:

```bash
docker build -f deploy/Dockerfile --target dev -t aiq-agent:skill-eval-test .
```

Then started the backend through Docker Compose on a non-default host port to avoid collisions with existing local services, and verified:

```bash
curl -sf http://127.0.0.1:18000/health
AIQ_SERVER_URL=http://127.0.0.1:18000 python3 .agents/skills/aiq-research/scripts/aiq.py agents
```

The deployed backend returned healthy status and listed both expected agents:

- `deep_researcher`
- `shallow_researcher`

Harbor/Codex eval was also run against the compose-deployed backend:

```bash
AIQ_SERVER_URL=http://host.docker.internal:18000 \
AIQ_SKILL_EVAL_AGENT=codex \
AIQ_SKILL_EVAL_MODEL=gpt-5.2 \
CODEX_FORCE_AUTH_JSON=1 \
AIQ_SKILL_EVAL_RESULTS_DIR=/tmp/aiq-skill-eval/compose-codex-retry-results \
python3 .github/skill-eval/skills_eval_agent.py --all --run-harbor \
  --output-dir /tmp/aiq-skill-eval/compose-codex-retry-datasets
```

Result: `2/2`, mean `1.000`, no exceptions.

## CI Notes

The normal PR CI path validates dataset generation. Full Harbor execution is intentionally gated behind manual workflow dispatch because it needs an AI-Q server URL and agent credentials on a self-hosted runner.

## Follow-Ups

Suggested follow-up work after this lands:

- Add a deeper `aiq-research` lifecycle eval that exercises a small research request once runner credentials and inference cost expectations are agreed.
- Add optional eval profiles for web-search-enabled and FRAG-backed modes.
- Decide whether the self-hosted `aiq-eval` runner should own AI-Q deployment before Harbor runs, or whether it should target a pre-provisioned shared eval server.
- Add more deploy-skill checks if the team wants the skill to actively provision Kubernetes/Helm environments instead of only guiding and verifying them.
