### PR TITLE
Update NVSkills CI request workflow

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -10,10 +10,9 @@ jobs:
     if: >
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
         startsWith(github.event.comment.body, '/nvskills-ci')) ||
       (github.event_name == 'push' &&
-        github.actor == (vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-nvskill-ci[bot]') &&
+        github.actor == (vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]') &&
         startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures'))
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Allow /nvskills-ci issue comments without checking GitHub author association in the wrapper workflow.
- Fix the default NVSkills signature push actor fallback to nv-skills-ci[bot].

## Notes
- This matches the workflow update requested by the Skills team.
- Direct push to develop was blocked by repository rules, so this PR contains the workflow-only update.

## Validation
- Diff is limited to .github/workflows/request-nvskills-ci.yml.
- Commit includes DCO sign-off.