### PR TITLE
feat(skills): add maintainer skill set foundation and first skill

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -24,7 +24,7 @@ AI-Q has two distinct kinds of skill, separated by audience:
 | :-- | :-- | :-- |
 | **Audience** | Developers changing the AI-Q repo | Users calling a running AI-Q server |
 | **Location** | `.agents/skills/` (this directory) | top-level `skills/` |
-| **Examples** | `aiq-add-tool`, `aiq-add-data-source`, `aiq-release-qa`, `aiq-prepare-pr` | `aiq-deploy`, `aiq-research` |
+| **Examples** | `aiq-add-data-source`, `aiq-release-qa`, `aiq-prepare-pr` | `aiq-deploy`, `aiq-research` |
 | **Assumes** | A repo checkout and dev toolchain | A reachable AI-Q backend |
 
 Consumer skills under `skills/` are authored to be self-contained and exportable

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -41,6 +41,7 @@ Each skill is a directory using the Agent Skills convention:
   references/              # optional: longer procedures, loaded only when needed
   scripts/                 # optional: deterministic, dependency-light helpers
   templates/               # optional: starter files or snippets
+  assets/                  # optional: images, binaries, or other bundled assets
 ```
 
 Keep `SKILL.md` concise and route long material into `references/`. See

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,76 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# AI-Q Maintainer Skills
+
+This directory is the maintainer/developer skill set for working **on** the AI-Q
+repository. These are repo-local Agent Skills: portable, task-scoped guidance
+that a coding agent (Claude Code, Codex, Cursor, OpenCode, or any Agent
+Skills-compatible tool) loads while a developer adds data sources, adds tools,
+runs release QA, or prepares a PR.
+
+They are **not** an in-product skill runtime. The user-facing AI-Q application
+remains a research blueprint built on the NeMo Agent Toolkit; nothing here is
+loaded or executed by the deployed product. These skills exist only to help
+coding agents and contributors work in this repository.
+
+## Maintainer skills vs. API-consumer skills
+
+AI-Q has two distinct kinds of skill, separated by audience:
+
+| | Maintainer skills | API-consumer skills |
+| :-- | :-- | :-- |
+| **Audience** | Developers changing the AI-Q repo | Users calling a running AI-Q server |
+| **Location** | `.agents/skills/` (this directory) | top-level `skills/` |
+| **Examples** | `aiq-add-tool`, `aiq-add-data-source`, `aiq-release-qa`, `aiq-prepare-pr` | `aiq-deploy`, `aiq-research` |
+| **Assumes** | A repo checkout and dev toolchain | A reachable AI-Q backend |
+
+Consumer skills under `skills/` are authored to be self-contained and exportable
+(for example, to the NVIDIA Skills catalog). They are surfaced to in-repo coding
+agents through symlinks; do not move maintainer skills there.
+
+## Layout
+
+Each skill is a directory using the Agent Skills convention:
+
+```
+.agents/skills/<skill-name>/
+  SKILL.md                 # required: frontmatter + concise routed workflow
+  references/              # optional: longer procedures, loaded only when needed
+  scripts/                 # optional: deterministic, dependency-light helpers
+  templates/               # optional: starter files or snippets
+```
+
+Keep `SKILL.md` concise and route long material into `references/`. See
+[TEMPLATE.md](TEMPLATE.md) for the canonical starting point.
+
+## Naming and frontmatter rules
+
+These are enforced by [`scripts/validate_skills.py`](../../scripts/validate_skills.py):
+
+- The directory name and the frontmatter `name` must match.
+- `name` is lowercase, hyphen-separated, and prefixed with `aiq-`.
+- `description` is required and must stay under 1024 characters (the Agent Skills
+  matching limit). Make it specific enough to route on.
+- Links into a skill's own `references/`, `scripts/`, `templates/`, or `assets/`
+  must resolve on disk.
+
+Keep names stable once a skill is published or mirrored externally.
+
+## Adding a skill
+
+1. Copy [TEMPLATE.md](TEMPLATE.md) to `.agents/skills/<aiq-skill-name>/SKILL.md`
+   and fill in the frontmatter and sections.
+2. Add a coding-agent compatibility symlink so the in-repo agent discovers it:
+   ```bash
+   ln -s ../../.agents/skills/<aiq-skill-name> .claude/skills/<aiq-skill-name>
+   ```
+3. Validate before committing:
+   ```bash
+   uv run python scripts/validate_skills.py .agents/skills
+   ```
+
+The validator also runs as a pre-commit hook and in CI's pytest job, so a
+malformed skill fails fast.

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -35,7 +35,7 @@ agents through symlinks; do not move maintainer skills there.
 
 Each skill is a directory using the Agent Skills convention:
 
-```
+```text
 .agents/skills/<skill-name>/
   SKILL.md                 # required: frontmatter + concise routed workflow
   references/              # optional: longer procedures, loaded only when needed
@@ -65,10 +65,13 @@ Keep names stable once a skill is published or mirrored externally.
 1. Copy [TEMPLATE.md](TEMPLATE.md) to `.agents/skills/<aiq-skill-name>/SKILL.md`
    and fill in the frontmatter and sections.
 2. Add a coding-agent compatibility symlink so the in-repo agent discovers it:
+
    ```bash
    ln -s ../../.agents/skills/<aiq-skill-name> .claude/skills/<aiq-skill-name>
    ```
+
 3. Validate before committing:
+
    ```bash
    uv run python scripts/validate_skills.py .agents/skills
    ```

--- a/.agents/skills/TEMPLATE.md
+++ b/.agents/skills/TEMPLATE.md
@@ -1,0 +1,104 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+This is the canonical template for AI-Q maintainer skills. To create a skill:
+
+  1. Copy the YAML frontmatter and body below into
+     .agents/skills/<aiq-skill-name>/SKILL.md
+  2. Replace every <PLACEHOLDER> and the example content.
+  3. Keep SKILL.md concise; move long procedures into references/*.md.
+  4. Validate: uv run python scripts/validate_skills.py .agents/skills
+
+This file lives at the directory root (not inside a skill folder), so the
+validator does not treat it as a skill. Do not add a SKILL.md beside it.
+-->
+
+# Skill authoring template
+
+Copy everything between the rulers below into your new `SKILL.md`.
+
+---
+
+```markdown
+---
+name: aiq-<skill-name>
+description: Use when <specific trigger>. Keep this under 1024 characters and specific enough for an agent to route on.
+license: Apache-2.0
+compatibility: Claude Code, Codex, Cursor, OpenCode, and Agent Skills-compatible tools.
+metadata:
+  version: "0.1.0"
+  source-repo: "NVIDIA-AI-Blueprints/aiq"
+  tags: "aiq nemo-agent-toolkit <area>"
+allowed-tools: Read Bash Edit
+---
+
+# <Human-Readable Skill Title>
+
+One or two sentences on what this skill helps a coding agent accomplish in the
+AI-Q repository, and when it applies.
+
+## Start Here
+
+- Confirm the requested change type before editing.
+- Read the authoritative AI-Q files listed below.
+- Preserve existing repo patterns; prefer the smallest change that fits.
+- Do not print secrets or hard-code tokens.
+
+## Authoritative References
+
+List the AI-Q files and docs that are the source of truth for this workflow.
+Point at precise paths, not whole trees.
+
+- `docs/source/<area>/<page>.md`: canonical walkthrough.
+- `<path/to/existing/example>`: existing pattern to follow.
+
+For longer procedures, link to local reference files (loaded only when needed):
+
+- [references/<topic>.md](references/<topic>.md)
+
+## Workflow
+
+1. Inspect the current implementation.
+2. Choose the smallest change that fits the existing pattern.
+3. Make the code or config change.
+4. Add or update focused tests.
+5. Run the validation commands below.
+6. Summarize changed files and evidence.
+
+## Validation
+
+Run the narrowest command first, then broaden if the change crosses shared
+boundaries. State the expected result.
+
+```bash
+uv run pytest <path/to/scoped/tests>
+uv run ruff check <path/to/changed/code>
+```
+
+Expected: tests pass and Ruff reports no lint failures for the changed code.
+
+## Common Mistakes
+
+- <A specific, high-frequency mistake for this workflow and how to avoid it.>
+- <Another concrete pitfall.>
+
+## Related Skills
+
+- `aiq-release-qa`
+- `aiq-prepare-pr`
+```
+
+---
+
+## Authoring rules
+
+- Embed the essential workflow in the skill; link to docs for extra context, but
+  do not require the agent to discover the entire docs tree.
+- Prefer checklists and exact commands over prose.
+- Keep references local to the skill bundle when the content is needed to
+  complete the task.
+- Avoid volatile model names in examples unless the skill tells the agent to
+  verify the current config.
+- Never include secrets, real tokens, or environment-specific hostnames.
+- Keep scripts small, deterministic, and dependency-light.

--- a/.agents/skills/TEMPLATE.md
+++ b/.agents/skills/TEMPLATE.md
@@ -74,9 +74,11 @@ boundaries. State the expected result.
 ```bash
 uv run pytest <path/to/scoped/tests>
 uv run ruff check <path/to/changed/code>
