### PR TITLE
Guard WebSocket outbound delivery

### DIFF
--- a/frontends/ui/src/adapters/api/websocket-client.ts
+++ b/frontends/ui/src/adapters/api/websocket-client.ts
@@ -224,7 +224,7 @@ export class NATWebSocketClient {
    * @param content - The message text content (query)
    * @param enabledDataSources - Optional array of enabled data source IDs to include in the query
    */
-  sendMessage = (content: string, enabledDataSources?: string[]): void => {
+  sendMessage = (content: string, enabledDataSources?: string[]): string | null => {
     // Format the text content as JSON with query and data_sources
     const textContent = JSON.stringify({
       query: content,
@@ -232,8 +232,6 @@ export class NATWebSocketClient {
     })
 
     const messageId = this.generateMessageId()
-    this.activeParentId = messageId
-
     const message: NATUserMessage = {
       type: NATMessageType.USER_MESSAGE,
       schema_type: NATSchemaType.CHAT_STREAM,
@@ -250,16 +248,20 @@ export class NATWebSocketClient {
       timestamp: new Date().toISOString(),
     }
 
-    this.send(message)
+    if (!this.send(message)) return null
+
+    this.activeParentId = messageId
+    return messageId
   }
 
   /**
    * Send a response to a human prompt (clarification, approval, etc.)
    */
-  sendInteractionResponse = (promptId: string, parentId: string, responseText: string): void => {
+  sendInteractionResponse = (promptId: string, parentId: string, responseText: string): string | null => {
+    const messageId = this.generateMessageId()
     const message: NATUserInteractionResponse = {
       type: NATMessageType.USER_INTERACTION,
-      id: this.generateMessageId(),
+      id: messageId,
       parent_id: parentId,
       conversation_id: this.options.conversationId,
       content: {
@@ -273,7 +275,8 @@ export class NATWebSocketClient {
       timestamp: new Date().toISOString(),
     }
 
-    this.send(message)
+    if (!this.send(message)) return null
+    return messageId
   }
 
   /**
@@ -416,11 +419,13 @@ export class NATWebSocketClient {
     }
   }
 
-  private send = (message: object): void => {
+  private send = (message: object): boolean => {
     if (this.ws?.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify(message))
+      return true
     } else {
       console.warn('NAT WebSocket not connected, message not sent')
+      return false
     }
   }
 

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
@@ -466,6 +466,165 @@ describe('useWebSocketChat', () => {
     expect(mockSetLoading).toHaveBeenCalledWith(false)
   })
 
+  test('replays a just-sent message once when no backend frame arrives before the ack timeout', () => {
+    vi.useFakeTimers()
+    try {
+      mockWsClient.isConnected.mockReturnValue(true)
+      mockWsClient.sendMessage
+        .mockReturnValueOnce('outbound-original')
+        .mockReturnValueOnce('outbound-replay')
+
+      const { result } = renderWebSocketHook()
+
+      act(() => {
+        result.current.sendMessage('Request after stale socket')
+      })
+
+      mockWsClient.sendMessage.mockClear()
+      mockWsClient.rotate.mockClear()
+      mockSetStreaming.mockClear()
+      mockSetLoading.mockClear()
+      mockAddErrorCard.mockClear()
+
+      act(() => {
+        vi.advanceTimersByTime(15_000)
+      })
+
+      expect(mockWsClient.rotate).toHaveBeenCalledTimes(1)
+      expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
+      expect(mockSetStreaming).not.toHaveBeenCalledWith(false)
+      expect(mockSetLoading).not.toHaveBeenCalledWith(false)
+      expect(mockAddErrorCard).not.toHaveBeenCalled()
+
+      act(() => {
+        capturedCallbacks.onConnectionChange?.('connected')
+      })
+
+      expect(mockWsClient.sendMessage).toHaveBeenCalledTimes(1)
+      expect(mockWsClient.sendMessage).toHaveBeenCalledWith(
+        'Request after stale socket',
+        expect.any(Array),
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('does not replay after the backend acknowledges the sent message before the ack timeout', () => {
+    vi.useFakeTimers()
+    try {
+      mockWsClient.isConnected.mockReturnValue(true)
+      mockWsClient.sendMessage.mockReturnValueOnce('outbound-original')
+
+      const { result } = renderWebSocketHook()
+
+      act(() => {
+        result.current.sendMessage('Request that gets a response')
+      })
+
+      mockStoreState.isStreaming = true
+      act(() => {
+        capturedCallbacks.onIntermediateStep?.('Thinking...', 'in_progress')
+      })
+
+      mockWsClient.sendMessage.mockClear()
+      mockWsClient.rotate.mockClear()
+
+      act(() => {
+        vi.advanceTimersByTime(15_000)
+      })
+
+      expect(mockWsClient.rotate).not.toHaveBeenCalled()
+      expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('does not replay or show an error when the ack timeout fires after switching conversations', () => {
+    vi.useFakeTimers()
+    try {
+      mockStoreState.currentConversation = { id: 'conv-A', messages: [], userId: 'user-1' }
+      mockWsClient.isConnected.mockReturnValue(true)
+      mockWsClient.sendMessage.mockReturnValueOnce('outbound-original')
+
+      const { result } = renderWebSocketHook()
+
+      act(() => {
+        result.current.sendMessage('Request from conv A')
+      })
+
+      mockStoreState.currentConversation = { id: 'conv-B', messages: [], userId: 'user-1' }
+      mockWsClient.sendMessage.mockClear()
+      mockWsClient.rotate.mockClear()
+      mockAddErrorCard.mockClear()
+      mockSetStreaming.mockClear()
+      mockSetLoading.mockClear()
+
+      act(() => {
+        vi.advanceTimersByTime(15_000)
+      })
+
+      expect(mockWsClient.rotate).not.toHaveBeenCalled()
+      expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
+      expect(mockAddErrorCard).not.toHaveBeenCalled()
+      expect(mockSetStreaming).not.toHaveBeenCalledWith(false)
+      expect(mockSetLoading).not.toHaveBeenCalledWith(false)
+
+      act(() => {
+        capturedCallbacks.onConnectionChange?.('connected')
+      })
+
+      expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('fails closed when the replay also receives no backend frame before the ack timeout', () => {
+    vi.useFakeTimers()
+    try {
+      mockWsClient.isConnected.mockReturnValue(true)
+      mockWsClient.sendMessage
+        .mockReturnValueOnce('outbound-original')
+        .mockReturnValueOnce('outbound-replay')
+
+      const { result } = renderWebSocketHook()
+
+      act(() => {
+        result.current.sendMessage('Request with repeated stale socket')
+      })
+
+      act(() => {
+        vi.advanceTimersByTime(15_000)
+      })
+      act(() => {
+        capturedCallbacks.onConnectionChange?.('connected')
+      })
+
+      mockWsClient.sendMessage.mockClear()
+      mockWsClient.rotate.mockClear()
+      mockSetStreaming.mockClear()
+      mockSetLoading.mockClear()
+      mockAddErrorCard.mockClear()
+
+      act(() => {
+        vi.advanceTimersByTime(15_000)
+      })
+
+      expect(mockWsClient.rotate).not.toHaveBeenCalled()
+      expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
+      expect(mockAddErrorCard).toHaveBeenCalledWith(
+        'connection.failed',
+        'No response received from the server. Please try again.',
+      )
+      expect(mockSetStreaming).toHaveBeenCalledWith(false)
+      expect(mockSetLoading).toHaveBeenCalledWith(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   test('sendMessage does not add knowledge_layer when no files uploaded', async () => {
     mockWsClient.isConnected.mockReturnValue(true)
 

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
@@ -510,7 +510,7 @@ describe('useWebSocketChat', () => {
     }
   })
 
-  test('does not replay after the backend acknowledges the sent message before the ack timeout', () => {
+  test('does not replay after an accepted intermediate frame with an internal parent id before the ack timeout', () => {
     vi.useFakeTimers()
     try {
       mockWsClient.isConnected.mockReturnValue(true)
@@ -524,7 +524,7 @@ describe('useWebSocketChat', () => {
 
       mockStoreState.isStreaming = true
       act(() => {
-        capturedCallbacks.onIntermediateStep?.('Thinking...', 'in_progress')
+        capturedCallbacks.onIntermediateStep?.('Thinking...', 'in_progress', 'internal-step-id')
       })
 
       mockWsClient.sendMessage.mockClear()

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
@@ -192,8 +192,8 @@ const mockWsClient = {
   connect: vi.fn(),
   disconnect: vi.fn(),
   rotate: vi.fn(),
-  sendMessage: vi.fn(),
-  sendInteractionResponse: vi.fn(),
+  sendMessage: vi.fn(() => 'mock-outbound-message-id'),
+  sendInteractionResponse: vi.fn(() => 'mock-outbound-interaction-id'),
   isConnected: vi.fn(() => false),
   updateConversationId: vi.fn(),
 }
@@ -367,6 +367,103 @@ describe('useWebSocketChat', () => {
       'Send during handshake',
       expect.any(Array),
     )
+  })
+
+  test('replays a just-sent message once when the socket drops before any backend frame', () => {
+    mockWsClient.isConnected.mockReturnValue(true)
+    mockWsClient.sendMessage
+      .mockReturnValueOnce('outbound-original')
+      .mockReturnValueOnce('outbound-replay')
+
+    const { result } = renderWebSocketHook()
+
+    act(() => {
+      result.current.sendMessage('Need current weather')
+    })
+
+    expect(mockWsClient.sendMessage).toHaveBeenCalledWith(
+      'Need current weather',
+      expect.any(Array),
+    )
+
+    mockWsClient.sendMessage.mockClear()
+    mockSetStreaming.mockClear()
+    mockSetLoading.mockClear()
+    mockAddErrorCard.mockClear()
+
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('disconnected')
+    })
+
+    expect(mockSetStreaming).not.toHaveBeenCalledWith(false)
+    expect(mockSetLoading).not.toHaveBeenCalledWith(false)
+    expect(mockAddErrorCard).not.toHaveBeenCalled()
+
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('connected')
+    })
+
+    expect(mockWsClient.sendMessage).toHaveBeenCalledTimes(1)
+    expect(mockWsClient.sendMessage).toHaveBeenCalledWith(
+      'Need current weather',
+      expect.any(Array),
+    )
+
+    // Once any backend frame arrives, the delivery guard is cleared. A later
+    // disconnect must not replay the same prompt again.
+    mockStoreState.isStreaming = true
+    mockWsClient.sendMessage.mockClear()
+
+    act(() => {
+      capturedCallbacks.onIntermediateStep?.('Thinking...', 'in_progress')
+    })
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('disconnected')
+    })
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('connected')
+    })
+
+    expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
+  })
+
+  test('does not replay an unacknowledged message more than once', () => {
+    mockWsClient.isConnected.mockReturnValue(true)
+    mockWsClient.sendMessage
+      .mockReturnValueOnce('outbound-original')
+      .mockReturnValueOnce('outbound-replay')
+
+    const { result } = renderWebSocketHook()
+
+    act(() => {
+      result.current.sendMessage('Retry bounded request')
+    })
+
+    mockWsClient.sendMessage.mockClear()
+
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('disconnected')
+    })
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('connected')
+    })
+
+    expect(mockWsClient.sendMessage).toHaveBeenCalledTimes(1)
+
+    mockWsClient.sendMessage.mockClear()
+    mockSetStreaming.mockClear()
+    mockSetLoading.mockClear()
+
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('disconnected')
+    })
+    act(() => {
+      capturedCallbacks.onConnectionChange?.('connected')
+    })
+
+    expect(mockWsClient.sendMessage).not.toHaveBeenCalled()
+    expect(mockSetStreaming).toHaveBeenCalledWith(false)
+    expect(mockSetLoading).toHaveBeenCalledWith(false)
   })
 
   test('sendMessage does not add knowledge_layer when no files uploaded', async () => {

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
@@ -487,7 +487,7 @@ describe('useWebSocketChat', () => {
       mockAddErrorCard.mockClear()
 
       act(() => {
-        vi.advanceTimersByTime(15_000)
+        vi.advanceTimersByTime(7_000)
       })
 
       expect(mockWsClient.rotate).toHaveBeenCalledTimes(1)
@@ -531,7 +531,7 @@ describe('useWebSocketChat', () => {
       mockWsClient.rotate.mockClear()
 
       act(() => {
-        vi.advanceTimersByTime(15_000)
+        vi.advanceTimersByTime(7_000)
       })
 
       expect(mockWsClient.rotate).not.toHaveBeenCalled()
@@ -562,7 +562,7 @@ describe('useWebSocketChat', () => {
       mockSetLoading.mockClear()
 
       act(() => {
-        vi.advanceTimersByTime(15_000)
+        vi.advanceTimersByTime(7_000)
       })
 
       expect(mockWsClient.rotate).not.toHaveBeenCalled()
@@ -596,7 +596,7 @@ describe('useWebSocketChat', () => {
       })
 
       act(() => {
-        vi.advanceTimersByTime(15_000)
+        vi.advanceTimersByTime(7_000)
       })
       act(() => {
         capturedCallbacks.onConnectionChange?.('connected')
@@ -609,7 +609,7 @@ describe('useWebSocketChat', () => {
       mockAddErrorCard.mockClear()
 
       act(() => {
-        vi.advanceTimersByTime(15_000)
+        vi.advanceTimersByTime(7_000)
       })
 
       expect(mockWsClient.rotate).not.toHaveBeenCalled()

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -128,6 +128,14 @@ const MAX_CONSECUTIVE_AUTH_EXPIRED = 3
 const MAX_UNACKNOWLEDGED_OUTGOING_REPLAYS = 1
 
 /**
+ * If the browser accepts a WebSocket send but the server never emits any
+ * response frame, `onclose` may also never fire on half-open network paths.
+ * This timeout closes that remaining gap: no backend contact within the
+ * window is treated like an unacknowledged stale send.
+ */
+const UNACKNOWLEDGED_OUTGOING_ACK_TIMEOUT_MS = 15_000
+
+/**
  * Map NAT/backend error codes to frontend ErrorCode for consistent UI display.
  * This provides a generic mapping for any backend error.
  */
@@ -256,6 +264,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
    * on the reconnected socket.
    */
   const unacknowledgedOutgoingRef = useRef<UnacknowledgedOutgoing | null>(null)
+  const unacknowledgedOutgoingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   /**
    * Set by the soft timer when it fires while streaming; consumed by the
@@ -290,7 +299,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
   const rotateSocket = useCallback((reason: string): void => {
     const client = wsClientRef.current
     if (!client) return
-    console.warn(`[WS] Rotating connection before token expiry (${reason})`)
+    console.warn(`[WS] Rotating connection (${reason})`)
     void client.rotate()
   }, [])
 
@@ -404,11 +413,87 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
     [authRequired, authError]
   )
 
+  const clearUnacknowledgedOutgoingTimeout = useCallback((): void => {
+    if (unacknowledgedOutgoingTimeoutRef.current) {
+      clearTimeout(unacknowledgedOutgoingTimeoutRef.current)
+      unacknowledgedOutgoingTimeoutRef.current = null
+    }
+  }, [])
+
+  const clearUnacknowledgedOutgoing = useCallback((): void => {
+    unacknowledgedOutgoingRef.current = null
+    clearUnacknowledgedOutgoingTimeout()
+  }, [clearUnacknowledgedOutgoingTimeout])
+
+  const failUnacknowledgedOutgoing = useCallback((): void => {
+    if (currentThinkingStepIdRef.current) {
+      completeThinkingStep(currentThinkingStepIdRef.current)
+      currentThinkingStepIdRef.current = null
+      currentStatusRef.current = null
+    }
+
+    addErrorCard(
+      'connection.failed',
+      'No response received from the server. Please try again.',
+    )
+    setCurrentStatus(null)
+    setStreaming(false)
+    setLoading(false)
+    clearPendingInteraction()
+    lastSentOutgoingRef.current = null
+    pendingOutgoingRef.current = null
+    clearUnacknowledgedOutgoing()
+  }, [
+    addErrorCard,
+    clearPendingInteraction,
+    clearUnacknowledgedOutgoing,
+    completeThinkingStep,
+    setCurrentStatus,
+    setLoading,
+    setStreaming,
+  ])
+
+  const handleUnacknowledgedOutgoingTimeout = useCallback((): void => {
+    const unacknowledged = unacknowledgedOutgoingRef.current
+    if (!unacknowledged) return
+
+    const activeConversationId = useChatStore.getState().currentConversation?.id
+    const sameConversation =
+      !unacknowledged.conversationId ||
+      unacknowledged.conversationId === activeConversationId
+
+    if (!sameConversation) {
+      lastSentOutgoingRef.current = null
+      pendingOutgoingRef.current = null
+      clearUnacknowledgedOutgoing()
+      return
+    }
+
+    if (
+      unacknowledged.retryCount < MAX_UNACKNOWLEDGED_OUTGOING_REPLAYS
+    ) {
+      pendingOutgoingRef.current = {
+        ...unacknowledged.payload,
+        deliveryRetryCount: unacknowledged.retryCount + 1,
+      } as PendingOutgoing
+      clearUnacknowledgedOutgoing()
+      rotateSocket('delivery-timeout')
+      return
+    }
+
+    failUnacknowledgedOutgoing()
+  }, [
+    clearUnacknowledgedOutgoing,
+    failUnacknowledgedOutgoing,
+    rotateSocket,
+  ])
+
   const trackSentOutgoing = useCallback(
     (payload: PendingOutgoing, outboundId: string): void => {
       const retryCount = payload.deliveryRetryCount ?? 0
       const conversationId = useChatStore.getState().currentConversation?.id ?? currentConversationId
 
+      clearUnacknowledgedOutgoingTimeout()
       lastSentOutgoingRef.current = payload
       unacknowledgedOutgoingRef.current = {
         payload,
@@ -417,8 +502,16 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         conversationId,
         retryCount,
       }
+      unacknowledgedOutgoingTimeoutRef.current = setTimeout(
+        handleUnacknowledgedOutgoingTimeout,
+        UNACKNOWLEDGED_OUTGOING_ACK_TIMEOUT_MS,
+      )
     },
-    [currentConversationId]
+    [
+      clearUnacknowledgedOutgoingTimeout,
+      currentConversationId,
+      handleUnacknowledgedOutgoingTimeout,
+    ]
   )
 
   const acknowledgeOutgoingDelivery = useCallback((parentId?: string): void => {
@@ -435,9 +528,9 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
       parentId === unacknowledged.ackParentId ||
       parentId === unacknowledged.outboundId
     ) {
-      unacknowledgedOutgoingRef.current = null
+      clearUnacknowledgedOutgoing()
     }
-  }, [])
+  }, [clearUnacknowledgedOutgoing])
 
   const sendOutgoingPayload = useCallback(
     (payload: PendingOutgoing): boolean => {
@@ -761,7 +854,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
             consecutiveAuthExpiredRef.current = 0
             lastSentOutgoingRef.current = null
             pendingOutgoingRef.current = null
-            unacknowledgedOutgoingRef.current = null
+            clearUnacknowledgedOutgoing()
             addErrorCard(
               'auth.session_expired' as ErrorCode,
               'Your session has expired. Please sign in again to continue.',
@@ -778,7 +871,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           if (lastSent) {
             pendingOutgoingRef.current = lastSent
           }
-          unacknowledgedOutgoingRef.current = null
+          clearUnacknowledgedOutgoing()
           rotateSocket('auth_expired')
           return
         }
@@ -803,7 +896,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           // pre-rotation payload behind the user's back.
           lastSentOutgoingRef.current = null
           pendingOutgoingRef.current = null
-          unacknowledgedOutgoingRef.current = null
+          clearUnacknowledgedOutgoing()
           return
         }
 
@@ -833,7 +926,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         // user expects to be re-sent once we've shown them an error card.
         lastSentOutgoingRef.current = null
         pendingOutgoingRef.current = null
-        unacknowledgedOutgoingRef.current = null
+        clearUnacknowledgedOutgoing()
       },
 
       onConnectionChange: (status, context?: ConnectionChangeContext) => {
@@ -885,11 +978,11 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
                 ...unacknowledged.payload,
                 deliveryRetryCount: unacknowledged.retryCount + 1,
               } as PendingOutgoing
-              unacknowledgedOutgoingRef.current = null
+              clearUnacknowledgedOutgoing()
               return
             }
 
-            unacknowledgedOutgoingRef.current = null
+            clearUnacknowledgedOutgoing()
             lastSentOutgoingRef.current = null
             pendingOutgoingRef.current = null
           }
@@ -933,6 +1026,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
     getTransportFailure,
     rotateSocket,
     acknowledgeOutgoingDelivery,
+    clearUnacknowledgedOutgoing,
     sendOutgoingPayload,
   ])
 
@@ -982,7 +1076,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
       }
       pendingOutgoingRef.current = null
       lastSentOutgoingRef.current = null
-      unacknowledgedOutgoingRef.current = null
+      clearUnacknowledgedOutgoing()
       consecutiveAuthExpiredRef.current = 0
       pendingRotationRef.current = false
       currentThinkingStepIdRef.current = null
@@ -993,6 +1087,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
     autoConnect,
     createCallbacks,
     refreshAuthBeforeReconnect,
+    clearUnacknowledgedOutgoing,
     setStreaming,
     setLoading,
     setCurrentStatus,

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -133,7 +133,7 @@ const MAX_UNACKNOWLEDGED_OUTGOING_REPLAYS = 1
  * This timeout closes that remaining gap: no backend contact within the
  * window is treated like an unacknowledged stale send.
  */
-const UNACKNOWLEDGED_OUTGOING_ACK_TIMEOUT_MS = 15_000
+const UNACKNOWLEDGED_OUTGOING_ACK_TIMEOUT_MS = 7_000
 
 /**
  * Map NAT/backend error codes to frontend ErrorCode for consistent UI display.

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -68,8 +68,16 @@ const EMPTY_CONVERSATIONS: Conversation[] = []
  * right `NATWebSocketClient` method.
  */
 type PendingOutgoing =
-  | { kind: 'message'; content: string; dataSources: string[] }
-  | { kind: 'interaction'; interactionId: string; parentId: string; response: string }
+  | { kind: 'message'; content: string; dataSources: string[]; deliveryRetryCount?: number }
+  | { kind: 'interaction'; interactionId: string; parentId: string; response: string; deliveryRetryCount?: number }
+
+type UnacknowledgedOutgoing = {
+  payload: PendingOutgoing
+  outboundId: string
+  ackParentId: string
+  conversationId?: string
+  retryCount: number
+}
 
 /**
  * Seconds before token expiry to proactively rotate the WebSocket. The
@@ -108,6 +116,16 @@ const WS_REFRESH_SOFT_GUARD_SECONDS = 60
  * because a single passing message proves the post-rotation auth is alive.
  */
 const MAX_CONSECUTIVE_AUTH_EXPIRED = 3
+
+/**
+ * One silent replay is enough to cover the stale-open socket race observed in
+ * staging: the browser reported OPEN, the UI wrote the prompt, and the socket
+ * closed before the backend emitted any frame. More than one replay risks
+ * duplicate workflows if the backend accepted the earlier send but was slow to
+ * answer, so a second unacknowledged close falls back to the normal connection
+ * failure path.
+ */
+const MAX_UNACKNOWLEDGED_OUTGOING_REPLAYS = 1
 
 /**
  * Map NAT/backend error codes to frontend ErrorCode for consistent UI display.
@@ -231,6 +249,15 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
   const lastSentOutgoingRef = useRef<PendingOutgoing | null>(null)
 
   /**
+   * Payload that has been written to a WebSocket but has not yet produced any
+   * backend frame. Browser `readyState === OPEN` is not a delivery guarantee:
+   * a proxy/backend close can arrive immediately after `send()`. This ref lets
+   * an unintentional close before first backend contact replay the payload once
+   * on the reconnected socket.
+   */
+  const unacknowledgedOutgoingRef = useRef<UnacknowledgedOutgoing | null>(null)
+
+  /**
    * Set by the soft timer when it fires while streaming; consumed by the
    * deferred-rotation effect once `isStreaming` returns to false. Ref (not
    * state) so flipping the flag doesn't re-run the timer effect.
@@ -319,6 +346,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
     currentStatus: s.currentStatus,
     pendingInteraction: s.pendingInteraction,
   })))
+  const currentConversationId = currentConversation?.id
 
   // Actions — stable references, individual selectors won't cause re-renders
   const addUserMessage = useChatStore((s) => s.addUserMessage)
@@ -376,6 +404,61 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
     [authRequired, authError]
   )
 
+  const trackSentOutgoing = useCallback(
+    (payload: PendingOutgoing, outboundId: string): void => {
+      const retryCount = payload.deliveryRetryCount ?? 0
+      const conversationId = useChatStore.getState().currentConversation?.id ?? currentConversationId
+
+      lastSentOutgoingRef.current = payload
+      unacknowledgedOutgoingRef.current = {
+        payload,
+        outboundId,
+        ackParentId: payload.kind === 'message' ? outboundId : payload.parentId,
+        conversationId,
+        retryCount,
+      }
+    },
+    [currentConversationId]
+  )
+
+  const acknowledgeOutgoingDelivery = useCallback((parentId?: string): void => {
+    const unacknowledged = unacknowledgedOutgoingRef.current
+    if (!unacknowledged) return
+
+    // Some NAT frames omit parent_id, and intermediate frames may carry an
+    // internal step id rather than the original user-message id. Any backend
+    // frame while this request is active proves the prior send crossed the
+    // socket boundary, but when parent_id is present and matches our known
+    // request ids we can be stricter.
+    if (
+      !parentId ||
+      parentId === unacknowledged.ackParentId ||
+      parentId === unacknowledged.outboundId
+    ) {
+      unacknowledgedOutgoingRef.current = null
+    }
+  }, [])
+
+  const sendOutgoingPayload = useCallback(
+    (payload: PendingOutgoing): boolean => {
+      const client = wsClientRef.current
+      if (!client?.isConnected()) return false
+
+      const outboundId = payload.kind === 'message'
+        ? client.sendMessage(payload.content, payload.dataSources)
+        : client.sendInteractionResponse(
+          payload.interactionId,
+          payload.parentId,
+          payload.response,
+        )
+
+      if (!outboundId) return false
+      trackSentOutgoing(payload, outboundId)
+      return true
+    },
+    [trackSentOutgoing]
+  )
+
   /**
    * Create WebSocket callbacks that route messages to the store
    */
@@ -415,6 +498,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           )
           return
         }
+        acknowledgeOutgoingDelivery(parentId)
 
         // Check for deep research escalation signal
         // Backend sends: "Deep research job submitted. Job ID: {uuid}"
@@ -543,7 +627,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         }
       },
 
-      onIntermediateStep: (content: NATIntermediateStepContent | string, status: string, _parentId?: string) => {
+      onIntermediateStep: (content: NATIntermediateStepContent | string, status: string, parentId?: string) => {
         // Same as onResponse: any backend-emitted frame on this socket
         // proves the rotated handshake is honoured. Reset the consecutive
         // auth_expired budget.
@@ -558,6 +642,8 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           console.warn('Ignoring stale intermediate step -- not currently streaming')
           return
         }
+        acknowledgeOutgoingDelivery(parentId)
+
         // Legacy string-content path: synthesize a generic thinking step.
         if (typeof content === 'string') {
           // For plain string content, create a generic thinking step
@@ -617,6 +703,8 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
       },
 
       onHumanPrompt: (promptId: string, parentId: string, prompt: NATHumanPrompt) => {
+        acknowledgeOutgoingDelivery(parentId)
+
         // Store the pending interaction for the UI to handle
         const inputType = prompt.input_type as PendingInteraction['inputType']
         const interaction: PendingInteraction = {
@@ -673,6 +761,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
             consecutiveAuthExpiredRef.current = 0
             lastSentOutgoingRef.current = null
             pendingOutgoingRef.current = null
+            unacknowledgedOutgoingRef.current = null
             addErrorCard(
               'auth.session_expired' as ErrorCode,
               'Your session has expired. Please sign in again to continue.',
@@ -689,6 +778,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           if (lastSent) {
             pendingOutgoingRef.current = lastSent
           }
+          unacknowledgedOutgoingRef.current = null
           rotateSocket('auth_expired')
           return
         }
@@ -713,6 +803,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           // pre-rotation payload behind the user's back.
           lastSentOutgoingRef.current = null
           pendingOutgoingRef.current = null
+          unacknowledgedOutgoingRef.current = null
           return
         }
 
@@ -742,6 +833,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         // user expects to be re-sent once we've shown them an error card.
         lastSentOutgoingRef.current = null
         pendingOutgoingRef.current = null
+        unacknowledgedOutgoingRef.current = null
       },
 
       onConnectionChange: (status, context?: ConnectionChangeContext) => {
@@ -761,26 +853,14 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           const client = wsClientRef.current
           if (pending && client) {
             pendingOutgoingRef.current = null
-            if (pending.kind === 'message') {
-              client.sendMessage(pending.content, pending.dataSources)
+            if (sendOutgoingPayload(pending)) {
+              // Match each send path's loading contract: chat sends clear the
+              // composer spinner after putting the message on the wire, while
+              // HITL answers keep it visible until the backend processes them.
+              setLoading(pending.kind === 'interaction')
             } else {
-              client.sendInteractionResponse(
-                pending.interactionId,
-                pending.parentId,
-                pending.response,
-              )
+              pendingOutgoingRef.current = pending
             }
-            // Mirror doSend(): the drain just put a payload on the wire,
-            // so it is now the canonical "last sent". Without this, a
-            // pre-flight rotation that gets immediately hit by a second
-            // `auth_expired` on the fresh socket would have a null
-            // `lastSentOutgoingRef` and silently drop the user's payload
-            // (the auth_expired handler couldn't re-buffer it).
-            lastSentOutgoingRef.current = pending
-            // Match each send path's loading contract: chat sends clear the
-            // composer spinner after putting the message on the wire, while
-            // HITL answers keep it visible until the backend processes them.
-            setLoading(pending.kind === 'interaction')
           }
           return
         }
@@ -790,6 +870,30 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         if (context?.intentional) return
 
         if (status === 'error' || status === 'disconnected') {
+          const unacknowledged = unacknowledgedOutgoingRef.current
+          if (unacknowledged) {
+            const activeConversationId = useChatStore.getState().currentConversation?.id
+            const sameConversation =
+              !unacknowledged.conversationId ||
+              unacknowledged.conversationId === activeConversationId
+
+            if (
+              sameConversation &&
+              unacknowledged.retryCount < MAX_UNACKNOWLEDGED_OUTGOING_REPLAYS
+            ) {
+              pendingOutgoingRef.current = {
+                ...unacknowledged.payload,
+                deliveryRetryCount: unacknowledged.retryCount + 1,
+              } as PendingOutgoing
+              unacknowledgedOutgoingRef.current = null
+              return
+            }
+
+            unacknowledgedOutgoingRef.current = null
+            lastSentOutgoingRef.current = null
+            pendingOutgoingRef.current = null
+          }
+
           // Don't show error cards here -- the WS client only fires
           // onError(CONNECTION_FAILED) after all retries are exhausted,
           // and the health-check gate there decides whether to show UI.
@@ -828,13 +932,13 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
     updateConversationTitle,
     getTransportFailure,
     rotateSocket,
+    acknowledgeOutgoingDelivery,
+    sendOutgoingPayload,
   ])
 
   /**
    * Initialize WebSocket client when conversation changes
    */
-  const currentConversationId = currentConversation?.id
-
   useEffect(() => {
     if (!currentConversationId || !autoConnect) return
 
@@ -878,6 +982,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
       }
       pendingOutgoingRef.current = null
       lastSentOutgoingRef.current = null
+      unacknowledgedOutgoingRef.current = null
       consecutiveAuthExpiredRef.current = 0
       pendingRotationRef.current = false
       currentThinkingStepIdRef.current = null
@@ -958,12 +1063,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
 
       // Helper to actually send the message
       const doSend = () => {
-        if (wsClientRef.current?.isConnected()) {
-          wsClientRef.current.sendMessage(content, dataSourcesForMessage)
-          // Remember the payload so a mid-workflow `auth_expired` can
-          // transparently re-issue it after the reconnect. Cleared on
-          // isFinal or any non-auth error.
-          lastSentOutgoingRef.current = outgoingPayload
+        if (sendOutgoingPayload(outgoingPayload)) {
           setLoading(false)
         } else {
           addErrorCard('connection.failed', 'WebSocket connection failed')
@@ -1022,6 +1122,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
       createCallbacks,
       refreshAuthBeforeReconnect,
       rotateSocket,
+      sendOutgoingPayload,
       authRequired,
       activeSocketTokenExpiresAt,
     ]
@@ -1071,16 +1172,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
       }
 
       const doSend = () => {
-        if (wsClientRef.current?.isConnected()) {
-          wsClientRef.current.sendInteractionResponse(
-            pendingInteraction.id,
-            pendingInteraction.parentId,
-            response
-          )
-          // Record the HITL payload so a follow-up `auth_expired` can
-          // transparently re-issue THIS response (not a stale chat
-          // payload that happened to be the previous `lastSentOutgoing`).
-          lastSentOutgoingRef.current = interactionPayload
+        if (sendOutgoingPayload(interactionPayload)) {
           setStreaming(true)
           setLoading(true)
         } else {
@@ -1120,6 +1212,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
       authRequired,
       activeSocketTokenExpiresAt,
       rotateSocket,
+      sendOutgoingPayload,
     ]
   )
 

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -720,7 +720,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         }
       },
 
-      onIntermediateStep: (content: NATIntermediateStepContent | string, status: string, parentId?: string) => {
+      onIntermediateStep: (content: NATIntermediateStepContent | string, status: string, _parentId?: string) => {
         // Same as onResponse: any backend-emitted frame on this socket
         // proves the rotated handshake is honoured. Reset the consecutive
         // auth_expired budget.
@@ -735,7 +735,11 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
           console.warn('Ignoring stale intermediate step -- not currently streaming')
           return
         }
-        acknowledgeOutgoingDelivery(parentId)
+        // This is the same signal that makes ChatThinking appear in the UI:
+        // after the streaming stale guard, any intermediate frame proves the
+        // backend received the outbound message even when NAT uses internal
+        // workflow parent IDs that do not match the user-message id.
+        clearUnacknowledgedOutgoing()
 
         // Legacy string-content path: synthesize a generic thinking step.
         if (typeof content === 'string') {


### PR DESCRIPTION
## Summary

This PR makes the WebSocket chat/HITL submit path more resilient to stale or half-open connections. In staging, the browser could report an open WebSocket, accept a prompt send, then close before any backend frame reached the UI, forcing the user to submit the prompt again. This change treats outbound sends as unacknowledged until the backend emits an accepted frame, then performs one bounded replay if the connection dies or produces no backend frame within the timeout window.

The goal is a pragmatic reliability fix, not a full transport refactor. WebSocket remains a live transport; this PR adds bounded delivery protection and clearer failure behavior for the current architecture.

## Changes

- Update `NATWebSocketClient.sendMessage()` and `sendInteractionResponse()` to return the outbound NAT message id only after `ws.send()` succeeds.
- Track outbound chat and HITL payloads in `useWebSocketChat` until the backend emits a frame proving the request reached the active workflow.
- Replay an unacknowledged payload once after an unexpected socket close before any backend frame arrives.
- Add a 7 second outbound acknowledgement timeout; on first timeout, rotate the socket and replay once, and on repeated timeout fail closed with a connection error.
- Treat accepted intermediate frames as delivery acknowledgement even when NAT uses internal workflow `parent_id`s. This matches the visible UI behavior: once the thinking row appears, the backend has responded.
- Scope replay buffers to the active conversation and clear them on auth failures, application errors, connection failures, and conversation cleanup to avoid cross-session replays.
- Add regression coverage for stale-send replay, ack timeout replay, repeated timeout failure, HITL outbound handling, and intermediate-frame acknowledgement.

## Testing

- `vitest run src/features/chat/hooks/use-websocket-chat.spec.ts -t "ack timeout"`
- `vitest run src/features/chat/hooks/use-websocket-chat.spec.ts`
- `vitest run src/adapters/api/websocket-client.spec.ts`
- Full UI Vitest run
- `tsc --noEmit`
- `eslint src --ext .ts,.tsx` with existing warnings only
- `next build` with existing CSS optimizer warnings only

## Notes

- This is intentionally bounded to one replay. Without a backend ACK protocol, replaying indefinitely could duplicate workflows if the backend accepted the original send but the response stream died.
- This does not make shallow WebSocket output durable or replayable after backend acceptance. A stronger long-term fix would move UI state toward explicit HTTP/job contracts or add backend ACK and event replay semantics.
- Deep research report streaming remains on the async job/SSE path after the WebSocket job-id handoff.
