### PR TITLE
Align AIQ skills with global requirements

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -1,0 +1,22 @@
+name: Request NVSkills CI
+
+on:
+  issue_comment:
+    types: [created]
+  push:
+
+jobs:
+  request:
+    if: >
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/nvskills-ci')) ||
+      (github.event_name == 'push' &&
+        github.actor == (vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-nvskill-ci[bot]') &&
+        startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures'))
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: NVIDIA/nvskills-ci/.github/workflows/team-request.yml@main
+    secrets:
+      NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}

--- a/skills/aiq-deploy/LICENSE
+++ b/skills/aiq-deploy/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 NVIDIA Corporation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/aiq-deploy/README.md
+++ b/skills/aiq-deploy/README.md
@@ -1,0 +1,86 @@
+# AIQ Deploy Skill
+
+## Overview
+
+`aiq-deploy` helps agents install, configure, start, validate, troubleshoot, and stop a local or self-hosted NVIDIA
+AI-Q Blueprint deployment. It prepares an AI-Q backend that can be handed to `aiq-research`.
+
+## Prerequisites
+
+Users need:
+
+- Git access to `https://github.com/NVIDIA-AI-Blueprints/aiq`.
+- Docker Engine with Docker Compose v2 for the default local deployment.
+- Python 3.11+ and `uv` for local process or CLI mode.
+- Node.js 20+ and `npm` for browser UI development mode.
+- `kubectl` 1.28+, Helm 3.12+, and Kubernetes cluster access for Helm mode.
+- `NVIDIA_API_KEY` for hosted-model usage.
+- At least one supported search provider key, such as `TAVILY_API_KEY`, `SERPER_API_KEY`, or `EXA_API_KEY`, for web
+  research workflows.
+- Network access to GitHub, NVIDIA-hosted model endpoints, and selected search providers.
+
+## Quick Start
+
+Copy or verify the local environment file:
+
+```bash
+test -f deploy/.env || cp deploy/.env.example deploy/.env
+git check-ignore deploy/.env
+```
+
+Start a backend-only Docker Compose deployment for `aiq-research`:
+
+```bash
+cd deploy/compose
+BUILD_TARGET=release docker compose --env-file ../.env -f docker-compose.yaml config --quiet
+BUILD_TARGET=release docker compose --env-file ../.env -f docker-compose.yaml up -d --build aiq-agent
+curl -sf http://localhost:8000/health
+```
+
+Expected result: Docker Compose starts `aiq-agent` and its dependencies, and the health endpoint returns successfully.
+
+## Structure
+
+```text
+aiq-deploy/
+|-- SKILL.md
+|-- LICENSE
+|-- README.md
+|-- evals/
+|   `-- evals.json
+`-- references/
+    |-- cli.md
+    |-- configs.md
+    |-- docker-compose.md
+    |-- end-to-end-validation.md
+    |-- env-and-secrets.md
+    |-- frag.md
+    |-- kubernetes-helm.md
+    |-- local-web.md
+    |-- locate-or-clone.md
+    |-- shutdown.md
+    |-- skill-backend.md
+    |-- troubleshooting.md
+    `-- validation.md
+```
+
+`SKILL.md` contains the agent-facing workflow. `references/` contains detailed paths for specific deployment modes and
+troubleshooting.
+
+## Version Compatibility
+
+This skill is designed for NVIDIA AI-Q Blueprint version 2.1.0. It follows semantic version compatibility:
+
+- Major versions must match.
+- Blueprint minor version must be equal to or newer than the skill minor version.
+- Patch version differences do not affect compatibility.
+
+## License
+
+Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+
+Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for full license text.
+
+## Copyright
+
+Copyright (c) 2026 NVIDIA Corporation. All rights reserved.

--- a/skills/aiq-deploy/SKILL.md
+++ b/skills/aiq-deploy/SKILL.md
@@ -1,36 +1,129 @@
 ---
 name: aiq-deploy
-description: Use when asked to install AIQ, deploy AIQ, install deep research, clone AIQ, start or stop AI-Q infrastructure, run the UI/backend, deploy with Docker Compose or Helm, choose an AI-Q workflow config, check health, inspect logs, rebuild, or prepare a local or self-hosted AI-Q server for aiq-research.
+description: |
+  Deploy and operate NVIDIA AI-Q Blueprint for local or self-hosted use. Use when asked to install AIQ,
+  deploy AIQ, install deep research, clone AIQ, start or stop AI-Q infrastructure, run the UI/backend,
+  deploy with Docker Compose or Helm, choose an AI-Q workflow config, check health, inspect logs, rebuild,
+  or prepare a local or self-hosted AI-Q server for aiq-research.
 license: Apache-2.0
-compatibility: Claude Code, OpenCode, Codex, and Agent Skills-compatible tools. Requires access to the AI-Q repository and the runtime selected by the user.
+compatibility: |
+  Designed for Claude Code, OpenCode, Codex, and Agent Skills-compatible tools. Requires Git, network
+  access to GitHub, and one selected runtime path: Docker Compose v2 for the default local deployment,
+  Python 3.11+ and uv for local process or CLI mode, Node.js 20+ and npm for local web UI mode, or
+  kubectl 1.28+ and Helm 3.12+ for Kubernetes and Helm mode.
 metadata:
   version: "2.1.0"
+  author: "NVIDIA AI-Q Blueprint Team"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/aiq"
-  tags: "nvidia aiq blueprint deploy operations agent-skills"
+  tags:
+    - nvidia
+    - aiq
+    - blueprint
+    - deploy
+    - operations
+    - agent-skills
 allowed-tools: Read Bash
 ---
 
 # AIQ Deploy Skill
 
-Use this skill to get a local or self-hosted NVIDIA AI-Q Blueprint server running and verified for use by `aiq-research`.
+## Purpose
 
-This skill owns setup, deployment, operational checks, troubleshooting, and shutdown. It does not run deep research itself. After deployment is healthy, hand off the verified server URL to `aiq-research`.
+Use this skill to get a local or self-hosted NVIDIA AI-Q Blueprint server running and verified for use by
+`aiq-research`.
 
-## Operating Boundary
+This skill owns setup, deployment, operational checks, troubleshooting, and shutdown. It does not run deep
+research itself. After deployment is healthy, hand off the verified server URL to `aiq-research`.
 
-- Target external/open-source users of `NVIDIA-AI-Blueprints/aiq`.
-- Do not assume access to hosted AIQ endpoints.
-- Use `http://localhost:8000` unless the user chooses another local or self-hosted URL.
+## Prerequisites
 
-## Safety Rules
+Users need:
 
-- Never print secret values. Check only whether required environment variables are set.
-- Do not overwrite `deploy/.env` when it already exists.
-- Ask before destructive cleanup such as deleting Docker volumes with `down -v`.
-- Do not claim FRAG is ready unless both `RAG_SERVER_URL` and `RAG_INGEST_URL` are configured and reachable.
-- Run verification commands yourself when possible.
+- Access to clone or update `https://github.com/NVIDIA-AI-Blueprints/aiq`.
+- Git available in the shell.
+- One deployment runtime:
+  - Docker Engine with Docker Compose v2 for the default durable local deployment.
+  - Python 3.11+ and `uv` for local process or CLI mode.
+  - Node.js 20+ and `npm` for local browser UI development mode.
+  - `kubectl` 1.28+, Helm 3.12+, and access to a Kubernetes cluster for Helm mode.
+- Network access to GitHub, NVIDIA-hosted model endpoints, and any selected search provider.
+- Credentials stored outside chat. Hosted-model usage requires `NVIDIA_API_KEY`; web research requires at least
+  one supported search provider key such as `TAVILY_API_KEY`, `SERPER_API_KEY`, or `EXA_API_KEY`.
+- System capacity for the selected runtime. Docker Compose mode starts the AI-Q backend and PostgreSQL by default;
+  browser UI mode also uses frontend port `3000`. Self-hosted model or RAG deployments may require GPU resources.
 
-## Intent Routing
+Before writing secrets, verify `deploy/.env` is ignored:
+
+```bash
+git check-ignore deploy/.env
+```
+
+Expected output: `deploy/.env` or a matching ignore rule. If it is not ignored, stop and fix the ignore rule before
+placing credentials in the file.
+
+## Instructions
+
+1. Locate or clone the AI-Q repository.
+2. Confirm the expected repository files exist.
+3. Select the deployment mode.
+4. Prepare `deploy/.env` without overwriting user secrets.
+5. Check runtime prerequisites for the selected path.
+6. Start the selected deployment.
+7. Run basic validation.
+8. Report the verified `AIQ_SERVER_URL` for `aiq-research`.
+9. Ask whether to run optional deep research completion validation.
+
+### Step 1 - Locate or clone AI-Q
+
+If no AI-Q checkout exists, read `references/locate-or-clone.md` before cloning. In an existing checkout, confirm the
+required files:
+
+```bash
+pwd
+test -f pyproject.toml
+test -f deploy/.env.example
+test -d configs
+```
+
+Expected output: `pwd` prints the AI-Q repository path; the `test` commands exit with status 0 and no output.
+
+### Step 2 - Select the deployment mode
+
+If the user asks to install, deploy, set up, or run AI-Q without naming a mode, ask:
+
+```text
+How do you want to run AI-Q?
+
+1. Skill backend - backend-only service for aiq-research w/o browser UI.
+2. CLI - interactive terminal AI-Q.
+3. UI - browser AI-Q app with backend and frontend.
+4. Custom - choose an existing AI-Q config or review advanced customization docs before deployment.
+```
+
+Wait for the user's answer before starting services.
+
+Do not ask this question when the user already specified a mode, such as Docker Compose, Helm, UI, CLI, or Agent Skill
+backend. Do not ask the full mode question when `aiq-research` routed here because a deep research request needs a
+backend. In that case, prefer Agent Skill backend and ask only for permission to start it if needed.
+
+### Step 3 - Prepare environment and secrets
+
+Read `references/env-and-secrets.md` before changing `deploy/.env`.
+
+```bash
+if [ ! -f deploy/.env ]; then
+  cp deploy/.env.example deploy/.env
+  echo "created deploy/.env from deploy/.env.example"
+fi
+```
+
+Expected output when the file is missing: `created deploy/.env from deploy/.env.example`. Expected output when the file
+already exists: no output, and the existing file is preserved.
+
+Never print secret values. If credentials are missing, ask the user to update `deploy/.env`; do not ask them to paste
+secret values into chat.
+
+### Step 4 - Route to the selected deployment path
 
 Match the user request, then read the referenced file before acting:
 
@@ -50,52 +143,20 @@ Match the user request, then read the referenced file before acting:
 | Logs, unhealthy services, port conflicts, config failures | `references/troubleshooting.md` |
 | Stop services, restart, rebuild, safe cleanup | `references/shutdown.md` |
 
-## Deployment Mode Selection
+### Step 5 - Validate and hand off
 
-If the user asks to install, deploy, set up, or run AI-Q without naming a mode, ask:
+After startup, read `references/validation.md` and run the appropriate checks for the selected mode. For the default
+local backend, verify health:
 
-```text
-How do you want to run AI-Q?
-
-1. Skill backend - backend-only service for aiq-research w/o browser UI.
-2. CLI - interactive terminal AI-Q.
-3. UI - browser AI-Q app with backend and frontend.
-4. Custom - choose an existing AI-Q config or review advanced customization docs before deployment.
+```bash
+curl -sf http://localhost:8000/health
 ```
 
-Wait for the user's answer before starting services.
+Expected output: a successful JSON health response or an empty successful response depending on the server build. If the
+command fails, read `references/troubleshooting.md` and diagnose before claiming the backend is ready.
 
-Do not ask this question when the user already specified a mode, such as Docker Compose, Helm, UI, CLI, or Agent Skill backend.
-
-Do not ask the full mode question when `aiq-research` routed here because a deep research request needs a backend. In that case, prefer Agent Skill backend and ask only for permission to start it if needed.
-
-Map the user's choice as follows:
-
-| Choice | Route | Default Config |
-|---|---|---|
-| Skill backend | `references/docker-compose.md` backend-only by default; `references/skill-backend.md` only for local process or no-container runs | `configs/config_web_default_llamaindex.yml` |
-| CLI | `references/cli.md` | `configs/config_cli_default.yml` |
-| UI | Full Docker Compose by default for durable local deployment; `references/local-web.md` only for quick development runs | `configs/config_web_default_llamaindex.yml` |
-| Custom | `references/configs.md`, then return to the selected deployment route | Existing config path |
-
-For external users, Docker Compose is the default durable local deployment after the user chooses Skill backend or UI. Use local process paths only when the user asks for a quick development run, asks to avoid containers, or Docker Compose is unavailable and the user accepts that fallback. If the user asks which config to use, read `configs.md` and select an existing config before deployment. If they explicitly ask for a terminal-only assistant, use `cli.md`. If they explicitly ask for Kubernetes or Helm, use `kubernetes-helm.md`.
-
-## Required Workflow
-
-1. Locate or clone the AI-Q repository.
-2. Confirm the expected repository files exist.
-3. Create `deploy/.env` from `deploy/.env.example` only when missing.
-4. If the deployment mode is ambiguous, ask the Deployment Mode Selection question.
-5. If using a non-default config, confirm the config path with `references/configs.md`.
-6. Check runtime prerequisites and required environment variables for the selected deployment path. Never print secret values.
-7. Start the selected deployment path.
-8. Run basic validation from `references/validation.md`.
-9. Tell the user the verified `AIQ_SERVER_URL` for `aiq-research`.
-10. Ask whether they want to run optional deep research completion validation now, or skip and try the deployment themselves.
-
-## Handoff Contract
-
-`aiq-research` needs a reachable AI-Q server URL. If the backend is on the default port, no extra configuration is needed:
+`aiq-research` needs a reachable AI-Q server URL. If the backend is on the default port, no extra configuration is
+needed:
 
 ```bash
 AIQ_SERVER_URL=http://localhost:8000
@@ -107,4 +168,179 @@ If the backend runs elsewhere, tell the user to set:
 export AIQ_SERVER_URL="http://localhost:<PORT>"
 ```
 
-Do not continue into deep research or deep research completion validation unless the user asks for it or confirms the post-deploy validation prompt. This skill's success criterion is a deployed and basically validated server, not report generation quality.
+Do not continue into deep research or deep research completion validation unless the user asks for it or confirms the
+post-deploy validation prompt. This skill's success criterion is a deployed and basically validated server, not report
+generation quality.
+
+## Version Compatibility
+
+**IMPORTANT:** This skill is designed for NVIDIA AI-Q Blueprint version 2.1.0.
+
+Semantic Versioning Compatibility Rules:
+
+```text
+Skill version: X.Y.Z
+Blueprint version: A.B.C
+
+Compatible IF:
+1. A == X (Major versions MUST match)
+2. B >= Y (Minor version must be equal or greater)
+3. C can be anything (Patch version does not affect compatibility)
+```
+
+Examples:
+
+- Skill version 2.1.0 is compatible with Blueprint version 2.1.0.
+- Skill version 2.1.0 is compatible with Blueprint version 2.2.0.
+- Skill version 2.1.0 is compatible with Blueprint version 2.1.5.
+- Skill version 2.1.0 is not compatible with Blueprint version 3.0.0.
+- Skill version 2.1.0 is not compatible with Blueprint version 2.0.0.
+
+If your Blueprint version is not compatible:
+
+1. Check for an updated skill version matching your Blueprint version.
+2. Use a Blueprint version compatible with this skill.
+3. Proceed with caution only when the user accepts the compatibility risk; deployment commands or config names may have
+   changed.
+
+## Security Best Practices
+
+- Never print secret values. Check only whether required environment variables are set.
+- Store credentials in `deploy/.env` or environment variables, not in chat transcripts, shell history, committed files,
+  or example commands.
+- Do not overwrite `deploy/.env` when it already exists.
+- Ask before destructive cleanup such as deleting Docker volumes with `down -v`.
+- Do not claim FRAG is ready unless both `RAG_SERVER_URL` and `RAG_INGEST_URL` are configured and reachable.
+- Run verification commands yourself when possible.
+
+## Working Examples
+
+### Example 1: Deploy a backend-only Skill server with Docker Compose
+
+```bash
+test -f deploy/.env || cp deploy/.env.example deploy/.env
+git check-ignore deploy/.env
+cd deploy/compose
+BUILD_TARGET=release docker compose --env-file ../.env -f docker-compose.yaml config --quiet
+BUILD_TARGET=release docker compose --env-file ../.env -f docker-compose.yaml up -d --build aiq-agent
+curl -sf http://localhost:8000/health
+```
+
+Expected output:
+
+```text
+deploy/.env
+<docker compose starts aiq-agent and dependencies>
+<health endpoint returns a successful response>
+```
+
+If Docker, ports, credentials, or health checks fail, read `references/troubleshooting.md` before retrying.
+
+### Example 2: Hand off a non-default backend URL to aiq-research
+
+```bash
+export AIQ_SERVER_URL="http://localhost:8100"
+curl -sf "$AIQ_SERVER_URL/health"
+```
+
+Expected output: a successful health response. Then tell the user to keep `AIQ_SERVER_URL` set before invoking
+`aiq-research`.
+
+## References
+
+| Topic | Documentation |
+|---|---|
+| Locate or clone AI-Q | `references/locate-or-clone.md` |
+| Environment and secrets | `references/env-and-secrets.md` |
+| Workflow configs | `references/configs.md` |
+| Agent Skill backend | `references/skill-backend.md` |
+| CLI deployment | `references/cli.md` |
+| Local web deployment | `references/local-web.md` |
+| Docker Compose deployment | `references/docker-compose.md` |
+| Kubernetes and Helm deployment | `references/kubernetes-helm.md` |
+| FRAG integration | `references/frag.md` |
+| Basic validation | `references/validation.md` |
+| End-to-end validation | `references/end-to-end-validation.md` |
+| Troubleshooting | `references/troubleshooting.md` |
+| Shutdown and cleanup | `references/shutdown.md` |
+
+## Common Issues
+
+### Issue: Backend port is already in use
+
+**Symptoms:**
+
+- Docker Compose fails to bind port `8000`.
+- `curl -sf http://localhost:8000/health` reaches an unexpected service or fails.
+
+**Causes:**
+
+- Another AI-Q backend or local development server is already running.
+- `PORT` in `deploy/.env` conflicts with an existing process.
+
+**Solutions:**
+
+1. Identify the process:
+   ```bash
+   lsof -nP -iTCP:8000 -sTCP:LISTEN
+   ```
+2. Either stop the conflicting process with the user's approval or set a different port in `deploy/.env`, such as
+   `PORT=8100`.
+3. Restart the selected deployment path and verify:
+   ```bash
+   curl -sf http://localhost:8100/health
+   ```
+
+### Issue: Required credentials are missing
+
+**Symptoms:**
+
+- Infrastructure starts, but model-backed chat or research requests fail.
+- Logs mention unauthorized, forbidden, invalid key, or missing provider configuration.
+
+**Causes:**
+
+- `NVIDIA_API_KEY` is missing or empty.
+- No supported search provider key is configured for web research.
+
+**Solutions:**
+
+1. Check presence without printing values by following `references/env-and-secrets.md`.
+2. Ask the user to update `deploy/.env`; do not ask them to paste secrets into chat.
+3. Rerun `references/validation.md` after the user updates credentials.
+
+### Issue: Backend is healthy but not compatible with aiq-research
+
+**Symptoms:**
+
+- `/health` succeeds, but `/chat` or `/v1/jobs/async/agents` fails.
+- `aiq-research` reports that async agents are unavailable.
+
+**Causes:**
+
+- The selected config is CLI-only or does not expose the web/API backend expected by the skill.
+- `BACKEND_CONFIG` or `CONFIG_FILE` points at the wrong AI-Q config.
+
+**Solutions:**
+
+1. Read `references/configs.md` and confirm the selected config is API-enabled.
+2. For the default Skill backend, use `configs/config_web_default_llamaindex.yml`.
+3. Restart the backend and rerun `references/validation.md`.
+
+### Issue: Docker cleanup would remove useful state
+
+**Symptoms:**
+
+- Troubleshooting suggests `docker compose down -v`.
+- The user may have local PostgreSQL job or checkpoint data they want to keep.
+
+**Causes:**
+
+- `down -v` removes Docker volumes.
+- Rebuilds and restarts are often enough for config or image changes.
+
+**Solutions:**
+
+1. Prefer a normal restart from `references/shutdown.md`.
+2. Ask for explicit approval before running volume deletion.
+3. After cleanup, rerun deployment and validation from the selected route.

--- a/skills/aiq-research/README.md
+++ b/skills/aiq-research/README.md
@@ -1,110 +1,71 @@
 # AIQ Research Skill
 
-Portable Agent Skill for interacting with a locally running NVIDIA AI-Q Blueprint server.
+## Overview
 
-## What This Skill Provides
-
-- Routed `/chat` requests against a local AI-Q server.
-- Async deep research job submission and polling.
-- Job status, event-store state, report retrieval, SSE streaming, and cancellation helpers.
-- A self-contained Python helper script at `scripts/aiq.py`.
-
-## Canonical Location
-
-This repository keeps the distributable skill at:
-
-```text
-.agents/skills/aiq-research/
-```
-
-The Claude Code repo-local path is a compatibility symlink:
-
-```text
-.claude/skills/aiq-research -> ../../.agents/skills/aiq-research
-```
+`aiq-research` sends research-shaped user requests to a running NVIDIA AI-Q Blueprint backend. It checks backend health,
+uses routed `/chat`, polls asynchronous deep research jobs, and returns final reports with citations intact.
 
 ## Prerequisites
 
-- Python 3.10 or newer.
-- A local AI-Q Blueprint server, usually at `http://localhost:8000`.
-- Set `AIQ_SERVER_URL` only when using a different local server URL.
+Users need:
 
-## Installing The Skill
+- Python 3.11+ available as `python3`.
+- A reachable local or self-hosted AI-Q Blueprint backend.
+- `AIQ_SERVER_URL` set when the backend is not running at `http://localhost:8000`.
+- A backend configured for this public local helper. Authenticated environments should use an authenticated AI-Q skill
+  or configure authentication outside this helper.
+- Network access from the local machine to the AI-Q backend URL.
 
-This repository stores portable agent skills under:
+The helper script uses only Python standard-library modules.
 
-```text
-.agents/skills/
-```
+## Canonical Location
 
-The AIQ research skill is available at:
-
-```text
-.agents/skills/aiq-research/
-```
-
-Install by copying or symlinking the full `aiq-research` directory into the skill location used by your coding harness. The installed directory must contain `SKILL.md` at its root.
-
-### Claude Code
-
-Claude Code supports repo-local skills under `.claude/skills/`.
-
-For this repository, Claude Code compatibility is provided by a symlink:
+This repository keeps the catalog-bound skill at:
 
 ```text
-.claude/skills/aiq-research -> ../../.agents/skills/aiq-research
+skills/aiq-research/
 ```
 
-To recreate it manually:
+Install by copying or symlinking the full `aiq-research` directory into the skill location used by your coding harness.
+The installed directory must contain `SKILL.md` at its root.
+
+## Quick Start
+
+Check the backend:
 
 ```bash
-mkdir -p .claude/skills
-ln -s ../../.agents/skills/aiq-research .claude/skills/aiq-research
+python3 scripts/aiq.py health
 ```
 
-User-level install:
+Send a routed research request:
 
 ```bash
-mkdir -p ~/.claude/skills
-cp -R .agents/skills/aiq-research ~/.claude/skills/aiq-research
+python3 scripts/aiq.py chat "Compare local AIQ deep research with a standard web search workflow"
 ```
 
-### OpenCode
+Resume polling when AI-Q returns a deep research job ID:
 
-OpenCode loads user skills from:
+```bash
+python3 scripts/aiq.py research_poll <JOB_ID>
+```
+
+Expected result: `health` returns JSON, `chat` returns either a direct JSON response or a job ID, and `research_poll`
+returns the final report JSON when the job completes.
+
+## Structure
 
 ```text
-~/.config/opencode/skills/
+aiq-research/
+|-- SKILL.md
+|-- LICENSE
+|-- README.md
+|-- evals/
+|   `-- evals.json
+`-- scripts/
+    `-- aiq.py
 ```
 
-Install with:
-
-```bash
-mkdir -p ~/.config/opencode/skills
-cp -R .agents/skills/aiq-research ~/.config/opencode/skills/aiq-research
-```
-
-Restart OpenCode or start a new session after installation.
-
-### Codex
-
-For Codex or other Agent Skills-compatible tools, install the skill into the runtime's configured skills directory.
-
-Generic install shape:
-
-```text
-<codex-skills-dir>/aiq-research/SKILL.md
-<codex-skills-dir>/aiq-research/scripts/aiq.py
-```
-
-Example:
-
-```bash
-mkdir -p <codex-skills-dir>
-cp -R .agents/skills/aiq-research <codex-skills-dir>/aiq-research
-```
-
-Replace `<codex-skills-dir>` with the skills directory configured for your Codex environment.
+`SKILL.md` contains the agent-facing workflow. `scripts/aiq.py` is the standard-library Python client used by the skill.
 
 ## Quick Verification
 
@@ -120,6 +81,20 @@ Expected output starts with:
 Usage: aiq.py <command> [args]
 ```
 
+## Version Compatibility
+
+This skill is designed for NVIDIA AI-Q Blueprint version 2.1.0. It follows semantic version compatibility:
+
+- Major versions must match.
+- Blueprint minor version must be equal to or newer than the skill minor version.
+- Patch version differences do not affect compatibility.
+
 ## License
 
-Apache-2.0. See `LICENSE`.
+Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+
+Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for full license text.
+
+## Copyright
+
+Copyright (c) 2026 NVIDIA Corporation. All rights reserved.

--- a/skills/aiq-research/SKILL.md
+++ b/skills/aiq-research/SKILL.md
@@ -1,22 +1,38 @@
 ---
 name: aiq-research
-description: Use when the user asks for deep research, AIQ research, research with AI-Q, or to use AI-Q on a question, unless they are asking to install, deploy, start, stop, or troubleshoot AI-Q infrastructure.
+description: |
+  Run research requests through a locally running NVIDIA AI-Q Blueprint server. Use when the user asks for deep
+  research, AIQ research, research with AI-Q, or to use AI-Q on a question, unless they are asking to install,
+  deploy, start, stop, or troubleshoot AI-Q infrastructure.
 license: Apache-2.0
-compatibility: Claude Code, OpenCode, Codex, and Agent Skills-compatible tools. Requires Python 3.10+ and access to a running local AI-Q Blueprint server.
+compatibility: |
+  Designed for Claude Code, OpenCode, Codex, and Agent Skills-compatible tools. Requires Python 3.11+, network
+  access to a running local or self-hosted AI-Q Blueprint server, and an AI-Q backend that exposes `/health`,
+  `/chat`, and asynchronous job endpoints.
 metadata:
   version: "2.1.0"
+  author: "NVIDIA AI-Q Blueprint Team"
   github-url: "https://github.com/NVIDIA-AI-Blueprints/aiq"
-  tags: "nvidia aiq blueprint deep-research agent-skills"
-  languages: "python bash"
+  tags:
+    - nvidia
+    - aiq
+    - blueprint
+    - deep-research
+    - research-agents
+    - agent-skills
+  languages:
+    - python
+    - bash
   domain: "research-agents"
 allowed-tools: Read Bash
 ---
 
 # AIQ Research Skill
 
-Use this skill to call a locally running AIQ Blueprint server through the helper script at `scripts/aiq.py`.
+## Purpose
 
-## Intent Boundary
+Use this skill to call a locally running NVIDIA AI-Q Blueprint server through the helper script at
+`scripts/aiq.py`.
 
 Use this skill for research-shaped requests, including:
 
@@ -26,24 +42,45 @@ Use this skill for research-shaped requests, including:
 - "use AI-Q to answer ..."
 - "ask AI-Q about ..."
 
-Do not use this skill for install, deploy, start, stop, UI, CLI, Docker, Helm, or troubleshooting requests. Those belong to `aiq-deploy`.
+Do not use this skill for install, deploy, start, stop, UI, CLI, Docker, Helm, or troubleshooting requests. Those
+belong to `aiq-deploy`.
 
-## Assumptions
+## Prerequisites
 
-- The AIQ server is running locally at `http://localhost:8000`.
-- Override the base URL only for another local deployment by setting `AIQ_SERVER_URL`.
-- For research-shaped requests, first check whether a research-compatible AI-Q Skill backend is reachable with `health`.
-- If the server is not reachable and `aiq-deploy` is installed, hand off to `aiq-deploy` to start and validate the Skill backend, then resume the original research request.
+Users need:
 
-## Backend Resolution
+- Python 3.11+ available as `python3`.
+- A reachable local or self-hosted AI-Q Blueprint backend.
+- `AIQ_SERVER_URL` set when the backend is not running at `http://localhost:8000`.
+- A backend configured with authentication disabled for this public helper, or a separate authenticated AI-Q skill for
+  authenticated environments.
+- Network access from the local machine to the AI-Q backend URL.
+- Credentials configured in the backend environment, not in this skill. This public helper does not collect or manage
+  API keys.
 
-Resolve the backend before running research:
+The helper script has no third-party Python package dependencies; it uses Python standard-library HTTP modules.
 
-1. If `AIQ_SERVER_URL` is set, use it.
-2. Otherwise try the default local backend: `http://localhost:8000`.
-3. Run `health`.
-4. If `health` succeeds, continue with `/chat` and async research checks.
-5. If `health` fails and no explicit `AIQ_SERVER_URL` was set, ask:
+## Instructions
+
+1. Resolve the target backend URL.
+2. Run `health` before sending research requests.
+3. If no backend is reachable, ask for a backend URL or hand off to `aiq-deploy`.
+4. Send the user's exact query through routed `/chat`.
+5. Poll asynchronous deep research jobs when AI-Q returns a job ID.
+6. Present returned reports with citations and source URLs intact.
+7. Stop on failed jobs and show the returned error; do not retry automatically.
+
+### Step 1 - Resolve the backend
+
+Use `AIQ_SERVER_URL` when set. Otherwise try the default local backend:
+
+```bash
+python3 $SKILL_DIR/scripts/aiq.py health
+```
+
+Expected output: JSON from a reachable AI-Q health endpoint.
+
+If `health` fails and no explicit `AIQ_SERVER_URL` was set, ask:
 
 ```text
 I do not see a reachable local AI-Q backend. Do you already have an AI-Q backend URL you want to use, or should I deploy a local Skill backend?
@@ -51,15 +88,90 @@ I do not see a reachable local AI-Q backend. Do you already have an AI-Q backend
 
 - If the user provides a URL, set `AIQ_SERVER_URL` for subsequent helper calls and rerun `health`.
 - If the user wants local deployment, hand off to `aiq-deploy` and preserve the original research request.
-- If a reachable backend returns `401` or `403`, stop and explain that this public skill does not manage authentication. Ask the user to use an authenticated AI-Q skill or configure authentication for their environment.
-- If `health` succeeds but `/chat` or `/v1/jobs/async/agents` fails, report that the backend is reachable but not compatible with this public research flow, then offer to run `aiq-deploy` validation.
+- If a reachable backend returns `401` or `403`, stop and explain that this public skill does not manage
+  authentication. Ask the user to use an authenticated AI-Q skill or configure authentication for their environment.
+- If `health` succeeds but `/chat` or `/v1/jobs/async/agents` fails, report that the backend is reachable but not
+  compatible with this public research flow, then offer to run `aiq-deploy` validation.
 
-## Use Cases
+### Step 2 - Send the routed research request
 
-- Submit a routed `/chat` request to the local AIQ server.
-- Poll an async deep research job to completion.
-- Fetch job status, final reports, or event-store artifacts.
-- Cancel a local async job.
+Run:
+
+```bash
+python3 $SKILL_DIR/scripts/aiq.py chat "<USER_QUESTION>"
+```
+
+Expected output:
+
+- A normal JSON response for shallow or direct answers.
+- Or structured JSON containing `{"status": "deep_research_running", "job_id": "<JOB_ID>"}` for asynchronous deep
+  research.
+
+If the response is normal JSON, present the result immediately. Do not force polling when there is no `job_id`.
+
+### Step 3 - Poll asynchronous jobs
+
+If the response includes `deep_research_running`, extract the `job_id` and poll with the same absolute script path:
+
+```bash
+python3 $SKILL_DIR/scripts/aiq.py research_poll <JOB_ID>
+```
+
+Expected output: the final report JSON when the job completes successfully.
+
+Use the runtime's non-blocking or background execution mechanism when available. If the chosen execution method requires
+escalated permissions, request explicit user approval first and explain why. Tell the user that deep research is running
+in the background.
+
+### Step 4 - Resume after interruptions
+
+If polling is interrupted, the job continues server-side. Resume with:
+
+```bash
+python3 $SKILL_DIR/scripts/aiq.py status <JOB_ID>
+python3 $SKILL_DIR/scripts/aiq.py report <JOB_ID>
+python3 $SKILL_DIR/scripts/aiq.py research_poll <JOB_ID>
+```
+
+Use `status` to inspect job status and saved artifacts. Use `report` when the job has already finished and you only need
+the final output. Use `research_poll` to keep waiting for completion.
+
+### Step 5 - Present the report
+
+When `research_poll` completes successfully, fetch and present the full report. Keep citations and source URLs intact.
+If the job status is `failed`, `failure`, or `cancelled`, show the error from the status response and ask whether the
+user wants to retry with a narrower query or different approach.
+
+## Version Compatibility
+
+**IMPORTANT:** This skill is designed for NVIDIA AI-Q Blueprint version 2.1.0.
+
+Semantic Versioning Compatibility Rules:
+
+```text
+Skill version: X.Y.Z
+Blueprint or endpoint version: A.B.C
+
+Compatible IF:
+1. A == X (Major versions MUST match)
+2. B >= Y (Minor version must be equal or greater)
+3. C can be anything (Patch version does not affect compatibility)
+```
+
+Examples:
+
+- Skill version 2.1.0 is compatible with Blueprint version 2.1.0.
+- Skill version 2.1.0 is compatible with Blueprint version 2.2.0.
+- Skill version 2.1.0 is compatible with Blueprint version 2.1.5.
+- Skill version 2.1.0 is not compatible with Blueprint version 3.0.0.
+- Skill version 2.1.0 is not compatible with Blueprint version 2.0.0.
+
+If your Blueprint version is not compatible:
+
+1. Check for an updated skill version matching your Blueprint version.
+2. Use a Blueprint version compatible with this skill.
+3. Proceed with caution only when the user accepts the compatibility risk; API routes or response shapes may have
+   changed.
 
 ## Available Script Commands
 
@@ -77,118 +189,144 @@ I do not see a reachable local AI-Q backend. Do you already have an AI-Q backend
 | `python3 scripts/aiq.py stream <job_id>` | Stream SSE events from a job |
 | `python3 scripts/aiq.py cancel <job_id>` | Cancel a running job |
 
-## Usage
-
-### Research flow
-
-Run:
-
-```bash
-python3 $SKILL_DIR/scripts/aiq.py chat "USER QUESTION"
-```
-
-- The `/chat` endpoint routes the request to the right AIQ path.
-- For shallow queries it returns a normal JSON response inline.
-- For deep research it returns structured JSON containing `{"status": "deep_research_running", "job_id": "..."}`.
-
-If the response is normal JSON:
-- Present the result immediately.
-- Do not force polling when there is no `job_id`.
-
-If the response includes `deep_research_running`:
-- Extract the `job_id`.
-- Launch polling with the same absolute script path:
-
-```bash
-python3 $SKILL_DIR/scripts/aiq.py research_poll <job_id>
-```
-
-- Use the runtime's non-blocking/background execution mechanism when available.
-- If the chosen execution method requires escalated permissions, request explicit user approval first and explain why.
-- Tell the user that deep research is running in the background.
-
-## Workflow
-
-1. Resolve the backend using the Backend Resolution flow.
-2. Run `health` first to check whether the local AIQ Skill backend is running.
-3. If `health` fails after backend resolution, preserve the user's original query and use `aiq-deploy` to start a Skill backend. After `aiq-deploy` returns a verified `AIQ_SERVER_URL`, rerun `health`.
-4. Run `chat "<query>"` by passing the user's exact query for routed chat/research.
-5. If the response contains `{"status": "deep_research_running", "job_id": "..."}`, run `research_poll <job_id>`.
-6. If polling is interrupted, resume with `status <job_id>`, `report <job_id>`, or `research_poll <job_id>`.
-7. Present returned reports with citations intact. Do not truncate source URLs.
-
-### Presenting the report
-
-- When `research_poll` completes successfully, fetch and present the full report.
-- Do not truncate citations or source URLs from the returned report.
-
-### Handling interruptions and timeouts
-
-If polling is interrupted, the job continues server-side. Resume with:
-
-```bash
-python3 $SKILL_DIR/scripts/aiq.py status <job_id>
-python3 $SKILL_DIR/scripts/aiq.py report <job_id>
-python3 $SKILL_DIR/scripts/aiq.py research_poll <job_id>
-```
-
-- Use `status` to inspect job status and saved artifacts.
-- Use `report` when the job has already finished and you only need the final output.
-- Use `research_poll` to keep waiting for completion.
-
-### Checking job progress and state
-
-Async jobs expose two useful progress views:
-
-- `status <job_id>` returns top-level job status and also fetches `/state` artifacts.
-- `state <job_id>` returns the event-store artifacts only, without refetching the outer status wrapper.
-
-Run:
-
-```bash
-python3 $SKILL_DIR/scripts/aiq.py status <job_id>
-python3 $SKILL_DIR/scripts/aiq.py state <job_id>
-```
-
-Treat the responses as follows:
-- If `job_status.status` is `completed` or `success`, fetch or present the report.
-- If status is `failed`, `failure`, or `cancelled`, show the error and do not silently retry.
-- If status is still running, queued, or another non-terminal state, continue polling.
-
-### Failure handling
-
-If the job status is `failed` or `failure`:
-- Show the user the error from the status response.
-- Ask whether they want to retry with a narrower query or different approach.
-- Do not retry automatically.
-
-### Cancelling a job
-
-```bash
-python3 $SKILL_DIR/scripts/aiq.py cancel <job_id>
-```
-
-## Examples
-
-```bash
-python3 $SKILL_DIR/scripts/aiq.py health
-python3 $SKILL_DIR/scripts/aiq.py chat "Compare local AIQ deep research with a standard web search workflow"
-python3 $SKILL_DIR/scripts/aiq.py research_poll 12345678-1234-1234-1234-123456789abc
-```
-
 ## Environment Variables
 
 | Variable | Required | Default | Description |
 |---|---:|---|---|
-| `AIQ_SERVER_URL` | No | `http://localhost:8000` | Local AIQ server base URL |
+| `AIQ_SERVER_URL` | No | `http://localhost:8000` | Local or self-hosted AI-Q server base URL |
 
-## Troubleshooting
+## Security Best Practices
 
-| Error | Likely Cause | Action |
-|---|---|---|
-| Connection refused | No backend is reachable at `AIQ_SERVER_URL` or `http://localhost:8000` | Ask whether the user already has an AI-Q backend URL; otherwise use `aiq-deploy` to start and validate a Skill backend, then retry with the same query |
-| HTTP 401 or 403 | Backend requires authentication | This public helper does not manage auth. Ask the user to use an authenticated AI-Q skill or configure authentication for their environment before retrying |
-| Health succeeds but `/chat` or async agents fail | Backend is reachable but not compatible with this public research flow | Report the compatibility failure and offer to run `aiq-deploy` validation |
-| Job remains running | Deep research is asynchronous | Continue with `research_poll <job_id>` |
-| Poll output shows `running`, but a report is returned or `cancel` says the job is already `success` | The job reached a terminal state while the local polling output was still showing prior status lines | Treat `has_report: true` or `job_status.status: success` as complete. Fetch the report with `report <job_id>` instead of cancelling or continuing to poll |
-| Job failed | Server-side workflow failed | Show the returned status/error; do not retry automatically |
+- Do not put API keys, bearer tokens, cookies, or basic-auth credentials in `AIQ_SERVER_URL`.
+- Store backend credentials in the AI-Q deployment environment, not in this skill or command examples.
+- Treat returned reports as potentially sensitive if the backend uses private data sources.
+- Do not truncate citations or source URLs from returned reports.
+
+## Working Examples
+
+### Example 1: Run a routed chat or research request
+
+```bash
+python3 $SKILL_DIR/scripts/aiq.py health
+python3 $SKILL_DIR/scripts/aiq.py chat "Compare local AIQ deep research with a standard web search workflow"
+```
+
+Expected output:
+
+```text
+<health JSON from AI-Q>
+<JSON chat response or {"status": "deep_research_running", "job_id": "<JOB_ID>"}>
+```
+
+If AI-Q returns a job ID, continue with `research_poll`.
+
+### Example 2: Resume an existing job
+
+```bash
+python3 $SKILL_DIR/scripts/aiq.py status <JOB_ID>
+python3 $SKILL_DIR/scripts/aiq.py research_poll <JOB_ID>
+```
+
+Replace `<JOB_ID>` with the UUID returned by AI-Q. Expected output: status JSON followed by the report JSON when the
+job completes. If the job failed, show the returned status and do not retry automatically.
+
+## References
+
+| Topic | Documentation |
+|---|---|
+| Helper script | `scripts/aiq.py` |
+| Deployment and backend validation | `../aiq-deploy/SKILL.md` |
+| Skill metadata and examples | `README.md` |
+
+## Common Issues
+
+### Issue: No backend is reachable
+
+**Symptoms:**
+
+- `health` fails with connection refused.
+- The default `http://localhost:8000` URL does not respond.
+
+**Causes:**
+
+- AI-Q is not running.
+- AI-Q is running on a different host or port.
+- A local firewall or network setting blocks the connection.
+
+**Solutions:**
+
+1. Ask whether the user has an existing AI-Q backend URL.
+2. If they provide one, set it and rerun health:
+   ```bash
+   export AIQ_SERVER_URL="http://localhost:<PORT>"
+   python3 $SKILL_DIR/scripts/aiq.py health
+   ```
+3. If they want a local backend, hand off to `aiq-deploy` and preserve the original research request.
+
+### Issue: Backend requires authentication
+
+**Symptoms:**
+
+- Requests fail with HTTP 401 or HTTP 403.
+- The backend is reachable but rejects `/chat` or async job calls.
+
+**Causes:**
+
+- The backend was deployed with authentication enabled.
+- The public helper does not attach user tokens or cookies.
+
+**Solutions:**
+
+1. Stop and explain that this public skill does not manage authentication.
+2. Ask the user to use an authenticated AI-Q skill or configure their backend for this public local workflow.
+3. Rerun `health` and the original query only after the authentication boundary is resolved.
+
+### Issue: Health succeeds but research routes fail
+
+**Symptoms:**
+
+- `health` returns successfully.
+- `/chat`, `/v1/jobs/async/agents`, or polling commands fail.
+
+**Causes:**
+
+- The backend is not using an API-enabled AI-Q config.
+- The async job registry is not available in the selected backend.
+- The backend version is incompatible with this skill.
+
+**Solutions:**
+
+1. Run:
+   ```bash
+   python3 $SKILL_DIR/scripts/aiq.py agents
+   ```
+2. If agents are unavailable, report the compatibility failure and offer to run `aiq-deploy` validation.
+3. Confirm the deployed Blueprint version is compatible with skill version 2.1.0.
+
+### Issue: Job is interrupted or appears stuck
+
+**Symptoms:**
+
+- Local polling is interrupted.
+- The job keeps showing `running`.
+- Poll output shows `running`, but a report is returned or cancel says the job is already `success`.
+
+**Causes:**
+
+- Deep research is asynchronous and continues server-side.
+- Local polling output can lag behind terminal server state.
+
+**Solutions:**
+
+1. Check current state:
+   ```bash
+   python3 $SKILL_DIR/scripts/aiq.py status <JOB_ID>
+   ```
+2. If `has_report: true` or `job_status.status: success`, fetch the report:
+   ```bash
+   python3 $SKILL_DIR/scripts/aiq.py report <JOB_ID>
+   ```
+3. If the job is still running, continue polling:
+   ```bash
+   python3 $SKILL_DIR/scripts/aiq.py research_poll <JOB_ID>
+   ```

--- a/skills/aiq-research/scripts/aiq.py
+++ b/skills/aiq-research/scripts/aiq.py
@@ -45,6 +45,7 @@ _STREAM_TERMINAL_EVENTS = frozenset({"complete", "error", "done"})
 
 
 def _validate_base_url(url: str) -> str:
+    """Validate and normalize the configured AI-Q server base URL."""
     raw = (url or "").strip()
     if not raw:
         raise RuntimeError("AIQ_SERVER_URL is empty")
@@ -59,6 +60,7 @@ def _validate_base_url(url: str) -> str:
 
 
 def _validate_api_path(path: str) -> None:
+    """Reject unsafe or malformed API paths before building a request URL."""
     if not path.startswith("/") or path.startswith("//"):
         raise RuntimeError("Invalid API path")
     if len(path) > 4096 or ".." in path or _CONTROL_CHAR_RE.search(path):
@@ -66,6 +68,7 @@ def _validate_api_path(path: str) -> None:
 
 
 def _validate_job_id(job_id: str) -> str:
+    """Validate an async job identifier and return its normalized value."""
     value = job_id.strip()
     if not _JOB_UUID_RE.fullmatch(value):
         raise RuntimeError("job_id must be a UUID")
@@ -73,6 +76,7 @@ def _validate_job_id(job_id: str) -> str:
 
 
 def _validate_agent_type(agent_type: str) -> str:
+    """Validate an async agent type name accepted by the AI-Q job API."""
     value = agent_type.strip()
     if not _AGENT_TYPE_RE.fullmatch(value):
         raise RuntimeError("Invalid agent_type")
@@ -86,6 +90,7 @@ def _api_request(
     *,
     timeout: int = DEFAULT_API_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
+    """Send a JSON API request to the configured AI-Q backend."""
     if method not in _ALLOWED_METHODS:
         raise RuntimeError(f"Unsupported HTTP method: {method!r}")
     _validate_api_path(path)
@@ -119,6 +124,7 @@ def _api_request(
 
 
 def _stream_request(path: str, *, timeout: int = DEFAULT_LONG_HTTP_TIMEOUT_SECONDS) -> Iterator[str]:
+    """Yield stripped text lines from an AI-Q streaming endpoint."""
     _validate_api_path(path)
     url = f"{_validate_base_url(AIQ_SERVER_URL)}{path}"
     req = urllib.request.Request(url, method="GET")
@@ -137,6 +143,7 @@ def _stream_request(path: str, *, timeout: int = DEFAULT_LONG_HTTP_TIMEOUT_SECON
 
 
 def health() -> dict[str, Any]:
+    """Return the first successful AI-Q health response."""
     for path in ("/health", "/v1/health"):
         try:
             return _api_request("GET", path, timeout=10)
@@ -146,31 +153,38 @@ def health() -> dict[str, Any]:
 
 
 def list_agents() -> dict[str, Any]:
+    """List async agent types registered by the AI-Q backend."""
     return _api_request("GET", "/v1/jobs/async/agents")
 
 
 def submit_job(query: str, agent_type: str = DEFAULT_AGENT_TYPE) -> dict[str, Any]:
+    """Submit an explicit async research job to AI-Q."""
     body = {"agent_type": _validate_agent_type(agent_type), "input": query}
     return _api_request("POST", "/v1/jobs/async/submit", body=body, timeout=DEFAULT_LONG_HTTP_TIMEOUT_SECONDS)
 
 
 def get_job_status(job_id: str) -> dict[str, Any]:
+    """Fetch the top-level status for an async AI-Q job."""
     return _api_request("GET", f"/v1/jobs/async/job/{_validate_job_id(job_id)}")
 
 
 def get_job_state(job_id: str) -> dict[str, Any]:
+    """Fetch event-store artifacts for an async AI-Q job."""
     return _api_request("GET", f"/v1/jobs/async/job/{_validate_job_id(job_id)}/state")
 
 
 def get_report(job_id: str) -> dict[str, Any]:
+    """Fetch the final report for a completed async AI-Q job."""
     return _api_request("GET", f"/v1/jobs/async/job/{_validate_job_id(job_id)}/report")
 
 
 def cancel_job(job_id: str) -> dict[str, Any]:
+    """Request cancellation for a running async AI-Q job."""
     return _api_request("POST", f"/v1/jobs/async/job/{_validate_job_id(job_id)}/cancel")
 
 
 def stream_job(job_id: str) -> None:
+    """Print server-sent event payloads for an async AI-Q job."""
     for line in _stream_request(f"/v1/jobs/async/job/{_validate_job_id(job_id)}/stream"):
         if line.startswith("data:"):
             data = line[5:].strip()
@@ -181,6 +195,7 @@ def stream_job(job_id: str) -> None:
 
 
 def chat_request(query: str) -> dict[str, Any]:
+    """Send a routed chat request that may return a direct answer or job ID."""
     body = {"messages": [{"role": "user", "content": query}]}
     print(f"Sending request to: {_validate_base_url(AIQ_SERVER_URL)}/chat", file=sys.stderr)
     return _api_request("POST", "/chat", body=body, timeout=DEFAULT_LONG_HTTP_TIMEOUT_SECONDS)
@@ -192,6 +207,7 @@ def poll_until_complete(
     timeout: int = DEFAULT_LONG_HTTP_TIMEOUT_SECONDS,
     max_consecutive_errors: int = POLL_MAX_CONSECUTIVE_ERRORS,
 ) -> dict[str, Any]:
+    """Poll a job until it reaches a terminal state or timeout."""
     deadline = time.time() + timeout
     consecutive_errors = 0
     while time.time() < deadline:
@@ -222,6 +238,7 @@ def poll_until_complete(
 
 
 def _poll_until_success_or_exit(job_id: str) -> None:
+    """Poll a job, print its report on success, and exit on failure."""
     try:
         final = poll_until_complete(job_id)
     except KeyboardInterrupt:
@@ -238,6 +255,7 @@ def _poll_until_success_or_exit(job_id: str) -> None:
 
 
 def _print_usage() -> None:
+    """Print CLI usage information."""
     print("Usage: aiq.py <command> [args]")
     print()
     print("Commands:")
@@ -257,6 +275,7 @@ def _print_usage() -> None:
 
 
 def main() -> None:
+    """Dispatch the command-line interface."""
     if len(sys.argv) < 2:
         _print_usage()
         sys.exit(1)


### PR DESCRIPTION
## Summary

- Align `aiq-deploy` and `aiq-research` `SKILL.md` files with the new global NVIDIA Blueprint skill requirements.
- Add per-skill `README.md` files and a missing `aiq-deploy/LICENSE` for publishing structure.
- Add function docstrings to the `aiq-research` helper script to satisfy code-bearing skill guidance.
- Add `.github/workflows/request-nvskills-ci.yml` so NVSkills/NVCARPS can generate required signing and skill-card artifacts.

## Why

The new global skill guidance requires consistent metadata, required documentation sections, version compatibility language, working examples, troubleshooting structure, README files, per-skill license files, and generated signing/card artifacts for published Blueprint skills.

## Notes

- Scope is limited to the top-level published AIQ skills: `skills/aiq-deploy` and `skills/aiq-research`.
- The nested `data-table-analysis` helper skill and API-integration-template-specific work are intentionally out of scope for this pass.
- The standards README does not require YAML frontmatter for `references/` documents; references are described as optional focused documentation linked from `SKILL.md`.
- Commit author, committer, and DCO sign-off metadata have been rewritten to `Allan Enemark <aenemark@nvidia.com>`.
- `/nvskills-ci` has been requested on this PR. Required `skill.oms.sig` and `SKILLCARD.yaml` or `skill-card.md` files should be accepted only from the generated NVSkills/NVCARPS signature commit.

## Validation

- `git diff --check`
- `LC_ALL=C rg -n "[^[:ascii:]]" skills/aiq-deploy skills/aiq-research`
- `python3 -m py_compile skills/aiq-research/scripts/aiq.py`
- `.venv/bin/python -m ruff check skills/aiq-research/scripts/aiq.py`
- Custom required-section and helper-docstring checks
- Commit hooks: ruff, ruff format, merge-conflict check, large-file check, end-of-file fix, trailing whitespace, secret detection, Markdown link check
- Confirmed current PR commits use NVIDIA author, committer, and DCO sign-off metadata.

## Known limitations

- Pre-commit reported existing warnings that `helm-lint` and `pytest` hooks use deprecated stage names. No hook failed.
- No NVSkills/NVCARPS signature commit is visible yet after the `/nvskills-ci` request; repo app/secret configuration may need maintainer follow-up if the bot does not respond.