+uv run ruff format --check <path/to/changed/code>
 ```
 
-Expected: tests pass and Ruff reports no lint failures for the changed code.
+Expected: tests pass and Ruff reports no lint or format failures for the changed
+code.
 
 ## Common Mistakes
 

--- a/.agents/skills/aiq-add-data-source/SKILL.md
+++ b/.agents/skills/aiq-add-data-source/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: aiq-add-data-source
+description: Use when adding or changing an AI-Q data source under sources/, registering it as a NeMo Agent Toolkit function, wiring it into the data_source_registry for UI toggles, or validating retrieval behavior with tests.
+license: Apache-2.0
+compatibility: Claude Code, Codex, Cursor, OpenCode, and Agent Skills-compatible tools.
+metadata:
+  version: "0.1.0"
+  source-repo: "NVIDIA-AI-Blueprints/aiq"
+  tags: "aiq nemo-agent-toolkit data-source sources registry"
+allowed-tools: Read Bash Edit
+---
+
+# Add an AI-Q Data Source
+
+Use this skill when a developer wants to add a retrieval or search source to
+AI-Q and expose it as a toggleable source in the UI. A data source is a NeMo
+Agent Toolkit (NAT) function package under `sources/`, registered in the
+`data_source_registry`.
+
+## Start Here
+
+- Confirm this is a new retrieval/search source (not a UI, auth, or prompt
+  change). For a general utility function, use `aiq-add-tool` instead.
+- Read the authoritative files below before editing.
+- Copy the closest existing source package rather than inventing a new shape.
+- Never print or commit API keys; resolve secrets at runtime via `SecretStr`.
+
+## Authoritative References
+
+- `docs/source/extending/adding-a-data-source.md`: canonical package and
+  registration walkthrough (the steps below mirror it).
+- `sources/google_scholar_paper_search/`: complete example package with a
+  client, a config + registration, a graceful missing-secret stub, and tests.
+- `sources/tavily_web_search/`: minimal source package for comparison.
+- `src/aiq_agent/common/data_source_registry.py`: the `data_source_registry`
+  config (`name="data_source_registry"`) that drives `GET /v1/data_sources`.
+- `docs/source/customization/tools-and-sources.md`: how the registry maps to UI
+  toggles and per-request filtering.
+- `frontends/ui/src/features/layout/data-sources.ts`: the UI `DataSource` type;
+  sources are fetched dynamically, so usually no UI code change is needed.
+
+Longer procedures live in this bundle:
+
+- [references/package-layout.md](references/package-layout.md): package files,
+  `pyproject.toml`, config class, `@register_function`, and the missing-secret stub.
+- [references/registry-and-ui.md](references/registry-and-ui.md): registering in
+  YAML and how the registry surfaces toggles and filtering.
+- [references/validation.md](references/validation.md): install, test, and lint
+  commands with expected results.
+
+## Workflow
+
+1. Pick the closest existing package under `sources/` and inspect its layout.
+2. Create `sources/<my_data_source>/` with `src/register.py`, the client
+   module, `pyproject.toml`, and `tests/` (see package-layout reference).
+3. Define a `FunctionBaseConfig` subclass with a stable `name=` and resolve any
+   API key via `SecretStr`; register it with `@register_function`.
+4. Yield a graceful stub when the required secret is missing.
+5. Install the package editable and add it to the `data_source_registry` in the
+   relevant config under `configs/`.
+6. Add focused tests; run the validation commands below.
+7. Summarize changed files and paste the test/lint evidence.
+
+## Validation
+
+Run the narrowest commands first; broaden only if the change touches shared code.
+
+```bash
+uv pip install -e ./sources/my_data_source
+uv run pytest sources/my_data_source/tests
+uv run ruff check sources/my_data_source
+```
+
+Expected: the package installs, its tests pass, and Ruff reports no lint
+failures for the new source package.
+
+## Common Mistakes
+
+- Forgetting to add the source to the `data_source_registry`, so the UI cannot
+  toggle it and agents do not inherit the tool.
+- Omitting the `[project.entry-points."nat.plugins"]` entry in `pyproject.toml`,
+  so NAT never discovers the registration.
+- Crashing on a missing API key instead of yielding a stub that returns a clear
+  error message.
+- Returning unstructured or citation-poor output, which weakens report grounding.
+- Printing API keys or embedding secrets in YAML instead of using environment
+  variables or `SecretStr`.
+
+## Related Skills
+
+- `aiq-add-tool`
+- `aiq-release-qa`
+- `aiq-prepare-pr`

--- a/.agents/skills/aiq-add-data-source/references/package-layout.md
+++ b/.agents/skills/aiq-add-data-source/references/package-layout.md
@@ -60,6 +60,8 @@ In `src/register.py`, define a `FunctionBaseConfig` subclass with a stable
 `FunctionInfo` from an async `@register_function`:
 
 ```python
