### PR TITLE
Add AI-Q product-level skill evals (push-triggered, complementary to NVSkills CI)

### DIFF
--- a/.github/skill-eval/AGENTS.md
+++ b/.github/skill-eval/AGENTS.md
@@ -1,0 +1,24 @@
+# AI-Q Skills Eval Agent
+
+You are the AI-Q skills-eval coordinator. Your job is to run product-level evals for Agent Skills under `skills/`.
+
+## Workflow
+
+1. Find changed skill directories or, in manual mode, all product-eval specs under `skills/<skill>/evals/*-product.json`.
+2. Require each spec to define `skills`, `resources.platforms`, `env`, and `expects`.
+3. Require an adapter at `.github/skill-eval/adapters/<skill>/generate.py`.
+4. Generate datasets with the adapter. Do not edit skill source during an eval run.
+5. If Harbor execution is enabled, run one trial for each generated platform/mode dataset.
+6. Report deterministic verifier results and trace paths.
+
+## Hard Rules
+
+- Do not print API keys or copied environment values.
+- Do not invent deployment assumptions. If a live AI-Q server is required, use `AIQ_SERVER_URL` and the `aiq-deploy` skill.
+- Do not bake VSS profile names, VSS ports, Brev secure-link rules, or video-service checks into AI-Q adapters.
+- If an adapter or spec is missing, fail clearly with the missing path.
+- Keep eval data under `/tmp/aiq-skill-eval/`; do not commit generated datasets.
+
+## Current Scope
+
+The initial scope is `aiq-research` smoke validation against an existing AI-Q server. Add deeper chat or async-job lifecycle specs only when the eval environment has stable model/search keys and expected runtime cost is accepted.

--- a/.github/skill-eval/README.md
+++ b/.github/skill-eval/README.md
@@ -1,0 +1,108 @@
+# AI-Q Skill Eval
+
+This directory contains the initial AI-Q Agent Skill evaluation harness. It follows the same broad pattern as the VSS skill-eval work, but removes VSS-specific deployment profiles, video services, GPU assumptions, and Brev pool naming.
+
+The first supported skill is `aiq-research`, with specs under:
+
+```text
+skills/aiq-research/evals/*-product.json
+```
+
+## What It Does
+
+1. Finds Agent Skill product-eval specs under `skills/<skill>/evals/*-product.json`.
+2. Validates each spec has `skills`, `resources.platforms`, `env`, and ordered `expects`.
+3. Uses a matching adapter under `.github/skill-eval/adapters/<skill>/generate.py`.
+4. Generates Harbor-style task datasets under `/tmp/aiq-skill-eval/datasets`.
+5. Optionally runs Harbor against generated datasets when a live AI-Q server and agent credentials are available.
+
+The initial `aiq-research` profile is a smoke test for a live AI-Q server:
+
+- health check through `scripts/aiq.py health`
+- async agent listing through `scripts/aiq.py agents`
+
+It intentionally avoids model-generating `/chat` calls so the baseline eval can validate the skill wrapper without spending inference credits. Deeper research lifecycle specs should be added once the eval runner has stable API keys and runtime expectations.
+
+## Spec Format
+
+Each spec is JSON:
+
+```json
+{
+  "skills": ["aiq-research"],
+  "resources": {
+    "platforms": {
+      "local": {"modes": ["existing-server"]}
+    }
+  },
+  "env": "Live environment notes",
+  "expects": [
+    {
+      "query": "Instruction shown to the agent",
+      "checks": [
+        "trajectory_contains:scripts/aiq.py health",
+        "shell:curl -sf \"${AIQ_SERVER_URL:-http://localhost:8000}/health\" >/dev/null"
+      ]
+    }
+  ]
+}
+```
+
+Supported deterministic check prefixes:
+
+| Prefix | Behavior |
+|---|---|
+| `shell:` | Runs the shell command. Passes on exit code 0. |
+| `json_command:` | Runs the shell command and requires stdout to parse as JSON. |
+| `trajectory_contains:` | Searches Harbor agent logs for a substring. |
+| `trajectory_not_contains:` | Passes only when the substring is absent from Harbor agent logs. |
+
+## Generate Locally
+
+From the AI-Q repository root:
+
+```bash
+python3 .github/skill-eval/skills_eval_agent.py --all \
+  --output-dir /tmp/aiq-skill-eval/datasets
+```
+
+The generated dataset contains `instruction.md`, `task.toml`, `tests/test.sh`, verifier helpers, a copy of the skill under test, and `solution/solve.sh`.
+
+## Run With Harbor
+
+Harbor execution requires a runner where:
+
+- `AIQ_SERVER_URL` points to a running AI-Q server.
+- `uvx harbor` is available.
+- Agent credentials are available for the selected Harbor agent.
+- `AIQ_SKILL_EVAL_MAX_RETRIES` can tune Harbor retries and defaults to `1` to tolerate transient agent install failures.
+
+Claude Code is the default agent and uses Anthropic-compatible credentials:
+
+```bash
+export AIQ_SERVER_URL=http://host.docker.internal:8000
+export ANTHROPIC_BASE_URL=...
+export ANTHROPIC_API_KEY=...
+export ANTHROPIC_MODEL=...
+
+python3 .github/skill-eval/skills_eval_agent.py --all --run-harbor
+```
+
+For local Docker Desktop runs, `host.docker.internal` lets the Harbor task container reach an AI-Q server running on the host. If AI-Q is running inside the same network as Harbor, use that reachable URL instead.
+
+Codex is also supported. To use the local Codex login without printing or copying tokens into commands, opt into Harbor's `auth.json` upload path:
+
+```bash
+export AIQ_SERVER_URL=http://host.docker.internal:8000
+export AIQ_SKILL_EVAL_AGENT=codex
+export AIQ_SKILL_EVAL_MODEL=gpt-5.2
+export CODEX_FORCE_AUTH_JSON=1
+
+python3 .github/skill-eval/skills_eval_agent.py --all --run-harbor
+```
+
+If the server is not already running, use the `aiq-deploy` skill first. The generated tasks include both `aiq-research` and `aiq-deploy` under `/skills` when the deploy skill is present in this repository.
+
+## CI
+
+`.github/workflows/skills-eval.yml` validates spec and adapter generation when Agent Skill or skill-eval files change. Full Harbor execution is available through manual dispatch on a self-hosted runner once an AI-Q eval runner is provisioned.

