### PR TITLE
fix(security): remediate CVE-2026-45134 (langsmith/langchain-classic) in aiq-agent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,8 @@ override-dependencies = [
     "lxml>=6.1.0,<7",
     "nltk>=3.9.4,<4",
     "pyasn1>=0.6.3,<0.7",
+    "langsmith>=0.8.0,<1",
+    "langchain-classic>=1.0.7,<2",
 ]
 
 [tool.uv.pip]

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,8 @@ overrides = [
     { name = "authlib", specifier = ">=1.6.11,<2" },
     { name = "banks", specifier = ">=2.4.2,<3" },
     { name = "cryptography", specifier = ">=46.0.6,<47" },
+    { name = "langchain-classic", specifier = ">=1.0.7,<2" },
+    { name = "langsmith", specifier = ">=0.8.0,<1" },
     { name = "litellm", specifier = ">=1.83.7,<2" },
     { name = "lxml", specifier = ">=6.1.0,<7" },
     { name = "mako", specifier = ">=1.3.12,<2" },
@@ -2406,7 +2408,7 @@ wheels = [
 
 [[package]]
 name = "langchain-classic"
-version = "1.0.1"
+version = "1.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -2417,9 +2419,9 @@ dependencies = [
     { name = "requests" },
     { name = "sqlalchemy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/4b/bd03518418ece4c13192a504449b58c28afee915dc4a6f4b02622458cb1b/langchain_classic-1.0.1.tar.gz", hash = "sha256:40a499684df36b005a1213735dc7f8dca8f5eb67978d6ec763e7a49780864fdc", size = 10516020, upload-time = "2025-12-23T22:55:22.615Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/78/84b5065816f348c39fefa4316f209f0135e8410216340a953bec17d9e4e4/langchain_classic-1.0.7.tar.gz", hash = "sha256:debbec8065e69b95108d2652e8d5c44f4516e19aa8d716c02ed2211c3aee099d", size = 10554118, upload-time = "2026-05-07T15:46:56.8Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/0f/eab87f017d7fe28e8c11fff614f4cdbfae32baadb77d0f79e9f922af1df2/langchain_classic-1.0.1-py3-none-any.whl", hash = "sha256:131d83a02bb80044c68fedc1ab4ae885d5b8f8c2c742d8ab9e7534ad9cda8e80", size = 1040666, upload-time = "2025-12-23T22:55:21.025Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/78/2d9980d028ff0523eea503a77c200e2ff252a3a75eb6e7842bcf5f9c979b/langchain_classic-1.0.7-py3-none-any.whl", hash = "sha256:d9d9be38f7aa534ed0259c2410432e34a1f80b1d491e686749bb55af56479be3", size = 1041386, upload-time = "2026-05-07T15:46:54.845Z" },
 ]
 
 [[package]]
@@ -2603,14 +2605,14 @@ wheels = [
 
 [[package]]
 name = "langchain-text-splitters"
-version = "1.1.0"
+version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/42/c178dcdc157b473330eb7cc30883ea69b8ec60078c7b85e2d521054c4831/langchain_text_splitters-1.1.0.tar.gz", hash = "sha256:75e58acb7585dc9508f3cd9d9809cb14751283226c2d6e21fb3a9ae57582ca22", size = 272230, upload-time = "2025-12-14T01:15:38.659Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/9f/6c545900fefb7b00ddfa3f16b80d61338a0ec68c31c5451eeeab99082760/langchain_text_splitters-1.1.2.tar.gz", hash = "sha256:782a723db0a4746ac91e251c7c1d57fd23636e4f38ed733074e28d7a86f41627", size = 293580, upload-time = "2026-04-16T14:20:39.162Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/1a/a84ed1c046deecf271356b0179c1b9fba95bfdaa6f934e1849dee26fad7b/langchain_text_splitters-1.1.0-py3-none-any.whl", hash = "sha256:f00341fe883358786104a5f881375ac830a4dd40253ecd42b4c10536c6e4693f", size = 34182, upload-time = "2025-12-14T01:15:37.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/26/1ef06f56198d631296d646a6223de35bcc6cf9795ceb2442816bc963b84c/langchain_text_splitters-1.1.2-py3-none-any.whl", hash = "sha256:a2de0d799ff31886429fd6e2e0032df275b60ec817c19059a7b46181cc1c2f10", size = 35903, upload-time = "2026-04-16T14:20:38.243Z" },
 ]
 
 [[package]]
@@ -2700,7 +2702,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.7.38"
+version = "0.8.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2713,9 +2715,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/c9/b3e54cfcb480876dfe33ecfdd64feeb621a86d9e6f4a6b9eb46851807018/langsmith-0.7.38.tar.gz", hash = "sha256:0db529b768d66c45f22fe959a0af7151342704fefafdecf3c60b14097c14fdb1", size = 4431914, upload-time = "2026-04-29T00:21:42.865Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/e9/4ceeba766bae47de1a6ecdaa4024d10eff63eed936796b77005742399e8d/langsmith-0.8.4.tar.gz", hash = "sha256:989b387f6ff92ec5f9d14c0edb333e2579590cad5a1ca07042d924b0ec43cd10", size = 4460243, upload-time = "2026-05-13T21:00:59.338Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/bc/a19d0a6d5575c637796675831dbef3555568e84d913f14ec579f92162ffa/langsmith-0.7.38-py3-none-any.whl", hash = "sha256:9c400ad508c0e4edc37bd55987047c6b8aac36ddd55f6096e3806f4d6a100618", size = 392310, upload-time = "2026-04-29T00:21:40.534Z" },
+    { url = "https://files.pythonhosted.org/packages/db/94/8b872959ea529ecfbbe2c3f91d9ebf98cb8dbd9e3f7487bc134740d3d235/langsmith-0.8.4-py3-none-any.whl", hash = "sha256:4e334ab223d10129c9943c461d95fa9089523638ea29cd048045a7f99b973f50", size = 398701, upload-time = "2026-05-13T21:00:57.393Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Remediates **CVE-2026-45134** (HIGH, CVSS 7.1) in the `aiq-agent` container, flagged by Trivy on `nvcr.io/nvstaging/blueprint/aiq-agent:2.1.0-rc4.20260513`.

## Vulnerability
- **CVE:** [CVE-2026-45134](https://github.com/langchain-ai/langsmith-sdk/security/advisories) — *LangSmith SDK: Public prompt pull deserializes untrusted manifests without trust boundary warning*
- **Severity:** HIGH (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:L/A:N — 7.1)
- **Affected packages (transitive):**
  - `langsmith` 0.7.38 → fixed in 0.8.0
  - `langchain-classic` 1.0.1 → fixed in 1.0.7

## Changes
- `uv.lock`: `langsmith` 0.7.38 → 0.8.4, `langchain-classic` 1.0.1 → 1.0.7, `langchain-text-splitters` 1.1.0 → 1.1.2 (transitive of `langchain-classic`).
- `pyproject.toml` — added floors to `[tool.uv].override-dependencies` so future `uv lock` regens stay past the patched line:
  - `langsmith>=0.8.0,<1`
  - `langchain-classic>=1.0.7,<2`

Both packages are transitive deps only (no direct pins anywhere in the workspace).

## Validation
- [x] `uv lock --check` — resolves cleanly (344 packages).
- [x] `docker build --target release -t aiq-agent:cve-fix -f deploy/Dockerfile .` — succeeds.
- [x] `trivy image --severity CRITICAL,HIGH aiq-agent:cve-fix` — **CVE-2026-45134 no longer present**.
- [x] Pre-commit hooks (including `uv-lock`) pass.

### Before / after (CRITICAL + HIGH)
| | Before (rc4) | After |
|---|---|---|
| Total | 5 HIGH | 3 HIGH |
| CVE-2026-45134 (langsmith) | present | **cleared** |
| CVE-2026-45134 (langchain-classic) | present | **cleared** |
| CVE-2026-25210 (libexpat1) | present | present — *no upstream Debian fix yet* |
| CVE-2025-69720 (libncursesw6) | present | present — *no upstream Debian fix yet* |
| CVE-2025-69720 (libtinfo6) | present | present — *no upstream Debian fix yet* |

The 3 remaining HIGH CVEs are in the `nvcr.io/nvidia/distroless/python:3.13-v4.0.5` base image and require an upstream distroless rebuild — not addressable in this repo.

## References
- LangSmith advisory: https://github.com/langchain-ai/langsmith-sdk
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-45134

🤖 Generated with [Claude Code](https://claude.com/claude-code)