+import os
+
 from pydantic import Field, SecretStr
 from nat.builder.builder import Builder
 from nat.builder.function_info import FunctionInfo

--- a/.agents/skills/aiq-add-data-source/references/package-layout.md
+++ b/.agents/skills/aiq-add-data-source/references/package-layout.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 
 Model new sources on `sources/google_scholar_paper_search/`. The layout is:
 
-```
+```text
 sources/my_data_source/
   pyproject.toml
   README.md

--- a/.agents/skills/aiq-add-data-source/references/package-layout.md
+++ b/.agents/skills/aiq-add-data-source/references/package-layout.md
@@ -1,0 +1,98 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Data source package layout
+
+Model new sources on `sources/google_scholar_paper_search/`. The layout is:
+
+```
+sources/my_data_source/
+  pyproject.toml
+  README.md
+  src/
+    __init__.py
+    register.py        # config class + NAT registration
+    search.py          # NAT-independent client/tool implementation
+  tests/
+    __init__.py
+    conftest.py
+    test_search.py
+```
+
+Keep the client (`search.py`) free of NAT imports so it is unit-testable on its
+own; `register.py` adapts it into a NAT function.
+
+## pyproject.toml
+
+```toml
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools >= 64", "setuptools-scm>=8"]
+
+[tool.setuptools]
+packages = ["my_data_source"]
+package-dir = {"my_data_source" = "src"}
+
+[project]
+name = "my-data-source"
+version = "1.0.0"
+description = "NAT-based <what it searches> data source"
+readme = "README.md"
+requires-python = ">=3.11,<3.14"
+license = {text = "Apache-2.0"}
+dependencies = [
+    "httpx>=0.24.0",
+    "pydantic>=2.0.0",
+]
+
+# REQUIRED so NAT discovers the registration. The left-hand key is the YAML
+# `_type` name; the right-hand value points at the register module.
+[project.entry-points."nat.plugins"]
+my_data_source = "my_data_source.register"
+```
+
+## Config class and registration
+
+In `src/register.py`, define a `FunctionBaseConfig` subclass with a stable
+`name=` (this is the YAML `_type`), resolve secrets via `SecretStr`, and yield a
+`FunctionInfo` from an async `@register_function`:
+
+```python
+from pydantic import Field, SecretStr
+from nat.builder.builder import Builder
+from nat.builder.function_info import FunctionInfo
+from nat.cli.register_workflow import register_function
+from nat.data_models.function import FunctionBaseConfig
+
+
+class MyDataSourceConfig(FunctionBaseConfig, name="my_data_source"):
+    """Config for the my_data_source retrieval tool."""
+
+    max_results: int = Field(default=10, description="Max results to return")
+    my_api_key: SecretStr | None = Field(default=None, description="API key")
+
+
+@register_function(config_type=MyDataSourceConfig)
+async def my_data_source(tool_config: MyDataSourceConfig, builder: Builder):
+    api_key = os.environ.get("MY_API_KEY") or (
+        tool_config.my_api_key.get_secret_value() if tool_config.my_api_key else None
+    )
+    if not api_key:
+        async def _stub(query: str) -> str:
+            """Tool unavailable - missing MY_API_KEY."""
+            return "Error: my_data_source is unavailable because MY_API_KEY is not set."
+
+        yield FunctionInfo.from_fn(_stub, description=_stub.__doc__)
+        return
+
+    async def _search(query: str) -> str:
+        """Searches <domain> and returns structured, citation-rich results."""
+        ...  # call the client in search.py
+
+    yield FunctionInfo.from_fn(_search, description=_search.__doc__)
+```
+
+The tool's docstring becomes the description the agent sees — make it specific
+and return well-structured, citable output.

--- a/.agents/skills/aiq-add-data-source/references/registry-and-ui.md
+++ b/.agents/skills/aiq-add-data-source/references/registry-and-ui.md
@@ -1,0 +1,62 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Registry and UI wiring
+
+Authoritative sources: `src/aiq_agent/common/data_source_registry.py` and
+`docs/source/customization/tools-and-sources.md`.
+
+## Register the source in YAML
+
+After installing the package editable, add the source to the
+`data_source_registry` in the relevant config under `configs/`. This is normally
+the **only** config change needed — agents inherit registry tools automatically:
+
+```yaml
+functions:
+  data_source_registry:
+    _type: data_source_registry
+    sources:
+      - id: my_data_source
+        name: My Data Source
+        category: web          # web | enterprise | storage | collaboration
+        default_enabled: true
+        tools:
+          - _type: my_data_source
+
+  my_data_source:
+    _type: my_data_source       # matches the config class name= / entry-point key
+```
+
+Confirm the field names against the `DataSourceRegistryConfig` in
+`src/aiq_agent/common/data_source_registry.py`; do not guess the schema.
+
+## How the registry surfaces the source
+
+- `GET /v1/data_sources` returns the registered sources; the UI renders them as
+  toggles. No UI code change is normally required.
+- Per-request filtering: the WebSocket chat payload and
+  `POST /v1/jobs/async/submit` accept a `data_sources` list to scope which
+  sources are active for that request.
+- Auto-inheritance: every agent gets every registered tool by default; use an
+  agent's `exclude_tools` for per-agent specialization.
+- Tools not listed in any registry source entry are always included (e.g. utility
+  tools like "think"). An explicit empty list (`data_sources: []`) disables
+  registry tools while leaving unmapped utility tools available.
+
+## UI type (reference only)
+
+`frontends/ui/src/features/layout/data-sources.ts` defines the `DataSource`
+TypeScript interface (`id`, `name`, `description`, `category`, `defaultEnabled`,
+`requiresAuth`). Because sources are fetched dynamically from
+`GET /v1/data_sources`, adding a source does not require editing this file. Touch
+the UI only for a genuinely new presentation need — that is `aiq-ui-change`
+territory, not this skill.
+
+## Authenticated sources
+
+If the source requires per-user auth, set the auth flags rather than hard-coding
+credentials, and follow the auth integration path. Protected-source auth is out
+of scope for this skill; coordinate with the auth integration workflow.