--- a/.github/skill-eval/adapters/aiq-research/generate.py
+++ b/.github/skill-eval/adapters/aiq-research/generate.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Generate Harbor tasks for the aiq-research skill."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+from pathlib import Path
+from string import Template
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+VERIFIER = Path(__file__).resolve().parents[2] / "verifiers" / "aiq_checks.py"
+DEFAULT_SERVER_URL = "http://localhost:8000"
+PREAMBLE = (
+    "You are running inside a non-interactive evaluation harness. "
+    "Use the installed AI-Q Agent Skills autonomously. Do not ask the user "
+    "to run commands that you can run yourself."
+)
+
+PLATFORMS = {
+    "local": {
+        "short_name": "local",
+        "description": "Runner-local or externally reachable AI-Q server",
+    }
+}
+
+
+def _copytree(src: Path, dst: Path) -> None:
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst)
+
+
+def _render(value: str, *, platform: str, mode: str, repo_root: Path) -> str:
+    rendered = value
+    server_url = os.environ.get("AIQ_SERVER_URL", DEFAULT_SERVER_URL)
+    replacements = {
+        "{{platform}}": platform,
+        "{{mode}}": mode,
+        "{{repo_root}}": str(repo_root),
+        "{{aiq_server_url}}": server_url,
+    }
+    for key, replacement in replacements.items():
+        rendered = rendered.replace(key, replacement)
+    return Template(rendered).safe_substitute(
+        platform=platform,
+        mode=mode,
+        repo_root=str(repo_root),
+        aiq_server_url=server_url,
+    )
+
+
+def _test_script(spec_name: str, step: int) -> str:
+    return (
+        "#!/bin/bash\n"
+        "set -uo pipefail\n"
+        'TEST_DIR="$(cd "$(dirname "$0")" && pwd)"\n'
+        'LOCAL_SKILLS_DIR="$(cd "$TEST_DIR/.." && pwd)/skills"\n'
+        'if [ -d "$LOCAL_SKILLS_DIR" ]; then\n'
+        '  export AIQ_EVAL_SKILLS_DIR="${AIQ_EVAL_SKILLS_DIR:-$LOCAL_SKILLS_DIR}"\n'
+        "fi\n"
+        f'python3 "$TEST_DIR/aiq_checks.py" --spec "$TEST_DIR/{spec_name}" --step {step}\n'
+        "exit 0\n"
+    )
+
+
+def _solution_script() -> str:
+    return "#!/bin/bash\nset -euo pipefail\npython3 /skills/aiq-research/scripts/aiq.py health\n"
+
+
+def _environment_compose() -> str:
+    return (
+        "services:\n"
+        "  main:\n"
+        "    extra_hosts:\n"
+        '      - "host.docker.internal:host-gateway"\n'
+        "    environment:\n"
+        "      AIQ_SERVER_URL: ${AIQ_SERVER_URL}\n"
+        "    volumes:\n"
+        "      - type: bind\n"
+        "        source: ${CONTEXT_DIR}/../skills\n"
+        "        target: /skills\n"
+        "        read_only: true\n"
+    )
+
+
+def _task_toml(skill: str, spec_stem: str, platform: str, mode: str, step: int, total_steps: int) -> str:
+    platform_short = PLATFORMS[platform]["short_name"]
+    step_suffix = f"-step-{step}" if total_steps > 1 else ""
+    server_url = os.environ.get("AIQ_SERVER_URL", DEFAULT_SERVER_URL)
+    return "\n".join(
+        [
+            "[task]",
+            f'name = "nvidia-aiq/{skill}-{spec_stem}-{platform_short}-{mode}{step_suffix}"',
+            f'description = "{skill} {spec_stem} eval on {platform}/{mode} step {step} of {total_steps}"',
+            f'keywords = ["aiq", "{skill}", "{spec_stem}", "{platform}", "{mode}"]',
+            "",
+            "[environment]",
+            'skills_dir = "/skills"',
+            "",
+            "[environment.env]",
+            f'AIQ_SERVER_URL = "{server_url}"',
+            "",
+            "[verifier.env]",
+            f'AIQ_SERVER_URL = "{server_url}"',
+            "",
+            "[metadata]",
+            f'skill = "{skill}"',
+            f'spec = "{spec_stem}"',
+            f'platform = "{platform}"',
+            f'mode = "{mode}"',
+            f"step = {step}",
+            f"total_steps = {total_steps}",
+            "",
+        ]
+    )
+
+
+def generate(spec_path: Path, skill_dir: Path, output_dir: Path, repo_root: Path) -> list[Path]:
+    spec = json.loads(spec_path.read_text())
+    skill = skill_dir.name
+    spec_stem = spec_path.stem
+    expects = spec.get("expects") or []
+    if not expects:
+        raise ValueError(f"{spec_path} has no expects entries")
+
+    generated: list[Path] = []
+    platforms = spec.get("resources", {}).get("platforms", {})
+    for platform, platform_cfg in platforms.items():
+        if platform not in PLATFORMS:
+            raise ValueError(f"unsupported platform {platform!r}; supported: {sorted(PLATFORMS)}")
+        for mode in platform_cfg.get("modes", []):
+            mode_slug = mode.lower().replace("_", "-")
+            base_dir = output_dir / spec_stem / f"{PLATFORMS[platform]['short_name']}-{mode_slug}"
+            for idx, expect in enumerate(expects, start=1):
+                step_dir = base_dir / f"step-{idx}" if len(expects) > 1 else base_dir
+                tests_dir = step_dir / "tests"
+                solution_dir = step_dir / "solution"
+                skills_dir = step_dir / "skills"
+                env_dir = step_dir / "environment"
+                tests_dir.mkdir(parents=True, exist_ok=True)
+                solution_dir.mkdir(parents=True, exist_ok=True)
+                skills_dir.mkdir(parents=True, exist_ok=True)
+                env_dir.mkdir(parents=True, exist_ok=True)
+
+                instruction = "\n".join(
+                    [
+                        PREAMBLE,
+                        "",
+                        f"AI-Q server URL: `{os.environ.get('AIQ_SERVER_URL', DEFAULT_SERVER_URL)}`.",
+                        "Use the `/aiq-research` skill for this task.",
+                        "If the server is unavailable and `/aiq-deploy` is installed, "
+                        "use it to start or verify AI-Q first.",
+                        "",
+                        f"## Query {idx} of {len(expects)}",
+                        "",
+                        _render(expect.get("query", ""), platform=platform, mode=mode, repo_root=repo_root),
+                        "",
+                        "## Environment Notes",
+                        "",
+                        _render(spec.get("env", ""), platform=platform, mode=mode, repo_root=repo_root),
+                        "",
+                    ]
+                )
+                (step_dir / "instruction.md").write_text(instruction + "\n")
+                (step_dir / "task.toml").write_text(
+                    _task_toml(skill, spec_stem, platform, mode_slug, idx, len(expects))
+                )
+                (env_dir / "Dockerfile").write_text("FROM python:3.12-slim\n")
+                (env_dir / "docker-compose.yaml").write_text(_environment_compose())
+                (tests_dir / spec_path.name).write_text(json.dumps(spec, indent=2) + "\n")
+                shutil.copy2(VERIFIER, tests_dir / "aiq_checks.py")
+                test_sh = tests_dir / "test.sh"
+                test_sh.write_text(_test_script(spec_path.name, idx))
+                test_sh.chmod(0o755)
+                solve_sh = solution_dir / "solve.sh"
+                solve_sh.write_text(_solution_script())
+                solve_sh.chmod(0o755)
+
+                _copytree(skill_dir, skills_dir / skill)
+                deploy_skill = repo_root / "skills" / "aiq-deploy"
+                if deploy_skill.exists():
+                    _copytree(deploy_skill, skills_dir / "aiq-deploy")
+            generated.append(base_dir)
+    return generated
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--skill-dir", required=True)
+    parser.add_argument("--spec", required=True)
+    parser.add_argument("--repo-root", default=str(REPO_ROOT))
+    args = parser.parse_args()
+
+    generated = generate(
+        spec_path=Path(args.spec).resolve(),
+        skill_dir=Path(args.skill_dir).resolve(),
+        output_dir=Path(args.output_dir).resolve(),
+        repo_root=Path(args.repo_root).resolve(),
+    )
+    print(json.dumps({"generated": [str(path) for path in generated]}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skill-eval/adapters/aiq-research/generate.py
+++ b/.github/skill-eval/adapters/aiq-research/generate.py
@@ -63,8 +63,10 @@ def _test_script(spec_name: str, step: int) -> str:
         'if [ -d "$LOCAL_SKILLS_DIR" ]; then\n'
         '  export AIQ_EVAL_SKILLS_DIR="${AIQ_EVAL_SKILLS_DIR:-$LOCAL_SKILLS_DIR}"\n'
         "fi\n"
+        "# Exit status propagates from the verifier: 0 means it wrote reward.txt\n"
+        "# (for any reward); non-zero means it crashed, which Harbor must see as\n"
+        "# an error rather than a silent clean exit with no reward.txt.\n"
         f'python3 "$TEST_DIR/aiq_checks.py" --spec "$TEST_DIR/{spec_name}" --step {step}\n'
-        "exit 0\n"
     )
 
 

--- a/.github/skill-eval/adapters/aiq-research/generate.py
+++ b/.github/skill-eval/adapters/aiq-research/generate.py
@@ -57,7 +57,7 @@ def _render(value: str, *, platform: str, mode: str, repo_root: Path) -> str:
 def _test_script(spec_name: str, step: int) -> str:
     return (
         "#!/bin/bash\n"
-        "set -uo pipefail\n"
+        "set -euo pipefail\n"
         'TEST_DIR="$(cd "$(dirname "$0")" && pwd)"\n'
         'LOCAL_SKILLS_DIR="$(cd "$TEST_DIR/.." && pwd)/skills"\n'
         'if [ -d "$LOCAL_SKILLS_DIR" ]; then\n'

--- a/.github/skill-eval/skills_eval_agent.py
+++ b/.github/skill-eval/skills_eval_agent.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""AI-Q skill-eval coordinator.
+
+This script validates Agent Skill eval specs, generates Harbor-style datasets,
+and can optionally run Harbor when the target environment is available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = Path(os.environ.get("AIQ_SKILL_EVAL_OUTPUT_DIR", "/tmp/aiq-skill-eval/datasets"))
+REQUIRED_SPEC_KEYS = ("skills", "resources", "env", "expects")
+
+# Argv elements whose key portion ends in any of these suffixes are redacted in
+# printed commands so credentials passed via `harbor --ae KEY=VALUE` (and similar
+# inline KEY=VALUE forms) do not leak into stdout or captured workflow logs.
+# The real values are still passed to subprocess.run unchanged.
+_SECRET_KEY_SUFFIXES = ("_KEY", "_TOKEN", "_SECRET", "_PASSWORD")
+
+
+def _is_secret_key(name: str) -> bool:
+    upper = name.upper()
+    return any(upper.endswith(suffix) for suffix in _SECRET_KEY_SUFFIXES)
+
+
+_SUFFIX_REVEAL_CHARS = 4
+_SUFFIX_REVEAL_MIN_VALUE_LEN = 9
+
+
+def _mask_value(value: str) -> str:
+    """Mask a secret value, optionally revealing a short suffix for identification.
+
+    Short values are fully masked (`***`); longer values keep the last few
+    characters to help operators confirm which key was loaded without
+    exposing meaningful entropy. The reveal length and minimum value
+    length are constants so they can be tuned in one place.
+    """
+    if len(value) < _SUFFIX_REVEAL_MIN_VALUE_LEN:
+        return "***"
+    return f"***{value[-_SUFFIX_REVEAL_CHARS:]}"
+
+
+def _mask_kv(arg: str) -> str:
+    """Return KEY=***xxxx if KEY looks secret-shaped, else `arg` unchanged."""
+    if "=" not in arg:
+        return arg
+    key, value = arg.split("=", 1)
+    return f"{key}={_mask_value(value)}" if _is_secret_key(key) else arg
+
+
+def _redact_for_log(cmd: list[str]) -> list[str]:
+    """Return a copy of `cmd` with secret-shaped values masked for safe printing."""
+    redacted: list[str] = []
+    iterator = iter(cmd)
+    for arg in iterator:
+        if arg == "--ae":
+            # The next argv element is the KEY=VALUE pair; mask its value if secret-shaped.
+            redacted.append(arg)
+            nxt = next(iterator, None)
+            if nxt is not None:
+                redacted.append(_mask_kv(nxt))
+            continue
+        # Inline KEY=VALUE arguments (e.g. exported through `KEY=VAL command` patterns
+        # that leak into argv) are also masked defensively.
+        redacted.append(_mask_kv(arg))
+    return redacted
+
+
+def _run(cmd: list[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    print("+ " + " ".join(_redact_for_log(cmd)), flush=True)
+    return subprocess.run(cmd, cwd=cwd, text=True, check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+
+def _git_changed_files(base: str) -> list[str]:
+    result = _run(["git", "diff", "--name-only", f"{base}...HEAD"])
+    if result.returncode != 0:
+        print(result.stdout, file=sys.stderr)
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _changed_skill_names(base: str | None) -> set[str]:
+    if not base:
+        return set()
+    changed: set[str] = set()
+    for path in _git_changed_files(base):
+        parts = Path(path).parts
+        if len(parts) >= 2 and parts[0] == "skills":
+            changed.add(parts[1])
+    return changed
+
+
+def _discover_specs(*, all_specs: bool, base: str | None) -> list[Path]:
+    changed = _changed_skill_names(base)
+    specs = sorted(REPO_ROOT.glob("skills/*/evals/*-product.json"))
+    if all_specs or not changed:
+        return specs
+    return [spec for spec in specs if spec.parts[-3] in changed]
+
+
+def _validate_spec(spec_path: Path) -> dict[str, Any]:
+    spec = json.loads(spec_path.read_text())
+    missing = [key for key in REQUIRED_SPEC_KEYS if key not in spec]
+    if missing:
+        raise ValueError(f"{spec_path} missing required keys: {', '.join(missing)}")
+    if not isinstance(spec["skills"], list) or not spec["skills"]:
+        raise ValueError(f"{spec_path} must define non-empty skills list")
+    platforms = spec.get("resources", {}).get("platforms")
+    if not isinstance(platforms, dict) or not platforms:
+        raise ValueError(f"{spec_path} must define resources.platforms")
+    if not isinstance(spec["expects"], list) or not spec["expects"]:
+        raise ValueError(f"{spec_path} must define non-empty expects list")
+    for idx, expect in enumerate(spec["expects"], start=1):
+        if "query" not in expect or "checks" not in expect:
+            raise ValueError(f"{spec_path} expects[{idx}] must define query and checks")
+    return spec
+
+
+def _adapter_for(skill: str) -> Path:
+    return REPO_ROOT / ".github" / "skill-eval" / "adapters" / skill / "generate.py"
+
+
+def _task_roots(dataset_root: Path) -> list[Path]:
+    roots: list[Path] = []
+    for task_toml in dataset_root.rglob("task.toml"):
+        parent = task_toml.parent
+        if parent.name.startswith("step-"):
+            roots.append(parent.parent)
+        else:
+            roots.append(parent)
+    return sorted(set(roots))
+
+
+def _run_harbor(task_root: Path) -> int:
+    agent = os.environ.get("AIQ_SKILL_EVAL_AGENT", "claude-code")
+    model = os.environ.get("AIQ_SKILL_EVAL_MODEL") or os.environ.get("ANTHROPIC_MODEL")
+    max_retries = os.environ.get("AIQ_SKILL_EVAL_MAX_RETRIES", "1")
+    if agent != "oracle" and not model:
+        print(
+            "BLOCKED: AIQ_SKILL_EVAL_MODEL or ANTHROPIC_MODEL is required for Harbor execution",
+            file=sys.stderr,
+        )
+        return 2
+
+    cmd = [
+        "uvx",
+        "harbor",
+        "run",
+        "-p",
+        str(task_root),
+        "-a",
+        agent,
+        "--max-retries",
+        max_retries,
+        "-n",
+        "1",
+        "--yes",
+        "-o",
+        os.environ.get("AIQ_SKILL_EVAL_RESULTS_DIR", "/tmp/aiq-skill-eval/results"),
+    ]
+    if model:
+        cmd.extend(["--model", model])
+    if agent == "claude-code":
+        cmd.extend(["--ae", "CLAUDE_CODE_DISABLE_THINKING=1"])
+        for key in ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"):
+            value = os.environ.get(key)
+            if value:
+                cmd.extend(["--ae", f"{key}={value}"])
+    if agent == "codex":
+        for key in ("OPENAI_API_KEY", "CODEX_FORCE_AUTH_JSON", "CODEX_AUTH_JSON_PATH"):
+            value = os.environ.get(key)
+            if value:
+                cmd.extend(["--ae", f"{key}={value}"])
+    result = _run(cmd)
+    print(result.stdout)
+    return result.returncode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--all", action="store_true", help="Generate every checked-in spec")
+    parser.add_argument("--base", default=os.environ.get("PR_BASE") or os.environ.get("GITHUB_BASE_REF"))
+    parser.add_argument("--output-dir", default=str(DEFAULT_OUTPUT_DIR))
+    parser.add_argument("--run-harbor", action="store_true", help="Run Harbor after generating datasets")
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    specs = _discover_specs(all_specs=args.all, base=args.base)
+    if not specs:
+        print("BLOCKED: no AI-Q skill eval specs found")
+        return 0
+
+    generated_roots: list[Path] = []
+    for spec_path in specs:
+        spec = _validate_spec(spec_path)
+        skill = spec["skills"][0]
+        skill_dir = REPO_ROOT / "skills" / skill
+        adapter = _adapter_for(skill)
+        if not skill_dir.exists():
+            raise FileNotFoundError(f"skill directory not found: {skill_dir}")
+        if not adapter.exists():
+            raise FileNotFoundError(f"adapter not found: {adapter}")
+
+        result = _run(
+            [
+                sys.executable,
+                str(adapter),
+                "--output-dir",
+                str(output_dir / skill),
+                "--skill-dir",
+                str(skill_dir),
+                "--spec",
+                str(spec_path),
+                "--repo-root",
+                str(REPO_ROOT),
+            ]
+        )
+        print(result.stdout)
+        if result.returncode != 0:
+            return result.returncode
+        generated_roots.extend(_task_roots(output_dir / skill / spec_path.stem))
+
+    summary = {
+        "specs": [str(path.relative_to(REPO_ROOT)) for path in specs],
+        "datasets": [str(path) for path in sorted(set(generated_roots))],
+    }
+    print(json.dumps(summary, indent=2))
+
+    if args.run_harbor:
+        for task_root in sorted(set(generated_roots)):
+            rc = _run_harbor(task_root)
+            if rc != 0:
+                return rc
+
+    print(f"DONE: generated {len(set(generated_roots))} AI-Q skill-eval dataset(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skill-eval/skills_eval_agent.py
+++ b/.github/skill-eval/skills_eval_agent.py
@@ -14,6 +14,7 @@ import json
 import os
 import subprocess
 import sys
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -121,8 +122,8 @@ def _validate_spec(spec_path: Path) -> dict[str, Any]:
     if not isinstance(spec["expects"], list) or not spec["expects"]:
         raise ValueError(f"{spec_path} must define non-empty expects list")
     for idx, expect in enumerate(spec["expects"], start=1):
-        if "query" not in expect or "checks" not in expect:
-            raise ValueError(f"{spec_path} expects[{idx}] must define query and checks")
+        if "query" not in expect or not expect.get("checks"):
+            raise ValueError(f"{spec_path} expects[{idx}] must define query and non-empty checks")
     return spec
 
 
@@ -141,7 +142,7 @@ def _task_roots(dataset_root: Path) -> list[Path]:
     return sorted(set(roots))
 
 
-def _run_harbor(task_root: Path) -> int:
+def _run_harbor(task_root: Path, out_dir: Path) -> tuple[int, Path | None]:
     agent = os.environ.get("AIQ_SKILL_EVAL_AGENT", "claude-code")
     model = os.environ.get("AIQ_SKILL_EVAL_MODEL") or os.environ.get("ANTHROPIC_MODEL")
     max_retries = os.environ.get("AIQ_SKILL_EVAL_MAX_RETRIES", "1")
@@ -150,7 +151,7 @@ def _run_harbor(task_root: Path) -> int:
             "BLOCKED: AIQ_SKILL_EVAL_MODEL or ANTHROPIC_MODEL is required for Harbor execution",
             file=sys.stderr,
         )
-        return 2
+        return 2, None
 
     cmd = [
         "uvx",
@@ -166,7 +167,7 @@ def _run_harbor(task_root: Path) -> int:
         "1",
         "--yes",
         "-o",
-        os.environ.get("AIQ_SKILL_EVAL_RESULTS_DIR", "/tmp/aiq-skill-eval/results"),
+        str(out_dir),
     ]
     if model:
         cmd.extend(["--model", model])
@@ -183,7 +184,44 @@ def _run_harbor(task_root: Path) -> int:
                 cmd.extend(["--ae", f"{key}={value}"])
     result = _run(cmd)
     print(result.stdout)
-    return result.returncode
+    # harbor writes <out_dir>/<timestamp>/result.json; out_dir is unique per run,
+    # so read the result directly from disk instead of scraping stdout.
+    candidates = sorted(out_dir.glob("*/result.json"))
+    return result.returncode, (candidates[-1] if candidates else None)
+
+
+def _gate(result_paths: list[Path | None], threshold: float) -> tuple[bool, list[str]]:
+    """Aggregate a pass/fail verdict across every trial of every spec/skill in the run.
+
+    Reads each Harbor job-level result.json. A trial that errored (exception)
+    ALWAYS fails the run. A trial whose reward is below `threshold` fails the run
+    unless `threshold <= 0` (report-only: every reward >= 0 passes). Returns
+    (ok, summary_lines) where ok=False means the job should exit non-zero.
+    """
+    ok = True
+    exceptions = 0
+    lines: list[str] = []
+    for path in result_paths:
+        if path is None or not path.exists():
+            ok = False
+            lines.append("  MISSING result.json (harbor produced no parseable result) -> FAIL")
+            continue
+        stats = json.loads(path.read_text()).get("stats", {})
+        exceptions += int(stats.get("n_errored_trials", 0) or 0)
+        for name, ev in (stats.get("evals") or {}).items():
+            buckets = ((ev or {}).get("reward_stats") or {}).get("reward") or {}
+            for reward_str, trials in buckets.items():
+                reward = float(reward_str)
+                for trial in trials:
+                    below = threshold > 0 and reward < threshold
+                    if below:
+                        ok = False
+                    mark = f"BELOW {threshold}" if below else "ok"
+                    lines.append(f"  {name} {trial}: reward {reward} [{mark}]")
+    if exceptions > 0:
+        ok = False
+        lines.append(f"  exceptions: {exceptions} errored trial(s) -> FAIL")
+    return ok, lines
 
 
 def main() -> int:
@@ -239,10 +277,40 @@ def main() -> int:
     print(json.dumps(summary, indent=2))
 
     if args.run_harbor:
-        for task_root in sorted(set(generated_roots)):
-            rc = _run_harbor(task_root)
+        results_root = Path(os.environ.get("AIQ_SKILL_EVAL_RESULTS_DIR", "/tmp/aiq-skill-eval/results"))
+        # Isolate this job's results so the gate can never read a previous job's
+        # output on the long-lived self-hosted runner (the results root persists
+        # between jobs). Keyed by GitHub run id + attempt in CI; random locally.
+        run_id = os.environ.get("GITHUB_RUN_ID", "")
+        attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "")
+        job_key = "-".join(p for p in (run_id, attempt) if p) or f"local-{uuid.uuid4().hex[:12]}"
+        job_results_root = results_root / job_key
+        result_paths: list[Path | None] = []
+        for index, task_root in enumerate(sorted(set(generated_roots))):
+            # Unique output dir per run so the result.json location is deterministic
+            # (harbor writes <out_dir>/<timestamp>/result.json).
+            out_dir = job_results_root / f"run-{index:02d}"
+            out_dir.mkdir(parents=True, exist_ok=True)
+            rc, results_path = _run_harbor(task_root, out_dir)
             if rc != 0:
-                return rc
+                return rc  # infrastructure failure (Harbor itself errored)
+            result_paths.append(results_path)
+
+        # Post-Harbor verdict. Harbor exits 0 even at low reward, so gate here so a
+        # green check actually means the eval passed (catches PR regressions).
+        threshold = float(os.environ.get("AIQ_SKILL_EVAL_REWARD_THRESHOLD", "1.0"))
+        ok, summary = _gate(result_paths, threshold)
+        gate_desc = "report-only" if threshold <= 0 else f"threshold {threshold}"
+        print(f"=== Skill-eval verdict ({gate_desc}) ===")
+        for line in summary:
+            print(line)
+        if not ok:
+            print(
+                "EVAL FAILED: a trial errored or scored below threshold "
+                "(set AIQ_SKILL_EVAL_REWARD_THRESHOLD=0 for report-only)"
+            )
+            return 1
+        print("EVAL PASSED")
 
     print(f"DONE: generated {len(set(generated_roots))} AI-Q skill-eval dataset(s)")
     return 0

--- a/.github/skill-eval/verifiers/aiq_checks.py
+++ b/.github/skill-eval/verifiers/aiq_checks.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic verifier for AI-Q skill eval tasks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+TRAJECTORY_CANDIDATES = (
+    "/logs/agent/trajectory.jsonl",
+    "/logs/agent/trajectory.json",
+    "/logs/agent/claude-code.txt",
+    "/logs/agent/agent.log",
+)
+
+
+def locate_trajectory() -> Path | None:
+    override = os.environ.get("AIQ_EVAL_TRAJECTORY")
+    if override:
+        path = Path(override)
+        return path if path.exists() else None
+    for candidate in TRAJECTORY_CANDIDATES:
+        path = Path(candidate)
+        if path.exists():
+            return path
+    return None
+
+
+def read_trajectory() -> str:
+    path = locate_trajectory()
+    if path is None:
+        return ""
+    return path.read_text(errors="replace")
+
+
+def run_shell(command: str) -> tuple[bool, str]:
+    skills_dir = os.environ.get("AIQ_EVAL_SKILLS_DIR")
+    if skills_dir:
+        command = command.replace("/skills/", f"{skills_dir.rstrip('/')}/")
+    result = subprocess.run(
+        command,
+        shell=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=int(os.environ.get("AIQ_EVAL_CHECK_TIMEOUT", "120")),
+        check=False,
+    )
+    output = (result.stdout or "").strip()
+    return result.returncode == 0, output[-4000:]
+
+
+def run_json_command(command: str) -> tuple[bool, str]:
+    passed, output = run_shell(command)
+    if not passed:
+        return False, output
+    try:
+        json.loads(output or "{}")
+    except json.JSONDecodeError as exc:
+        return False, f"stdout was not valid JSON: {exc}: {output[:1000]}"
+    return True, output[:1000]
+
+
+def evaluate_check(check: str, trajectory: str) -> dict[str, Any]:
+    if check.startswith("shell:"):
+        command = check.removeprefix("shell:").strip()
+        passed, output = run_shell(command)
+        return {"check": check, "pass": passed, "route": "shell", "evidence": output}
+
+    if check.startswith("json_command:"):
+        command = check.removeprefix("json_command:").strip()
+        passed, output = run_json_command(command)
+        return {"check": check, "pass": passed, "route": "json_command", "evidence": output}
+
+    if check.startswith("trajectory_contains:"):
+        needle = check.removeprefix("trajectory_contains:").strip()
+        passed = needle in trajectory
+        return {
+            "check": check,
+            "pass": passed,
+            "route": "trajectory_contains",
+            "evidence": needle if passed else "substring not found",
+        }
+
+    if check.startswith("trajectory_not_contains:"):
+        needle = check.removeprefix("trajectory_not_contains:").strip()
+        passed = needle not in trajectory
+        return {
+            "check": check,
+            "pass": passed,
+            "route": "trajectory_not_contains",
+            "evidence": "absent" if passed else needle,
+        }
+
+    return {
+        "check": check,
+        "pass": False,
+        "route": "unsupported",
+        "evidence": "check must start with shell:, json_command:, trajectory_contains:, or trajectory_not_contains:",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--spec", required=True)
+    parser.add_argument("--step", type=int, required=True)
+    args = parser.parse_args()
+
+    spec = json.loads(Path(args.spec).read_text())
+    expects = spec.get("expects") or []
+    if args.step < 1 or args.step > len(expects):
+        raise SystemExit(f"step {args.step} out of range for {len(expects)} expects")
+
+    checks = expects[args.step - 1].get("checks") or []
+    trajectory = read_trajectory()
+    results = [evaluate_check(check, trajectory) for check in checks]
+    passed = sum(1 for result in results if result["pass"])
+    total = len(results)
+    reward = 1.0 if total == 0 else passed / total
+
+    log_dir = Path(os.environ.get("AIQ_EVAL_VERIFIER_LOG_DIR", "/logs/verifier"))
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "reward.txt").write_text(f"{reward:.6f}\n")
+    (log_dir / "aiq-checks.json").write_text(json.dumps(results, indent=2) + "\n")
+
+    for result in results:
+        status = "PASS" if result["pass"] else "FAIL"
+        print(f"{status}: {result['check']}")
+        if result["evidence"]:
+            print(f"  {result['evidence']}")
+    print(f"=== Results: {passed} passed, {total - passed} failed (of {total}) ===")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skill-eval/verifiers/aiq_checks.py
+++ b/.github/skill-eval/verifiers/aiq_checks.py
@@ -124,7 +124,9 @@ def main() -> int:
     results = [evaluate_check(check, trajectory) for check in checks]
     passed = sum(1 for result in results if result["pass"])
     total = len(results)
-    reward = 1.0 if total == 0 else passed / total
+    # A step with no checks verifies nothing; score it 0.0 rather than a silent
+    # perfect 1.0 (validation also rejects empty `checks`, this is defense-in-depth).
+    reward = 0.0 if total == 0 else passed / total
 
     log_dir = Path(os.environ.get("AIQ_EVAL_VERIFIER_LOG_DIR", "/logs/verifier"))
     log_dir.mkdir(parents=True, exist_ok=True)

--- a/.github/skill-eval/verifiers/aiq_checks.py
+++ b/.github/skill-eval/verifiers/aiq_checks.py
@@ -60,8 +60,10 @@ def run_json_command(command: str) -> tuple[bool, str]:
     passed, output = run_shell(command)
     if not passed:
         return False, output
+    if not output:
+        return False, "stdout was empty; expected JSON output"
     try:
-        json.loads(output or "{}")
+        json.loads(output)
     except json.JSONDecodeError as exc:
         return False, f"stdout was not valid JSON: {exc}: {output[:1000]}"
     return True, output[:1000]

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -274,7 +274,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: aiq-skill-eval-results-${{ github.run_id }}
-          path: /tmp/aiq-skill-eval/results
+          # Only this job's results (skills_eval_agent.py isolates output under
+          # <results>/<run_id>-<attempt>/), not the shared root's accumulated history.
+          path: /tmp/aiq-skill-eval/results/${{ github.run_id }}-${{ github.run_attempt }}
           if-no-files-found: ignore
           retention-days: 7
 

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# AI-Q skill eval. Two jobs on the aiq-eval self-hosted runner:
+#   - generate-datasets: spec validation, no credentials.
+#   - harbor-eval:       full Harbor trial; runs only when run_harbor=true.
+# Testing phase: manual dispatch only, gated to the working branch.
+# When ready to enable PR gating, see the commented `pull_request:` block.
+# Credentials and runtime knobs live in a runner-side .env;
+# see README-aiq-runner-bootstrap.md.
+
+name: Skills Eval
+
+on:
+  # Testing phase: manual dispatch only, restricted to the working branch.
+  # When ready to gate PRs, re-enable the `pull_request:` trigger below.
+  # pull_request:
+  #   branches: [develop, "release/**"]
+  #   paths:
+  #     - "skills/**"
+  #     - ".github/skill-eval/**"
+  #     - ".github/workflows/skills-eval.yml"
+  #     - "deploy/**"
+  workflow_dispatch:
+    inputs:
+      run_harbor:
+        description: "Run Harbor trials on the self-hosted aiq-eval runner"
+        required: false
+        default: false
+        type: boolean
+      agent:
+        description: "Harbor agent to run"
+        required: false
+        default: "claude-code"
+        type: choice
+        options:
+          - claude-code
+          - codex
+      model:
+        description: "Override AIQ_SKILL_EVAL_MODEL for this dispatch (blank = use runner .env default)"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: aiq-skills-eval-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  RUNNER_ENV_FILE: /home/ubuntu/aiq-eval/.env
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # generate-datasets: spec validation + Harbor task-root materialization.
+  # Cheap. No credentials.
+  # ---------------------------------------------------------------------------
+  generate-datasets:
+    name: Validate skill-eval specs
+    # Testing-phase guard: only run on the working branch.
+    if: github.ref == 'refs/heads/feat/product-evals'
+    runs-on: [self-hosted, aiq-eval]
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Generate datasets
+        run: |
+          python3 .github/skill-eval/skills_eval_agent.py --all \
+            --output-dir /tmp/aiq-skill-eval/datasets
+
+      - name: Upload generated datasets
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: aiq-skill-eval-datasets-${{ github.run_id }}
+          path: /tmp/aiq-skill-eval/datasets
+          if-no-files-found: error
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # harbor-eval: bring up AI-Q from PR HEAD, run Harbor trials, tear down.
+  # Gated on workflow_dispatch + inputs.run_harbor=true.
+  # ---------------------------------------------------------------------------
+  harbor-eval:
+    name: Run Harbor skill eval
+    # Testing-phase guard: only run on the working branch, only when the
+    # dispatcher explicitly sets run_harbor=true.
+    if: |
+      github.ref == 'refs/heads/feat/product-evals' &&
+      inputs.run_harbor
+    runs-on: [self-hosted, aiq-eval]
+    timeout-minutes: 60
+    needs: generate-datasets
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Verify runner .env exists
+        run: |
+          if [ ! -r "$RUNNER_ENV_FILE" ]; then
+            echo "::error::Runner credential file missing or unreadable at $RUNNER_ENV_FILE"
+            echo "See README-aiq-runner-bootstrap.md for the one-time setup."
+            exit 1
+          fi
+          # Print only the *names* of keys present, never values.
+          echo "Loaded credential keys (names only):"
+          grep -oE '^[A-Z_][A-Z0-9_]*=' "$RUNNER_ENV_FILE" | sed 's/=$//' | sort
+
+      - name: Materialize deploy/.env from runner credentials
+        run: |
+          # docker-compose.yaml has `env_file: [../.env]` paths that resolve to
+          # aiq/deploy/.env. That file is gitignored. Copy the runner's
+          # canonical .env into place for the duration of this job.
+          install -m 0600 "$RUNNER_ENV_FILE" deploy/.env
+
+      - name: Bring up AI-Q stack from PR HEAD
+        working-directory: deploy/compose
+        run: |
+          set -a
+          # shellcheck disable=SC1090
+          source "$RUNNER_ENV_FILE"
+          set +a
+          # Mirror local recipe: build from source, tag with run id so
+          # concurrent runs (if any) don't collide.
+          export BACKEND_IMAGE="aiq-agent:ci-${{ github.run_id }}"
+          docker compose --env-file ../.env -f docker-compose.yaml up -d --build aiq-agent postgres
+
+      - name: Wait for AI-Q /health
+        run: |
+          # Poll up to 5 minutes. AI-Q cold start on the runner is typically
+          # <2 min; 5 min gives margin for the postgres init + first build.
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:8000/health >/dev/null 2>&1; then
+              echo "AI-Q healthy after ${i} x 5s"
+              curl -s http://localhost:8000/health | head -c 400; echo
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::AI-Q did not report healthy within 5 minutes"
+          docker compose --env-file deploy/.env -f deploy/compose/docker-compose.yaml ps || true
+          docker compose --env-file deploy/.env -f deploy/compose/docker-compose.yaml logs --tail 200 aiq-agent || true
+          exit 1
+
+      - name: Run Harbor trials
+        env:
+          # Constant in our architecture. The adapter emits
+          # extra_hosts: host.docker.internal:host-gateway so this resolves
+          # from inside the Harbor task container too (see A0).
+          AIQ_SERVER_URL: http://host.docker.internal:8000
+          # Dispatch-time overrides take precedence over runner .env defaults.
+          AIQ_SKILL_EVAL_AGENT: ${{ inputs.agent }}
+        run: |
+          set -a
+          # shellcheck disable=SC1090
+          source "$RUNNER_ENV_FILE"
+          set +a
+          # Honor dispatch override of model when provided.
+          if [ -n "${{ inputs.model }}" ]; then
+            export AIQ_SKILL_EVAL_MODEL="${{ inputs.model }}"
+          fi
+          # AIQ_SKILL_EVAL_AGENT from job env beats the .env's default, if any.
+          export AIQ_SKILL_EVAL_AGENT="$AIQ_SKILL_EVAL_AGENT"
+          python3 .github/skill-eval/skills_eval_agent.py --all --run-harbor \
+            --output-dir /tmp/aiq-skill-eval/datasets
+
+      - name: Upload Harbor results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: aiq-skill-eval-results-${{ github.run_id }}
+          path: /tmp/aiq-skill-eval/results
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Tear down AI-Q stack
+        if: always()
+        working-directory: deploy/compose
+        run: |
+          # Conservative cleanup: stop+remove containers, drop volumes so
+          # Postgres doesn't leak state between runs, prune dangling images
+          # so we don't fill the runner disk. Keep the image cache for the
+          # `aiq-agent` build layers (next run is faster).
+          docker compose --env-file ../.env -f docker-compose.yaml down -v --remove-orphans || true
+          docker image prune -f || true
+
+      - name: Remove materialized deploy/.env
+        if: always()
+        run: |
+          # The runner is long-lived; don't leave the copied .env on disk
+          # between job runs even though the source file at $RUNNER_ENV_FILE
+          # is the canonical home.
+          rm -f deploy/.env || true
+
+      - name: Clean ephemeral image
+        if: always()
+        run: |
+          docker image rm "aiq-agent:ci-${{ github.run_id }}" 2>/dev/null || true

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -81,16 +81,21 @@ jobs:
           fetch-depth: 0
       - name: Filter watched paths
         id: f
+        env:
+          # Pass context via env; never interpolate ${{ }} into the shell body.
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
           # Manual dispatch always runs (full-sweep intent).
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
           # pull-request/<N> mirror: compare against develop. Direct
           # develop/release push: compare against the pre-push SHA.
-          case "${{ github.ref_name }}" in
+          case "$REF_NAME" in
             pull-request/*) BASE="origin/develop" ;;
-            *)              BASE="${{ github.event.before }}" ;;
+            *)              BASE="$BEFORE_SHA" ;;
           esac
           # Missing/zero/unresolvable base (e.g. new branch) -> run to be safe.
           if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ] \
@@ -128,10 +133,12 @@ jobs:
           python-version: "3.13"
 
       - name: Generate datasets
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           # pull-request/<N> mirror branch: only skills changed vs develop.
           # Direct develop/release push or manual dispatch: full sweep.
-          case "${{ github.ref_name }}" in
+          case "$REF_NAME" in
             pull-request/*) SCOPE="--base origin/develop" ;;
             *)              SCOPE="--all" ;;
           esac
@@ -235,23 +242,27 @@ jobs:
           # extra_hosts: host.docker.internal:host-gateway so this resolves
           # from inside the Harbor task container too (see A0).
           AIQ_SERVER_URL: http://host.docker.internal:8000
+          # Pass inputs/context via env; never interpolate ${{ }} into the shell
+          # body -- a free-form `model` input would otherwise allow injection.
+          AGENT_INPUT: ${{ inputs.agent }}
+          MODEL_INPUT: ${{ inputs.model }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           # Agent: dispatch input wins; default to claude-code on push events
           # (no inputs -> would otherwise be empty and harbor rejects `-a ''`).
-          # Captured before sourcing .env so a runner default can't blank it.
-          AGENT="${{ inputs.agent || 'claude-code' }}"
+          AGENT="${AGENT_INPUT:-claude-code}"
           set -a
           # shellcheck disable=SC1090
           source "$RUNNER_ENV_FILE"
           set +a
           # Honor dispatch override of model when provided.
-          if [ -n "${{ inputs.model }}" ]; then
-            export AIQ_SKILL_EVAL_MODEL="${{ inputs.model }}"
+          if [ -n "$MODEL_INPUT" ]; then
+            export AIQ_SKILL_EVAL_MODEL="$MODEL_INPUT"
           fi
           export AIQ_SKILL_EVAL_AGENT="$AGENT"
           # pull-request/<N> mirror branch: only skills changed vs develop.
           # Direct develop/release push or manual dispatch: full sweep.
-          case "${{ github.ref_name }}" in
+          case "$REF_NAME" in
             pull-request/*) SCOPE="--base origin/develop" ;;
             *)              SCOPE="--all" ;;
           esac

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -3,24 +3,30 @@
 #
 # AI-Q skill eval. Two jobs on the aiq-eval self-hosted runner:
 #   - generate-datasets: spec validation, no credentials.
-#   - harbor-eval:       full Harbor trial; runs only when run_harbor=true.
-# Testing phase: manual dispatch only, gated to the working branch.
-# When ready to enable PR gating, see the commented `pull_request:` block.
+#   - harbor-eval:       full Harbor trial; auto on push, or dispatch w/ run_harbor.
+# Push-triggered on develop/release/pull-request/<N> (copy-pr-bot mirror after a
+# vetter's `/ok to test`); workflow_dispatch for manual full sweeps.
 # Credentials and runtime knobs live in a runner-side .env;
 # see README-aiq-runner-bootstrap.md.
 
 name: Skills Eval
 
 on:
-  # Testing phase: manual dispatch only, restricted to the working branch.
-  # When ready to gate PRs, re-enable the `pull_request:` trigger below.
-  # pull_request:
-  #   branches: [develop, "release/**"]
-  #   paths:
-  #     - "skills/**"
-  #     - ".github/skill-eval/**"
-  #     - ".github/workflows/skills-eval.yml"
-  #     - "deploy/**"
+  # Push-only, matching the repo CI model (ci.yml/ui.yml): all PRs (internal and
+  # external) are mirrored to pull-request/<N> branches by copy-pr-bot after a
+  # vetter's `/ok to test`, so the mirror branch is the trust gate. Direct pushes
+  # to develop/release also run.
+  # NB: deliberately NO `paths:` filter. copy-pr-bot creates the mirror branch at
+  # an already-existing commit, so the branch-creation push has no file diff and a
+  # `paths:` filter would silently exclude the workflow (ci.yml/ui.yml omit it for
+  # the same reason). The detect-changes job below does the path gating instead,
+  # by diffing against the PR base.
+  # workflow_dispatch remains for manual full sweeps.
+  push:
+    branches:
+      - develop
+      - "release/**"
+      - "pull-request/[0-9]+"
   workflow_dispatch:
     inputs:
       run_harbor:
@@ -58,13 +64,56 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
+  # detect-changes: path gate. Replaces the trigger `paths:` filter, which is
+  # unreliable for copy-pr-bot mirror branches (created at an existing commit, so
+  # the push carries no diff). Diffs against the PR base / pre-push SHA instead.
+  # Runs on a GitHub-hosted runner; no credentials.
+  # ---------------------------------------------------------------------------
+  detect-changes:
+    name: Detect skill/eval changes
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.f.outputs.relevant }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Filter watched paths
+        id: f
+        run: |
+          # Manual dispatch always runs (full-sweep intent).
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          # pull-request/<N> mirror: compare against develop. Direct
+          # develop/release push: compare against the pre-push SHA.
+          case "${{ github.ref_name }}" in
+            pull-request/*) BASE="origin/develop" ;;
+            *)              BASE="${{ github.event.before }}" ;;
+          esac
+          # Missing/zero/unresolvable base (e.g. new branch) -> run to be safe.
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ] \
+             || ! git rev-parse --verify "$BASE" >/dev/null 2>&1; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if git diff --name-only "$BASE"...HEAD \
+               | grep -qE '^(skills/|\.github/skill-eval/|\.github/workflows/skills-eval\.yml|deploy/)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ---------------------------------------------------------------------------
   # generate-datasets: spec validation + Harbor task-root materialization.
   # Cheap. No credentials.
   # ---------------------------------------------------------------------------
   generate-datasets:
     name: Validate skill-eval specs
-    # Testing-phase guard: only run on the working branch.
-    if: github.ref == 'refs/heads/feat/product-evals'
+    # Path gate (see detect-changes). harbor-eval needs this job, so when it is
+    # skipped the whole eval is skipped. Only trusted refs / dispatch can trigger.
+    needs: detect-changes
+    if: needs.detect-changes.outputs.relevant == 'true'
     runs-on: [self-hosted, aiq-eval]
     timeout-minutes: 15
     steps:
@@ -80,7 +129,13 @@ jobs:
 
       - name: Generate datasets
         run: |
-          python3 .github/skill-eval/skills_eval_agent.py --all \
+          # pull-request/<N> mirror branch: only skills changed vs develop.
+          # Direct develop/release push or manual dispatch: full sweep.
+          case "${{ github.ref_name }}" in
+            pull-request/*) SCOPE="--base origin/develop" ;;
+            *)              SCOPE="--all" ;;
+          esac
+          python3 .github/skill-eval/skills_eval_agent.py $SCOPE \
             --output-dir /tmp/aiq-skill-eval/datasets
 
       - name: Upload generated datasets
@@ -98,14 +153,21 @@ jobs:
   # ---------------------------------------------------------------------------
   harbor-eval:
     name: Run Harbor skill eval
-    # Testing-phase guard: only run on the working branch, only when the
-    # dispatcher explicitly sets run_harbor=true.
-    if: |
-      github.ref == 'refs/heads/feat/product-evals' &&
-      inputs.run_harbor
+    # Push events (vetted pull-request/<N> mirrors, develop/release) run harbor
+    # automatically; manual dispatch runs it only when run_harbor=true.
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.run_harbor)
     runs-on: [self-hosted, aiq-eval]
     timeout-minutes: 60
     needs: generate-datasets
+    # Global single-flight: the stack is stateful on one runner, so only one
+    # harbor run anywhere at a time. Others queue; a live run is never
+    # cross-cancelled by a different PR. (Same-PR new commits are aborted by the
+    # workflow-level concurrency above, whose always() teardown clears the stack.)
+    concurrency:
+      group: aiq-harbor-eval
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -173,9 +235,11 @@ jobs:
           # extra_hosts: host.docker.internal:host-gateway so this resolves
           # from inside the Harbor task container too (see A0).
           AIQ_SERVER_URL: http://host.docker.internal:8000
-          # Dispatch-time overrides take precedence over runner .env defaults.
-          AIQ_SKILL_EVAL_AGENT: ${{ inputs.agent }}
         run: |
+          # Agent: dispatch input wins; default to claude-code on push events
+          # (no inputs -> would otherwise be empty and harbor rejects `-a ''`).
+          # Captured before sourcing .env so a runner default can't blank it.
+          AGENT="${{ inputs.agent || 'claude-code' }}"
           set -a
           # shellcheck disable=SC1090
           source "$RUNNER_ENV_FILE"
@@ -184,9 +248,14 @@ jobs:
           if [ -n "${{ inputs.model }}" ]; then
             export AIQ_SKILL_EVAL_MODEL="${{ inputs.model }}"
           fi
-          # AIQ_SKILL_EVAL_AGENT from job env beats the .env's default, if any.
-          export AIQ_SKILL_EVAL_AGENT="$AIQ_SKILL_EVAL_AGENT"
-          python3 .github/skill-eval/skills_eval_agent.py --all --run-harbor \
+          export AIQ_SKILL_EVAL_AGENT="$AGENT"
+          # pull-request/<N> mirror branch: only skills changed vs develop.
+          # Direct develop/release push or manual dispatch: full sweep.
+          case "${{ github.ref_name }}" in
+            pull-request/*) SCOPE="--base origin/develop" ;;
+            *)              SCOPE="--all" ;;
+          esac
+          python3 .github/skill-eval/skills_eval_agent.py $SCOPE --run-harbor \
             --output-dir /tmp/aiq-skill-eval/datasets
 
       - name: Upload Harbor results

--- a/skills/aiq-research/evals/basic-product.json
+++ b/skills/aiq-research/evals/basic-product.json
@@ -1,0 +1,27 @@
+{
+  "skills": ["aiq-research"],
+  "resources": {
+    "platforms": {
+      "local": {
+        "modes": ["existing-server"]
+      }
+    }
+  },
+  "env": "Requires an AI-Q server reachable at AIQ_SERVER_URL, defaulting to http://localhost:8000. The server can be started with the aiq-deploy skill before running this eval. This smoke profile intentionally avoids model-generating /chat calls so it can verify the skill wrapper against a live server without consuming model credits.",
+  "expects": [
+    {
+      "query": "Use the aiq-research skill to check whether the local AI-Q server is healthy. Return a concise status and include the server URL you checked.",
+      "checks": [
+        "trajectory_contains:scripts/aiq.py health",
+        "json_command:python3 /skills/aiq-research/scripts/aiq.py health"
+      ]
+    },
+    {
+      "query": "Use the aiq-research skill to list the available async agent types. Return the result without truncating the JSON keys.",
+      "checks": [
+        "trajectory_contains:scripts/aiq.py agents",
+        "json_command:python3 /skills/aiq-research/scripts/aiq.py agents"
+      ]
+    }
+  ]
+}

--- a/skills/aiq-research/scripts/aiq.py
+++ b/skills/aiq-research/scripts/aiq.py
@@ -40,7 +40,7 @@ AIQ_SERVER_URL = os.environ.get("AIQ_SERVER_URL", DEFAULT_SERVER_URL)
 
 _HEADLESS_HEADERS = {"Content-Type": "application/json", "X-AIQ-Mode": "headless"}
 DEFAULT_AGENT_TYPE = "shallow_researcher"
-_LOCAL_BACKEND_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+_LOCAL_BACKEND_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "host.docker.internal"})
 
 URL_MAX_LENGTH = _int_const("2048")
 API_PATH_MAX_LENGTH = _int_const("4096")


### PR DESCRIPTION
## Summary
Adds a product-level skill-eval harness: runs AI-Q Agent Skills through Harbor
trials against a live AI-Q server the job builds and deploys, scoring
deterministic checks. Complements the existing NVSkills CI with product-side
coverage of skill behavior across the profiles we control.

## Included
- `.github/skill-eval/` — eval coordinator, `aiq-research` adapter, deterministic
  verifier, docs.
- `.github/workflows/skills-eval.yml` — `generate-datasets` (spec validation, no
  credentials) and `harbor-eval` (full trial) on the self-hosted `aiq-eval`
  runner. Push-triggered to match the repo CI model (`ci.yml`/`ui.yml`): runs on
  `develop`, `release/**`, and `pull-request/<N>` mirror branches, filtered to
  skill/eval/deploy paths. `workflow_dispatch` retained for manual runs.
- `skills/aiq-research/evals/basic-product.json` — first product spec (smoke
  profile: health + agent listing; no model-credit `/chat` calls).
- A one-line `aiq-research` connectivity adjustment so the in-container eval can
  reach the deployed server (kept as its own commit; happy to discuss in review).

## Behavior
- Incremental on PRs (only the skills changed vs `develop`); full sweep on
  `develop`/`release`/manual dispatch.
- `harbor-eval` is single-flight so the shared runner isn't double-booked.
- Distinct trigger from NVSkills CI — the two pipelines don't collide.

## Validation
Full Harbor trial on the self-hosted runner: build -> deploy -> health -> trials
-> teardown — reward 1.0, 0 exceptions.
