### PR TITLE
Add copy-pr-bot support to CI workflows

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,12 @@
+# copy-pr-bot configuration for NVIDIA-AI-Blueprints/aiq
+# Docs: https://docs.gha-runners.nvidia.com/platform/apps/copy-pr-bot/
+#
+# additional_trustees: users explicitly trusted even if not org members.
+# Needed when author_association is CONTRIBUTOR (not MEMBER of NVIDIA-AI-Blueprints org).
+enabled: true
+additional_vetters:
+  - exactlyallan
+  - AjayThorve
+  - sarathm-nvidia
+auto_sync_draft: false
+auto_sync_ready: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,14 @@
 name: AIQ CI
 
+# Trigger: push-only. All PRs (internal and external) are mirrored to
+# pull-request/<N> branches by copy-pr-bot after `/ok to test` approval.
+# Direct pushes to develop or release branches also trigger CI.
 on:
-  pull_request:
-    branches:
-      - develop
-      - "release/**"
   push:
     branches:
       - develop
       - "release/**"
+      - "pull-request/[0-9]+"
 
 permissions:
   contents: read

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -1,17 +1,14 @@
 name: AIQ UI CI
 
+# Trigger: push-only. All PRs (internal and external) are mirrored to
+# pull-request/<N> branches by copy-pr-bot after `/ok to test` approval.
+# Only runs when UI source or this workflow file changes.
 on:
-  pull_request:
-    branches:
-      - develop
-      - "release/**"
-    paths:
-      - "frontends/ui/**"
-      - ".github/workflows/ui.yml"
   push:
     branches:
       - develop
       - "release/**"
+      - "pull-request/[0-9]+"
     paths:
       - "frontends/ui/**"
       - ".github/workflows/ui.yml"


### PR DESCRIPTION
## Summary

- Switch CI and UI workflows to push-only triggers, matching the VSS pattern
- Add `pull-request/[0-9]+` branch pattern so CI runs on mirror branches created by copy-pr-bot after `/ok to test` approval
- Drop `pull_request:` trigger — all PRs (internal and external) go through copy-pr-bot
- Add `.github/copy-pr-bot.yaml` config with auto-sync on ready PRs and vetters list

## Files changed

- `.github/workflows/ci.yml` — push-only + mirror branch pattern
- `.github/workflows/ui.yml` — push-only + mirror branch pattern + path filter retained
- `.github/copy-pr-bot.yaml` — bot config (enabled, auto-sync ready PRs, vetters: exactlyallan, AjayThorve, sarathm-nvidia)

## Test plan

- [ ] Verify CI triggers on direct push to `develop`
- [ ] Verify CI triggers on copy-pr-bot mirror branch (`pull-request/N`)
- [ ] Verify UI CI only triggers when `frontends/ui/**` changes on mirror branch
- [ ] Verify copy-pr-bot creates mirror branches after `/ok to test` approval