--- a/.agents/skills/aiq-add-data-source/references/validation.md
+++ b/.agents/skills/aiq-add-data-source/references/validation.md
@@ -30,9 +30,10 @@ configured path and the missing-secret stub path.
 
 ```bash
 uv run ruff check sources/my_data_source
+uv run ruff format --check sources/my_data_source
 ```
 
-Expected: no lint failures (Ruff line length 120, target 3.11).
+Expected: no lint or formatting failures (Ruff line length 120, target 3.11).
 
 ## 4. Smoke-check the registration (optional)
 

--- a/.agents/skills/aiq-add-data-source/references/validation.md
+++ b/.agents/skills/aiq-add-data-source/references/validation.md
@@ -1,0 +1,57 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Validation
+
+Run from the repo root. Start with the narrowest command and broaden only if the
+change crosses shared boundaries.
+
+## 1. Install the package editable
+
+```bash
+uv pip install -e ./sources/my_data_source
+```
+
+Expected: the package installs and its `nat.plugins` entry point is registered.
+
+## 2. Run the package tests
+
+```bash
+uv run pytest sources/my_data_source/tests
+```
+
+Model tests on `sources/google_scholar_paper_search/tests/test_paper_search.py`:
+unit-test the client with `unittest.mock` (no live network), and cover both the
+configured path and the missing-secret stub path.
+
+## 3. Lint
+
+```bash
+uv run ruff check sources/my_data_source
+```
+
+Expected: no lint failures (Ruff line length 120, target 3.11).
+
+## 4. Smoke-check the registration (optional)
+
+Start the backend with a config that registers the source and confirm it appears:
+
+```bash
+./scripts/start_cli.sh
+curl -s http://localhost:8000/v1/data_sources
+```
+
+Expected: the new source `id` appears in the returned list.
+
+## Evidence to capture
+
+For the PR (see `aiq-prepare-pr`), record:
+
+- The list of created/changed files.
+- The `pytest` transcript with pass counts.
+- The `ruff check` result.
+- Confirmation the source is registered in the `data_source_registry` config.
+
+Do not print secret values in any captured output.

--- a/.claude/skills/aiq-add-data-source
+++ b/.claude/skills/aiq-add-data-source
@@ -1,0 +1,1 @@
+../../.agents/skills/aiq-add-data-source

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,13 @@ repos:
 
   - repo: local
     hooks:
+      - id: validate-skills
+        name: Validate agent skills
+        entry: python scripts/validate_skills.py .agents/skills
+        language: python
+        additional_dependencies: ["pyyaml"]
+        files: ^\.agents/skills/
+        pass_filenames: false
       - id: clear-notebook-output-cells
         name: Clear Jupyter Notebook Output Cells
         entry: ci/scripts/clear_notebook_output_cells.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
         name: Validate agent skills
         entry: python scripts/validate_skills.py .agents/skills
         language: python
-        additional_dependencies: ["pyyaml"]
+        additional_dependencies: ["pyyaml==6.0.3"]
         files: ^\.agents/skills/
         pass_filenames: false
       - id: clear-notebook-output-cells

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,9 +134,11 @@ change crosses shared boundaries.
 - This repo uses a maintainer-reviewed PR workflow with **DCO sign-off**,
   code-owner review, copy-pr-bot mirroring, and GitHub Actions validation.
 - Every commit must be signed off:
+
   ```bash
   git commit -s -m "Concise, scoped change"
   ```
+
   The commit must contain a `Signed-off-by: Your Name <your@email.com>` trailer.
   Commits without sign-off may be rejected.
 - Keep PRs scoped: no unrelated files, no accidental generated artifacts, no

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,156 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# AI-Q Agent Guidance
+
+Repository-global instructions for coding agents and for humans reviewing
+agent-authored changes. These rules apply to every task in this repository.
+Task-specific runbooks live in [`.agents/skills/`](.agents/skills/) — load the
+relevant skill before starting a workflow it covers.
+
+## Project overview
+
+AI-Q is an NVIDIA AI Blueprint: an enterprise research agent built on the
+**NeMo Agent Toolkit (NAT)**. The deployed product is a research blueprint, not
+a general skill runtime. New retrieval sources and tools are NAT functions;
+agent behavior is driven by workflow YAML, Jinja2 prompts, and a data-source
+registry — not by hard-coded logic.
+
+Primary boundaries:
+
+- Backend Python package: `src/aiq_agent/`.
+- Data-source and tool packages: `sources/` (each is its own package).
+- Frontends and tooling: `frontends/` (web UI in `frontends/ui/`, eval harnesses
+  in `frontends/benchmarks/`).
+- Configs, deployment, docs: `configs/`, `deploy/`, `docs/`.
+
+Stay inside this repository. If your workspace also contains adjacent repos
+(for example a sibling NeMo-Relay checkout), do not edit them as part of an AI-Q
+change. Treat `sources/*` as independent packages: prefer the smallest change
+scoped to the package you are touching.
+
+## Repository structure
+
+| Path | Purpose |
+| :-- | :-- |
+| `src/aiq_agent/` | Backend agent, FastAPI extensions, auth, observability, knowledge |
+| `sources/` | Data-source / tool packages (e.g. `tavily_web_search`, `google_scholar_paper_search`) |
+| `configs/` | Workflow YAML configs (e.g. `config_cli_default.yml`) |
+| `frontends/ui/` | Next.js / React / TypeScript / Tailwind / KUI web UI |
+| `frontends/benchmarks/` | Eval harnesses: `freshqa`, `deepsearch_qa`, `deepresearch_bench` |
+| `deploy/` | Docker Compose and Helm/Kubernetes assets; `deploy/.env` for secrets |
+| `docs/source/` | Sphinx documentation |
+| `skills/` | API-consumer Agent Skills (`aiq-deploy`, `aiq-research`) |
+| `.agents/skills/` | Maintainer Agent Skills (this contributor skill set) |
+| `tests/` | Pytest suite |
+
+## Build, test, and validation commands
+
+Python (run from the repo root; the project uses `uv`):
+
+```bash
+./scripts/setup.sh                 # one-time environment setup
+uv run ruff check .                # lint
+uv run ruff format --check .       # format check
+uv run pytest                      # tests
+```
+
+Run the backend locally:
+
+```bash
+./scripts/start_cli.sh             # CLI mode (configs/config_cli_default.yml)
+nat serve --config_file configs/config_cli_default.yml --port 8000
+```
+
+The backend API serves at `http://localhost:8000`.
+
+Frontend (from `frontends/ui/`):
+
+```bash
+npm run lint
+npm run type-check
+npm run test:ci
+```
+
+Docs (from `docs/`): build with the provided `Makefile` (Sphinx).
+
+Evals (from the repo root) use the NAT eval harness, for example:
+
+```bash
+dotenv -f deploy/.env run nat eval \
+  --config_file frontends/benchmarks/deepresearch_bench/configs/config_deep_research_bench.yml
+```
+
+Run the narrowest relevant command first; broaden to the full suite only when a
+change crosses shared boundaries.
+
+## Coding style and naming conventions
+
+- Python is linted and formatted with **Ruff** (line length 120, target 3.11,
+  rule sets `E,F,W,I,PL,UP`; isort `force-single-line`). Match the existing
+  import and formatting style; do not hand-reformat unrelated code.
+- New tools and data sources are NAT functions registered with
+  `@register_function`; config schemas inherit from `FunctionBaseConfig`; YAML
+  `_type` names come from the registered config class.
+- Register new data sources in the `data_source_registry` so the UI can toggle
+  them.
+- `pre-commit` enforces the above plus secret detection, link checking, and
+  skill validation. Install it and let it run before pushing.
+
+## Security and auth rules
+
+- Never commit secrets, tokens, or environment-specific hostnames. Use
+  environment variables and `SecretStr`; resolve API keys at runtime.
+- Never print or log secret values, including in tool output or error messages.
+- Missing-secret paths must degrade gracefully (stub/skip), not crash or leak.
+- Respect authenticated data sources: honor `requires_auth`, per-user token
+  pass-through, and backend token validators. Apply owner guardrails before
+  loading protected report or artifact context into an agent.
+- Do not weaken or bypass `AuthMiddleware`, validators, or auth gating without a
+  prior design discussion.
+
+## Frontend conventions
+
+- The UI is Next.js / React / TypeScript / Tailwind with KUI components and an
+  adapter-based structure under `frontends/ui/src/`. Reuse existing KUI
+  components and visual patterns rather than introducing new ones.
+- The backend is reached via the proxy and `BACKEND_URL`; preserve auth-aware UI
+  states.
+- Validate UI-affecting changes with `npm run lint`, `npm run type-check`, and
+  `npm run test:ci`. Include a screenshot for visible changes.
+
+## Documentation and design expectations
+
+- Update the docs under `docs/source/` when behavior, configuration, or
+  workflows change. Skills are a task-oriented layer above the docs — keep the
+  docs canonical; do not duplicate full doc pages into skill text.
+- For substantial behavior, auth, UI, or architecture changes, open a design
+  discussion before coding rather than landing a large unreviewed change.
+
+## Git and PR hygiene
+
+- This repo uses a maintainer-reviewed PR workflow with **DCO sign-off**,
+  code-owner review, copy-pr-bot mirroring, and GitHub Actions validation.
+- Every commit must be signed off:
+  ```bash
+  git commit -s -m "Concise, scoped change"
+  ```
+  The commit must contain a `Signed-off-by: Your Name <your@email.com>` trailer.
+  Commits without sign-off may be rejected.
+- Keep PRs scoped: no unrelated files, no accidental generated artifacts, no
+  secrets. Provide validation evidence (commands run and results).
+
+## Skill usage
+
+- Repository-global rules live in this `AGENTS.md`.
+- Task-specific runbooks live in [`.agents/skills/`](.agents/skills/) (maintainer
+  skills). See its [README](.agents/skills/README.md) and
+  [TEMPLATE](.agents/skills/TEMPLATE.md) to use or add one.
+- API-consumer skills for calling a running AI-Q server live in `skills/`
+  (`aiq-research`, `aiq-deploy`); they are a different audience and are not
+  maintainer skills.
+- These skills are guidance for coding agents working in this repository. They
+  are not an in-product skill runtime and are not executed by the deployed
+  AI-Q application.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/source/integration/agent-skills.md
+++ b/docs/source/integration/agent-skills.md
@@ -17,7 +17,7 @@ the **API-consumer** skills. The maintainer skills are documented in their own
 | :-- | :-- | :-- |
 | **Audience** | Users calling a running AI-Q server | Developers changing the AI-Q repo |
 | **Location** | top-level `skills/` | `.agents/skills/` |
-| **Examples** | `aiq-deploy`, `aiq-research` | `aiq-add-tool`, `aiq-add-data-source` |
+| **Examples** | `aiq-deploy`, `aiq-research` | `aiq-add-data-source` |
 | **Assumes** | A reachable AI-Q backend | A repo checkout and dev toolchain |
 
 The API-consumer skills are:
@@ -108,7 +108,6 @@ skills point into `skills/`; the maintainer skills point into `.agents/skills/`:
 .claude/skills/aiq-deploy -> ../../skills/aiq-deploy
 .claude/skills/aiq-research -> ../../skills/aiq-research
 .claude/skills/aiq-add-data-source -> ../../.agents/skills/aiq-add-data-source
-.claude/skills/aiq-add-tool -> ../../.agents/skills/aiq-add-tool
 ```
 
 To recreate the consumer-skill repo-local install manually:

--- a/docs/source/integration/agent-skills.md
+++ b/docs/source/integration/agent-skills.md
@@ -7,10 +7,25 @@ SPDX-License-Identifier: Apache-2.0
 
 AI-Q includes portable Agent Skills for coding harnesses that support skill-style instructions and helper scripts.
 
+## Two kinds of AI-Q skill
+
+AI-Q ships two distinct skill sets, separated by audience. This page documents
+the **API-consumer** skills. The maintainer skills are documented in their own
+[README](../../../.agents/skills/README.md).
+
+| | API-consumer skills | Maintainer skills |
+| :-- | :-- | :-- |
+| **Audience** | Users calling a running AI-Q server | Developers changing the AI-Q repo |
+| **Location** | top-level `skills/` | `.agents/skills/` |
+| **Examples** | `aiq-deploy`, `aiq-research` | `aiq-add-tool`, `aiq-add-data-source` |
+| **Assumes** | A reachable AI-Q backend | A repo checkout and dev toolchain |
+
+The API-consumer skills are:
+
 - `aiq-deploy` helps an assistant clone or locate AI-Q, choose an existing workflow config, deploy locally or in self-hosted environments, verify basic system health, optionally run deep research completion validation, troubleshoot, rebuild, and stop services.
 - `aiq-research` lets an assistant call a running local or self-hosted AI-Q Blueprint server for routed `/chat` requests and async deep research job lifecycle operations.
 
-The canonical packaged skills live at:
+The canonical packaged consumer skills live at:
 
 ```text
 skills/aiq-deploy/
@@ -19,10 +34,14 @@ skills/aiq-research/
 
 Each installed skill directory must contain `SKILL.md` at its root. The deploy skill keeps detailed guidance under `references/` so agents only load the path-specific material they need.
 
-For harnesses that expect repository-local Agent Skills under `.agents/skills`, this repository keeps a compatibility symlink:
+For harnesses that expect repository-local Agent Skills under `.agents/skills`,
+this repository surfaces the consumer skills there with per-skill symlinks
+(`.agents/skills/` itself is the maintainer skill home, not a symlink to
+`skills/`):
 
 ```text
-.agents/skills -> ../skills
+.agents/skills/aiq-deploy -> ../../skills/aiq-deploy
+.agents/skills/aiq-research -> ../../skills/aiq-research
 ```
 
 ## Recommended Flow
@@ -81,20 +100,28 @@ Use the repo-local instructions below when developing AI-Q itself, validating ch
 
 ## Claude Code
 
-Claude Code supports repo-local skills under `.claude/skills/`. This repository keeps those paths as compatibility symlinks:
+Claude Code supports repo-local skills under `.claude/skills/`. This repository
+keeps those paths as compatibility symlinks for both skill sets. The consumer
+skills point into `skills/`; the maintainer skills point into `.agents/skills/`:
 
 ```text
 .claude/skills/aiq-deploy -> ../../skills/aiq-deploy
 .claude/skills/aiq-research -> ../../skills/aiq-research
+.claude/skills/aiq-add-data-source -> ../../.agents/skills/aiq-add-data-source
+.claude/skills/aiq-add-tool -> ../../.agents/skills/aiq-add-tool
 ```
 
-To recreate the repo-local install manually:
+To recreate the consumer-skill repo-local install manually:
 
 ```bash
 mkdir -p .claude/skills
 ln -s ../../skills/aiq-deploy .claude/skills/aiq-deploy
 ln -s ../../skills/aiq-research .claude/skills/aiq-research
 ```
+
+The maintainer-skill symlinks are managed alongside the maintainer skill set;
+see the [maintainer skills README](../../../.agents/skills/README.md) for how
+those are added.
 
 For a user-level install:
 

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -149,6 +149,7 @@ def validate_roots(roots: list[Path]) -> Report:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: parse root arguments, run validation, and return an exit code."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "roots",

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validate AI-Q repo-local agent skill bundles.
+
+Checks every skill directory under one or more roots (default ``.agents/skills``)
+for a well-formed ``SKILL.md`` and bundle layout. Runs fully offline with no
+network access so it is safe in pre-commit and CI.
+
+Usage:
+    python scripts/validate_skills.py [ROOT ...]
+
+Exit code is 0 when every skill is valid, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from dataclasses import field
+from pathlib import Path
+
+import yaml
+
+# Skill name contract: lowercase, hyphen-separated, ``aiq-`` prefixed.
+NAME_PREFIX = "aiq-"
+NAME_RE = re.compile(r"^aiq-[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+# Names that predate the contract and are allowed to keep their existing form.
+GRANDFATHERED_NAMES: set[str] = set()
+
+# Anthropic Agent Skills cap the matching ``description`` at 1024 characters.
+MAX_DESCRIPTION_CHARS = 1024
+
+# Only relative links pointing into these in-bundle subdirectories are checked
+# for on-disk existence. Anchors, external URLs, and links into the wider repo
+# are intentionally left to markdown-link-check.
+BUNDLE_DIRS = ("references", "scripts", "templates", "assets")
+
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+MD_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+DEFAULT_ROOTS = (".agents/skills",)
+
+
+@dataclass
+class Report:
+    """Accumulates per-skill validation errors."""
+
+    errors: list[str] = field(default_factory=list)
+    skills_checked: int = 0
+
+    def fail(self, skill: str, message: str) -> None:
+        self.errors.append(f"{skill}: {message}")
+
+
+def _parse_frontmatter(text: str) -> dict | None:
+    """Return the parsed YAML frontmatter mapping, or None if absent/invalid."""
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return None
+    try:
+        data = yaml.safe_load(match.group(1))
+    except yaml.YAMLError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _check_bundle_links(skill_md: Path, text: str, dir_name: str, report: Report) -> None:
+    """Verify relative links into references/scripts/templates/assets resolve."""
+    for target in MD_LINK_RE.findall(text):
+        target = target.strip()
+        # Skip external schemes and pure anchors.
+        if target.startswith(("http://", "https://", "mailto:", "#")) or "://" in target:
+            continue
+        path_part = target.split("#", 1)[0]
+        if not path_part:
+            continue
+        first_segment = path_part.split("/", 1)[0]
+        if first_segment not in BUNDLE_DIRS:
+            continue
+        if not (skill_md.parent / path_part).exists():
+            report.fail(dir_name, f"SKILL.md links to missing bundle file '{path_part}'")
+
+
+def validate_skill(skill_dir: Path, report: Report) -> None:
+    """Validate a single skill directory in place, recording any failures."""
+    dir_name = skill_dir.name
+    report.skills_checked += 1
+
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file():
+        report.fail(dir_name, "missing SKILL.md")
+        return
+
+    text = skill_md.read_text(encoding="utf-8")
+    frontmatter = _parse_frontmatter(text)
+    if frontmatter is None:
+        report.fail(dir_name, "SKILL.md frontmatter is missing or not valid YAML")
+        return
+
+    name = frontmatter.get("name")
+    if not name or not isinstance(name, str):
+        report.fail(dir_name, "frontmatter 'name' is missing")
+    else:
+        if name != dir_name:
+            report.fail(dir_name, f"frontmatter name '{name}' does not match directory '{dir_name}'")
+        if name not in GRANDFATHERED_NAMES and not NAME_RE.match(name):
+            report.fail(dir_name, f"name '{name}' must be lowercase-hyphenated and start with '{NAME_PREFIX}'")
+
+    description = frontmatter.get("description")
+    if not description or not isinstance(description, str) or not description.strip():
+        report.fail(dir_name, "frontmatter 'description' is missing or empty")
+    elif len(description) > MAX_DESCRIPTION_CHARS:
+        report.fail(dir_name, f"description is {len(description)} chars (limit {MAX_DESCRIPTION_CHARS})")
+
+    _check_bundle_links(skill_md, text, dir_name, report)
+
+
+def iter_skill_dirs(root: Path) -> list[Path]:
+    """Return sorted skill directories (symlinks followed) directly under root."""
+    return sorted(p for p in root.iterdir() if p.is_dir())
+
+
+def validate_roots(roots: list[Path]) -> Report:
+    """Validate every skill under each root and return the combined report."""
+    report = Report()
+    for root in roots:
+        if not root.is_dir():
+            report.errors.append(f"{root}: skills root does not exist")
+            continue
+        for skill_dir in iter_skill_dirs(root):
+            validate_skill(skill_dir, report)
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "roots",
+        nargs="*",
+        default=list(DEFAULT_ROOTS),
+        help="Skill root directories to validate (default: .agents/skills).",
+    )
+    args = parser.parse_args(argv)
+
+    report = validate_roots([Path(r) for r in args.roots])
+
+    if report.errors:
+        print(f"Skill validation FAILED ({len(report.errors)} error(s)):", file=sys.stderr)
+        for error in report.errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print(f"Skill validation passed: {report.skills_checked} skill(s) OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -51,7 +51,7 @@ MAX_DESCRIPTION_CHARS = 1024
 # are intentionally left to markdown-link-check.
 BUNDLE_DIRS = ("references", "scripts", "templates", "assets")
 
-FRONTMATTER_RE = re.compile(r"^---\r?\n(.*?)\r?\n---", re.DOTALL)
+FRONTMATTER_RE = re.compile(r"^---\r?\n(.*?)\r?\n---(?:\r?\n|$)", re.DOTALL)
 MD_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
 
 DEFAULT_ROOTS = (".agents/skills",)

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -51,7 +51,7 @@ MAX_DESCRIPTION_CHARS = 1024
 # are intentionally left to markdown-link-check.
 BUNDLE_DIRS = ("references", "scripts", "templates", "assets")
 
-FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+FRONTMATTER_RE = re.compile(r"^---\r?\n(.*?)\r?\n---", re.DOTALL)
 MD_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
 
 DEFAULT_ROOTS = (".agents/skills",)
@@ -93,7 +93,11 @@ def _check_bundle_links(skill_md: Path, text: str, dir_name: str, report: Report
         first_segment = path_part.split("/", 1)[0]
         if first_segment not in BUNDLE_DIRS:
             continue
-        if not (skill_md.parent / path_part).exists():
+        candidate = (skill_md.parent / path_part).resolve(strict=False)
+        bundle_root = (skill_md.parent / first_segment).resolve(strict=False)
+        if not candidate.is_relative_to(bundle_root):
+            report.fail(dir_name, f"SKILL.md link '{path_part}' escapes the '{first_segment}' bundle directory")
+        elif not candidate.exists():
             report.fail(dir_name, f"SKILL.md links to missing bundle file '{path_part}'")
 
 
@@ -107,7 +111,12 @@ def validate_skill(skill_dir: Path, report: Report) -> None:
         report.fail(dir_name, "missing SKILL.md")
         return
 
-    text = skill_md.read_text(encoding="utf-8")
+    try:
+        text = skill_md.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError) as err:
+        report.fail(dir_name, f"Unable to read SKILL.md: {err}")
+        return
+
     frontmatter = _parse_frontmatter(text)
     if frontmatter is None:
         report.fail(dir_name, "SKILL.md frontmatter is missing or not valid YAML")

--- a/tests/test_agent_skills.py
+++ b/tests/test_agent_skills.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Repo-local agent skills under .agents/skills must pass the skill validator.
+
+This guards the maintainer skill set in CI's pytest job, in addition to the
+pre-commit hook, since the skills-eval workflow is scoped to skills/ only.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_ROOT = REPO_ROOT / ".agents" / "skills"
+VALIDATOR = REPO_ROOT / "scripts" / "validate_skills.py"
+
+
+def _load_validator():
+    spec = importlib.util.spec_from_file_location("validate_skills", VALIDATOR)
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so dataclasses can resolve annotations under
+    # `from __future__ import annotations` during dynamic import.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_agent_skills_are_valid():
+    validator = _load_validator()
+    report = validator.validate_roots([SKILLS_ROOT])
+    assert report.skills_checked >= 1, f"no skills found under {SKILLS_ROOT}"
+    assert report.errors == [], "skill validation errors:\n" + "\n".join(report.errors)

--- a/tests/test_agent_skills.py
+++ b/tests/test_agent_skills.py
@@ -30,6 +30,10 @@ VALIDATOR = REPO_ROOT / "scripts" / "validate_skills.py"
 def _load_validator():
     """Dynamically import scripts/validate_skills.py and return the module."""
     spec = importlib.util.spec_from_file_location("validate_skills", VALIDATOR)
+    if spec is None:
+        raise RuntimeError(f"failed to create import spec for {VALIDATOR}")
+    if spec.loader is None:
+        raise RuntimeError(f"import spec loader missing for {VALIDATOR}")
     module = importlib.util.module_from_spec(spec)
     # Register before exec so dataclasses can resolve annotations under
     # `from __future__ import annotations` during dynamic import.

--- a/tests/test_agent_skills.py
+++ b/tests/test_agent_skills.py
@@ -28,6 +28,7 @@ VALIDATOR = REPO_ROOT / "scripts" / "validate_skills.py"
 
 
 def _load_validator():
+    """Dynamically import scripts/validate_skills.py and return the module."""
     spec = importlib.util.spec_from_file_location("validate_skills", VALIDATOR)
     module = importlib.util.module_from_spec(spec)
     # Register before exec so dataclasses can resolve annotations under
@@ -38,6 +39,7 @@ def _load_validator():
 
 
 def test_agent_skills_are_valid():
+    """Assert every skill bundle under .agents/skills passes structural validation."""
     validator = _load_validator()
     report = validator.validate_roots([SKILLS_ROOT])
     assert report.skills_checked >= 1, f"no skills found under {SKILLS_ROOT}"

--- a/tests/test_agent_skills.py
+++ b/tests/test_agent_skills.py
@@ -19,8 +19,11 @@ pre-commit hook, since the skills-eval workflow is scoped to skills/ only.
 """
 
 import importlib.util
+import os
 import sys
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SKILLS_ROOT = REPO_ROOT / ".agents" / "skills"
@@ -48,3 +51,53 @@ def test_agent_skills_are_valid():
     report = validator.validate_roots([SKILLS_ROOT])
     assert report.skills_checked >= 1, f"no skills found under {SKILLS_ROOT}"
     assert report.errors == [], "skill validation errors:\n" + "\n".join(report.errors)
+
+
+def _make_bundle(root: Path, name: str, *, body: str = "", newline: str = "\n") -> Path:
+    """Create a minimal, otherwise-valid skill bundle under root and return its directory."""
+    bundle = root / name
+    bundle.mkdir(parents=True)
+    skill_md = (
+        f"---{newline}"
+        f"name: {name}{newline}"
+        f"description: Temporary skill bundle for validator tests.{newline}"
+        f"---{newline}{newline}"
+        f"{body}{newline}"
+    )
+    # newline="" keeps our explicit line endings so the CRLF case stays CRLF on disk.
+    (bundle / "SKILL.md").write_text(skill_md, encoding="utf-8", newline="")
+    return bundle
+
+
+def test_validator_flags_bundle_link_escape(tmp_path):
+    """A relative bundle link that traverses out of its bundle directory is an error."""
+    validator = _load_validator()
+    root = tmp_path / "skills"
+    _make_bundle(root, "aiq-escape-skill", body="See [oops](references/../../secret.md).")
+    report = validator.validate_roots([root])
+    assert any("escapes the" in e for e in report.errors), report.errors
+
+
+def test_validator_flags_unreadable_skill_md(tmp_path):
+    """An unreadable SKILL.md is reported rather than crashing the validator."""
+    validator = _load_validator()
+    root = tmp_path / "skills"
+    skill_md = _make_bundle(root, "aiq-unreadable-skill") / "SKILL.md"
+    skill_md.chmod(0o000)
+    if os.access(skill_md, os.R_OK):  # e.g. running as root, where chmod can't block reads
+        skill_md.chmod(0o644)
+        pytest.skip("cannot make file unreadable as the current user")
+    try:
+        report = validator.validate_roots([root])
+    finally:
+        skill_md.chmod(0o644)
+    assert any("Unable to read SKILL.md" in e for e in report.errors), report.errors
+
+
+def test_validator_accepts_crlf_frontmatter(tmp_path):
+    """CRLF line endings in frontmatter are valid; the regex matches `\\r?\\n` by design."""
+    validator = _load_validator()
+    root = tmp_path / "skills"
+    _make_bundle(root, "aiq-crlf-skill", body="# body", newline="\r\n")
+    report = validator.validate_roots([root])
+    assert report.errors == [], report.errors


### PR DESCRIPTION
#### Overview

Adds the first repo-local **maintainer Agent Skills** to AI-Q, mirroring the
NeMo Relay split between repo guidance, maintainer skills, and consumer skills.
This is the foundation slice of the DEVSKILLS work: repo guidance +
authoring scaffolding + a validator + one exemplar skill. It intentionally adds
**no in-product skill runtime** — these are static guidance bundles that coding
agents (Claude Code, Codex, Cursor, OpenCode) load while working in this repo.

What's included:

- **`AGENTS.md`** (+ `CLAUDE.md` symlink) — repository-global contract for coding
  agents: structure, build/test/eval commands, coding style, security/auth rules,
  frontend conventions, docs expectations, and DCO/PR hygiene.
- **`.agents/skills/README.md`** — maintainer skill index; explains maintainer
  skills (`.agents/skills/`) vs. API-consumer skills (`skills/`: `aiq-deploy`,
  `aiq-research`).
- **`.agents/skills/TEMPLATE.md`** — canonical authoring template and frontmatter
  contract for new skills.
- **`scripts/validate_skills.py`** — offline validator (frontmatter, naming, name
  ↔ directory match, description length, in-bundle link existence), wired into
  **pre-commit** and a **pytest** gate. This is the sole automated gate for
  `.agents/skills/`, since the existing `skills-eval` workflow is scoped to
  `skills/` only.
- **`.agents/skills/aiq-add-data-source/`** — exemplar skill (SKILL.md + 3
  references) covering the full data-source workflow: package layout,
  `FunctionBaseConfig` + `@register_function`, missing-secret stub,
  `data_source_registry` wiring, and validation commands. Surfaced to agents via
  a `.claude/skills/` symlink.

#### Validation

```bash
uv run python scripts/validate_skills.py .agents/skills   # -> 3 skill(s) OK
uv run pytest tests/test_agent_skills.py                  # -> 1 passed
pre-commit run --all-files                                # all hooks pass (incl. validate-skills)
uv run ruff check . && uv run ruff format --check .
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added maintainer-facing agent-skills guidance (maintainer README, authoring template, and “add data source” workflow/reference docs)
  * Clarified maintainer vs API-consumer skills in integration docs, including updated symlink behavior
  * Added repository-wide authoring guidance via `AGENTS.md` and a `CLAUDE.md` link
* **Tests**
  * Added a validation-focused test suite for the skills validator (acceptance and failure cases)
* **Chores**
  * Added an offline skills validator and a pre-commit hook to fail fast on malformed skills
<!-- end of auto-generated comment: release notes by coderabbit.ai -->