### PR TITLE
Add report follow-up jobs and chat routing

### DIFF
--- a/ci/markdown-link-check-config.json
+++ b/ci/markdown-link-check-config.json
@@ -11,6 +11,12 @@
         },
         {
             "pattern": "^https://www\\.postgresql\\.org/$"
+        },
+        {
+            "pattern": "^https://fastapi\\.tiangolo\\.com/$"
+        },
+        {
+            "pattern": "^https://www\\.dask\\.org/$"
         }
     ],
     "replacementPatterns": [

--- a/deploy/compose/init-db.sql
+++ b/deploy/compose/init-db.sql
@@ -57,10 +57,17 @@ CREATE TABLE IF NOT EXISTS job_access (
     owner_auth_type VARCHAR NOT NULL,
     owner_subject VARCHAR NOT NULL,
     owner_email VARCHAR,
+    conversation_id VARCHAR,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
+-- Upgrade path: CREATE TABLE IF NOT EXISTS does not add columns to a pre-existing table,
+-- so add conversation_id explicitly (idempotent) for deployments created before report follow-up.
+ALTER TABLE job_access ADD COLUMN IF NOT EXISTS conversation_id VARCHAR;
+
 CREATE INDEX IF NOT EXISTS idx_job_access_owner ON job_access(owner_auth_type, owner_subject);
+-- Supports the report-follow-up default: "latest completed report job in this conversation".
+CREATE INDEX IF NOT EXISTS idx_job_access_conversation ON job_access(conversation_id);
 
 -- Job events table (SSE streaming, event persistence)
 CREATE TABLE IF NOT EXISTS job_events (

--- a/deploy/compose/init-db.sql
+++ b/deploy/compose/init-db.sql
@@ -58,12 +58,14 @@ CREATE TABLE IF NOT EXISTS job_access (
     owner_subject VARCHAR NOT NULL,
     owner_email VARCHAR,
     conversation_id VARCHAR,
+    agent_type VARCHAR,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
 -- Upgrade path: CREATE TABLE IF NOT EXISTS does not add columns to a pre-existing table,
--- so add conversation_id explicitly (idempotent) for deployments created before report follow-up.
+-- so add the report-follow-up columns explicitly (idempotent) for older deployments.
 ALTER TABLE job_access ADD COLUMN IF NOT EXISTS conversation_id VARCHAR;
+ALTER TABLE job_access ADD COLUMN IF NOT EXISTS agent_type VARCHAR;
 
 CREATE INDEX IF NOT EXISTS idx_job_access_owner ON job_access(owner_auth_type, owner_subject);
 -- Supports the report-follow-up default: "latest completed report job in this conversation".

--- a/docs/source/architecture/agents/deep-researcher.md
+++ b/docs/source/architecture/agents/deep-researcher.md
@@ -156,7 +156,7 @@ functions:
     source_router_llm: nemotron_super_llm
     researcher_llm: nemotron_llm
     planner_llm: nemotron_llm
-    writer_llm: gpt_oss_llm
+    writer_llm: nemotron_super_llm
     verbose: true
     tools:
       - web_search_tool

--- a/docs/source/customization/configuration-reference.md
+++ b/docs/source/customization/configuration-reference.md
@@ -351,7 +351,7 @@ functions:
     source_router_llm: nemotron_super_llm
     researcher_llm: nemotron_super_llm
     planner_llm: nemotron_super_llm
-    writer_llm: gpt_oss_llm
+    writer_llm: nemotron_super_llm
     tools:
       - paper_search_tool
       - advanced_web_search_tool

--- a/docs/source/integration/rest-api.md
+++ b/docs/source/integration/rest-api.md
@@ -146,6 +146,21 @@ response carries `parent_job_id`, `interaction_action` (`edit`), and `result_kin
 | `500` | Failed to submit the report edit job |
 | `503` | Dask scheduler not available |
 
+#### Conversation-scoped default for chat follow-up
+
+The chat surface (`POST /chat`) routes report follow-up (ask / edit / delta) using an
+`active_report_job_id`. Clients may send it explicitly (it always wins), but when it is omitted
+the server **defaults to the most recent completed report job in the request's conversation** —
+identified by the `conversation-id` request header. This lets any client (CLI, API, or the UI on
+reload) get report follow-up by simply reusing a stable `conversation-id` across turns, without
+tracking report ids. Jobs record their originating `conversation-id` at submit time for this lookup.
+
+When no `active_report_job_id` and no (or a brand-new) `conversation-id` are present, follow-up
+degrades to fresh research. The lookup is authorized like every other job read: under
+`REQUIRE_AUTH=true` it is scoped to the caller's own jobs; under `REQUIRE_AUTH=false` (the public
+default) ownership is not enforced, so `conversation-id` is the only isolation boundary — keep it
+unguessable in any shared/multi-user deployment, consistent with the other job endpoints in that mode.
+
 ### Get Job Status
 
 ```bash

--- a/docs/source/integration/rest-api.md
+++ b/docs/source/integration/rest-api.md
@@ -42,7 +42,8 @@ Base path: `/v1/jobs/async`
 Returns all **public** registered agent types that can be used with the submit endpoint.
 Internal-only agents (registered with `public=False`, for example the `report_rewriter`
 used by report follow-up) are intentionally omitted from this list and are rejected by
-`POST /v1/jobs/async/submit` with `400 Agent type is internal-only`.
+`POST /v1/jobs/async/submit` with `400` and a `detail` of `Agent type is internal-only: <agent_type>`
+(the requested agent type is interpolated into the message).
 
 ```bash
 curl http://localhost:8000/v1/jobs/async/agents

--- a/docs/source/integration/rest-api.md
+++ b/docs/source/integration/rest-api.md
@@ -31,6 +31,7 @@ Base path: `/v1/jobs/async`
 | `GET` | `/v1/jobs/async/job/{job_id}/stream` | SSE event stream from beginning |
 | `GET` | `/v1/jobs/async/job/{job_id}/stream/{last_event_id}` | SSE stream from event ID (reconnection) |
 | `POST` | `/v1/jobs/async/job/{job_id}/cancel` | Cancel a running job |
+| `POST` | `/v1/jobs/async/job/{job_id}/report/edit` | Create a revised report from a completed report job |
 | `GET` | `/v1/jobs/async/job/{job_id}/state` | Get accumulated job artifacts |
 | `GET` | `/v1/jobs/async/job/{job_id}/report` | Get final research report |
 | `GET` | `/v1/data_sources` | List available data sources |
@@ -38,7 +39,10 @@ Base path: `/v1/jobs/async`
 
 ### List Available Agents
 
-Returns all registered agent types that can be used with the submit endpoint.
+Returns all **public** registered agent types that can be used with the submit endpoint.
+Internal-only agents (registered with `public=False`, for example the `report_rewriter`
+used by report follow-up) are intentionally omitted from this list and are rejected by
+`POST /v1/jobs/async/submit` with `400 Agent type is internal-only`.
 
 ```bash
 curl http://localhost:8000/v1/jobs/async/agents
@@ -92,8 +96,51 @@ curl -X POST http://localhost:8000/v1/jobs/async/submit \
 
 | Status | Reason |
 |--------|--------|
-| `400` | Unknown agent type or invalid request |
+| `400` | Unknown agent type, **internal-only agent type**, or invalid request |
+| `409` | A custom `job_id` was supplied that collides with an existing job |
 | `422` | One or more unknown data source IDs. Response `detail` includes `message`, `invalid_ids`, and `known_ids` for client-side recovery UX |
+| `503` | Dask scheduler not available |
+
+### Edit a Report (Report Follow-up)
+
+Create a revised report from a **completed** report job. The caller is authorized against
+the parent job, the durable report context is reconstructed, and an internal `report_rewriter`
+child job is submitted that emits a full revised report. The parent report is never mutated.
+
+```bash
+curl -X POST http://localhost:8000/v1/jobs/async/job/{job_id}/report/edit \
+  -H "Content-Type: application/json" \
+  -d '{"input": "Make the executive summary shorter and remove the appendix."}'
+```
+
+**Request body (`ReportEditRequest`):**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `input` | `string` | Yes | Edit instruction for the parent report (min 1 character) |
+| `job_id` | `string` | No | Custom child job ID. Auto-generated if omitted. Pattern: `[a-zA-Z0-9_-]`, max 64 chars |
+| `expiry_seconds` | `integer` | No | Child job expiry in seconds. Range: 600--604800. Default from config |
+
+**Response (`ReportEditResponse`):**
+
+```json
+{
+  "job_id": "child-job-uuid",
+  "parent_job_id": "parent-job-uuid",
+  "status": "SUBMITTED",
+  "agent_type": "report_rewriter"
+}
+```
+
+Track the child job with the standard status/stream/report endpoints. Its `GET .../report`
+response carries `parent_job_id`, `interaction_action` (`edit`), and `result_kind` (`report`).
+
+**Error responses:**
+
+| Status | Reason |
+|--------|--------|
+| `404` | Parent job not found (or not accessible to the caller when auth is enabled) |
+| `409` | Parent job is incomplete, has no durable report, or the supplied child `job_id` collides |
 | `503` | Dask scheduler not available |
 
 ### Get Job Status
@@ -221,9 +268,17 @@ curl http://localhost:8000/v1/jobs/async/job/{job_id}/report
 {
   "job_id": "abc123",
   "has_report": true,
-  "report": "# Quantum Computing Trends in 2026\n\n..."
+  "report": "# Quantum Computing Trends in 2026\n\n...",
+  "parent_job_id": null,
+  "interaction_action": null,
+  "result_kind": null
 }
 ```
+
+For report follow-up child jobs (see [Edit a Report](#edit-a-report-report-follow-up)),
+`parent_job_id`, `interaction_action` (for example `edit`), and `result_kind` (for example
+`report`) identify the originating report and interaction. They are `null` for root research
+jobs.
 
 ## SSE Event Types
 

--- a/docs/source/integration/rest-api.md
+++ b/docs/source/integration/rest-api.md
@@ -77,7 +77,7 @@ curl -X POST http://localhost:8000/v1/jobs/async/submit \
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `agent_type` | `string` | Yes | Agent identifier (for example, `deep_researcher`, `shallow_researcher`) |
-| `input` | `string` | Yes | Research query (min 1 character) |
+| `input` | `string` | Yes | Research query. Must be non-blank after trimming (whitespace-only is rejected with 422) |
 | `job_id` | `string` | No | Custom job ID. Auto-generated UUID if omitted. Pattern: `[a-zA-Z0-9_-]`, max 64 chars |
 | `expiry_seconds` | `integer` | No | Job expiry in seconds. Range: 600--604800 (10 min to 7 days). Default from config |
 | `data_sources` | `list[string]` | No | Optional data source IDs (from `/v1/data_sources`) to scope the job. Omit or `null` for all data-source tools; `[]` for no data-source tools. Unmapped utility tools remain available. Unknown IDs return 422 |
@@ -98,7 +98,7 @@ curl -X POST http://localhost:8000/v1/jobs/async/submit \
 |--------|--------|
 | `400` | Unknown agent type, **internal-only agent type**, or invalid request |
 | `409` | A custom `job_id` was supplied that collides with an existing job |
-| `422` | One or more unknown data source IDs. Response `detail` includes `message`, `invalid_ids`, and `known_ids` for client-side recovery UX |
+| `422` | Validation error: blank/whitespace-only `input`, invalid request fields, or one or more unknown data source IDs. Data source errors include `message`, `invalid_ids`, and `known_ids` for client-side recovery UX |
 | `503` | Dask scheduler not available |
 
 ### Edit a Report (Report Follow-up)
@@ -117,7 +117,7 @@ curl -X POST http://localhost:8000/v1/jobs/async/job/{job_id}/report/edit \
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `input` | `string` | Yes | Edit instruction for the parent report (min 1 character) |
+| `input` | `string` | Yes | Edit instruction for the parent report. Must be non-blank after trimming (whitespace-only is rejected with 422) |
 | `job_id` | `string` | No | Custom child job ID. Auto-generated if omitted. Pattern: `[a-zA-Z0-9_-]`, max 64 chars |
 | `expiry_seconds` | `integer` | No | Child job expiry in seconds. Range: 600--604800. Default from config |
 
@@ -141,6 +141,7 @@ response carries `parent_job_id`, `interaction_action` (`edit`), and `result_kin
 |--------|--------|
 | `404` | Parent job not found (or not accessible to the caller when auth is enabled) |
 | `409` | Parent job is incomplete, has no durable report, or the supplied child `job_id` collides |
+| `422` | Validation error: blank/whitespace-only `input`, invalid child `job_id`, or invalid `expiry_seconds` |
 | `500` | Failed to submit the report edit job |
 | `503` | Dask scheduler not available |
 

--- a/docs/source/integration/rest-api.md
+++ b/docs/source/integration/rest-api.md
@@ -141,6 +141,7 @@ response carries `parent_job_id`, `interaction_action` (`edit`), and `result_kin
 |--------|--------|
 | `404` | Parent job not found (or not accessible to the caller when auth is enabled) |
 | `409` | Parent job is incomplete, has no durable report, or the supplied child `job_id` collides |
+| `500` | Failed to submit the report edit job |
 | `503` | Dask scheduler not available |
 
 ### Get Job Status

--- a/frontends/aiq_api/src/aiq_api/jobs/access.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/access.py
@@ -50,12 +50,18 @@ _JOB_ACCESS_SELECT_SQL = text(
 # applied only when REQUIRE_AUTH=true, mirroring authorize_job_access (which skips ownership
 # under REQUIRE_AUTH=false). This keeps the fallback consistent with the auth gate and avoids
 # brittle owner-subject matching for the synthesized no-auth principal.
+# Agent types whose successful output is a full report eligible for follow-up. Excludes
+# non-report agents (e.g. shallow_researcher); legacy rows with NULL agent_type are allowed.
+_REPORT_PRODUCING_AGENTS = ("deep_researcher", "report_rewriter")
+_REPORT_AGENT_FILTER = (
+    "AND (ja.agent_type IS NULL OR ja.agent_type IN (" + ", ".join(f"'{a}'" for a in _REPORT_PRODUCING_AGENTS) + ")) "
+)
 _LATEST_REPORT_JOB_BASE = (
     "SELECT ja.job_id FROM job_access ja "
     "JOIN job_info ji ON ja.job_id = ji.job_id "
     "WHERE ja.conversation_id = :conversation_id "
     "AND ji.status = 'success' "
-    "AND ji.is_expired IS NOT TRUE "
+    "AND ji.is_expired IS NOT TRUE " + _REPORT_AGENT_FILTER
 )
 _LATEST_REPORT_JOB_SQL_ANY = text(_LATEST_REPORT_JOB_BASE + "ORDER BY ji.created_at DESC LIMIT 1")
 _LATEST_REPORT_JOB_SQL_OWNED = text(
@@ -83,11 +89,17 @@ def ensure_job_access_table(db_url: str) -> None:
         conn.commit()
 
 
-def create_job_access(job_id: str, principal: Principal, db_url: str, conversation_id: str | None = None) -> None:
-    """Persist the verified owner (and originating conversation) for a newly created job."""
+def create_job_access(
+    job_id: str,
+    principal: Principal,
+    db_url: str,
+    conversation_id: str | None = None,
+    agent_type: str | None = None,
+) -> None:
+    """Persist the verified owner (and originating conversation + agent type) for a new job."""
     with _job_access_connection(db_url) as conn:
         _ensure_job_access_schema(conn, db_url)
-        conn.execute(_job_access_upsert_sql(db_url), _principal_params(job_id, principal, conversation_id))
+        conn.execute(_job_access_upsert_sql(db_url), _principal_params(job_id, principal, conversation_id, agent_type))
         conn.commit()
 
 
@@ -294,27 +306,30 @@ def _ensure_job_access_schema(conn: Connection, db_url: str) -> None:
     if db_url in _job_access_schema_initialized:
         return
     conn.execute(text(_job_access_table_sql(db_url)))
-    _ensure_conversation_id_column(conn, db_url)
+    _ensure_extra_columns(conn, db_url)
     conn.execute(text(_JOB_ACCESS_INDEX_SQL))
     conn.execute(text(_JOB_ACCESS_CONVERSATION_INDEX_SQL))
     _job_access_schema_initialized.add(db_url)
 
 
-def _ensure_conversation_id_column(conn: Connection, db_url: str) -> None:
-    """Add conversation_id to a pre-existing job_access table (CREATE TABLE IF NOT EXISTS won't).
+def _ensure_extra_columns(conn: Connection, db_url: str) -> None:
+    """Add conversation_id / agent_type to a pre-existing job_access table.
 
-    Idempotent across upgrades: Postgres supports ADD COLUMN IF NOT EXISTS; SQLite does not, so
-    check PRAGMA table_info first. Best-effort — a concurrent add or older engine degrades cleanly.
+    CREATE TABLE IF NOT EXISTS won't add columns to an existing table. Idempotent across upgrades:
+    Postgres supports ADD COLUMN IF NOT EXISTS; SQLite does not, so check PRAGMA table_info first.
+    Best-effort — a concurrent add or older engine degrades cleanly.
     """
     try:
         if _is_postgres(db_url):
-            conn.execute(text("ALTER TABLE job_access ADD COLUMN IF NOT EXISTS conversation_id VARCHAR"))
+            for col in ("conversation_id", "agent_type"):
+                conn.execute(text(f"ALTER TABLE job_access ADD COLUMN IF NOT EXISTS {col} VARCHAR"))
         else:
             cols = {row[1] for row in conn.execute(text("PRAGMA table_info(job_access)")).fetchall()}
-            if "conversation_id" not in cols:
-                conn.execute(text("ALTER TABLE job_access ADD COLUMN conversation_id VARCHAR"))
+            for col in ("conversation_id", "agent_type"):
+                if col not in cols:
+                    conn.execute(text(f"ALTER TABLE job_access ADD COLUMN {col} VARCHAR"))
     except Exception as e:
-        logger.debug("Could not ensure job_access.conversation_id column: %s", type(e).__name__)
+        logger.debug("Could not ensure job_access extra columns: %s", type(e).__name__)
 
 
 def _job_access_table_sql(db_url: str) -> str:
@@ -329,6 +344,7 @@ def _job_access_table_sql(db_url: str) -> str:
         "  owner_subject VARCHAR NOT NULL,"
         "  owner_email VARCHAR,"
         "  conversation_id VARCHAR,"
+        "  agent_type VARCHAR,"
         f"  created_at {created_at_type}"
         ")"
     )
@@ -336,28 +352,30 @@ def _job_access_table_sql(db_url: str) -> str:
 
 def _job_access_upsert_sql(db_url: str):
     """Return the dialect-appropriate upsert statement for ``job_access``."""
+    cols = "job_id, owner_auth_type, owner_subject, owner_email, conversation_id, agent_type"
+    vals = ":job_id, :owner_auth_type, :owner_subject, :owner_email, :conversation_id, :agent_type"
     postgres_upsert = (
-        "INSERT INTO job_access (job_id, owner_auth_type, owner_subject, owner_email, conversation_id) "
-        "VALUES (:job_id, :owner_auth_type, :owner_subject, :owner_email, :conversation_id) "
+        f"INSERT INTO job_access ({cols}) VALUES ({vals}) "
         "ON CONFLICT(job_id) DO UPDATE SET "
         "owner_auth_type = excluded.owner_auth_type, "
         "owner_subject = excluded.owner_subject, "
         "owner_email = excluded.owner_email, "
-        "conversation_id = excluded.conversation_id"
+        "conversation_id = excluded.conversation_id, "
+        "agent_type = excluded.agent_type"
     )
-    sqlite_upsert = (
-        "INSERT OR REPLACE INTO job_access (job_id, owner_auth_type, owner_subject, owner_email, conversation_id) "
-        "VALUES (:job_id, :owner_auth_type, :owner_subject, :owner_email, :conversation_id)"
-    )
+    sqlite_upsert = f"INSERT OR REPLACE INTO job_access ({cols}) VALUES ({vals})"
     return text(postgres_upsert if _is_postgres(db_url) else sqlite_upsert)
 
 
-def _principal_params(job_id: str, principal: Principal, conversation_id: str | None = None) -> dict[str, str | None]:
-    """Return SQL bind params for a job's owner identity and conversation."""
+def _principal_params(
+    job_id: str, principal: Principal, conversation_id: str | None = None, agent_type: str | None = None
+) -> dict[str, str | None]:
+    """Return SQL bind params for a job's owner identity, conversation, and agent type."""
     return {
         "job_id": job_id,
         "owner_auth_type": principal.type,
         "owner_subject": principal.sub,
         "owner_email": principal.email,
         "conversation_id": conversation_id,
+        "agent_type": agent_type,
     }

--- a/frontends/aiq_api/src/aiq_api/jobs/access.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/access.py
@@ -39,8 +39,29 @@ _job_access_schema_initialized: set[str] = set()
 _TERMINAL_STATUS_SQL = "('success','failure','failed','interrupted','cancelled','completed','error')"
 
 _JOB_ACCESS_INDEX_SQL = "CREATE INDEX IF NOT EXISTS idx_job_access_owner ON job_access(owner_auth_type, owner_subject)"
+_JOB_ACCESS_CONVERSATION_INDEX_SQL = (
+    "CREATE INDEX IF NOT EXISTS idx_job_access_conversation ON job_access(conversation_id)"
+)
 _JOB_ACCESS_SELECT_SQL = text(
-    "SELECT job_id, owner_auth_type, owner_subject, owner_email, created_at FROM job_access WHERE job_id = :job_id"
+    "SELECT job_id, owner_auth_type, owner_subject, owner_email, conversation_id, created_at "
+    "FROM job_access WHERE job_id = :job_id"
+)
+# Most recent completed, non-expired report job for a conversation. The owner predicate is
+# applied only when REQUIRE_AUTH=true, mirroring authorize_job_access (which skips ownership
+# under REQUIRE_AUTH=false). This keeps the fallback consistent with the auth gate and avoids
+# brittle owner-subject matching for the synthesized no-auth principal.
+_LATEST_REPORT_JOB_BASE = (
+    "SELECT ja.job_id FROM job_access ja "
+    "JOIN job_info ji ON ja.job_id = ji.job_id "
+    "WHERE ja.conversation_id = :conversation_id "
+    "AND ji.status = 'success' "
+    "AND ji.is_expired IS NOT TRUE "
+)
+_LATEST_REPORT_JOB_SQL_ANY = text(_LATEST_REPORT_JOB_BASE + "ORDER BY ji.created_at DESC LIMIT 1")
+_LATEST_REPORT_JOB_SQL_OWNED = text(
+    _LATEST_REPORT_JOB_BASE
+    + "AND ja.owner_auth_type = :owner_auth_type AND ja.owner_subject = :owner_subject "
+    + "ORDER BY ji.created_at DESC LIMIT 1"
 )
 _JOB_ACCESS_DELETE_SQL = text("DELETE FROM job_access WHERE job_id = :job_id")
 _JOB_ACCESS_CLEANUP_SQL = text(
@@ -62,12 +83,43 @@ def ensure_job_access_table(db_url: str) -> None:
         conn.commit()
 
 
-def create_job_access(job_id: str, principal: Principal, db_url: str) -> None:
-    """Persist the verified owner for a newly created job."""
+def create_job_access(job_id: str, principal: Principal, db_url: str, conversation_id: str | None = None) -> None:
+    """Persist the verified owner (and originating conversation) for a newly created job."""
     with _job_access_connection(db_url) as conn:
         _ensure_job_access_schema(conn, db_url)
-        conn.execute(_job_access_upsert_sql(db_url), _principal_params(job_id, principal))
+        conn.execute(_job_access_upsert_sql(db_url), _principal_params(job_id, principal, conversation_id))
         conn.commit()
+
+
+def get_latest_report_job_for_conversation(
+    conversation_id: str | None, principal: Principal, db_url: str
+) -> str | None:
+    """Return the most recent completed report job submitted in this conversation by this caller.
+
+    Used as the server-side default for report follow-up when the client does not supply an
+    explicit ``active_report_job_id``. Returns None (degrade to fresh research) for an empty
+    conversation id, no match, or any storage error — it must never raise into the request path.
+    """
+    if not conversation_id:
+        return None
+    enforce_owner = os.environ.get("REQUIRE_AUTH", "false").lower() == "true"
+    if enforce_owner and principal is None:
+        return None
+    params: dict[str, str] = {"conversation_id": conversation_id}
+    if enforce_owner:
+        sql = _LATEST_REPORT_JOB_SQL_OWNED
+        params["owner_auth_type"] = principal.type
+        params["owner_subject"] = principal.sub
+    else:
+        sql = _LATEST_REPORT_JOB_SQL_ANY
+    try:
+        with _job_access_connection(db_url) as conn:
+            _ensure_job_access_schema(conn, db_url)
+            row = conn.execute(sql, params).first()
+            return row[0] if row else None
+    except Exception as e:
+        logger.debug("Conversation report-job lookup failed for %s: %s", conversation_id, type(e).__name__)
+        return None
 
 
 def get_job_access(job_id: str, db_url: str) -> dict[str, Any] | None:
@@ -242,8 +294,27 @@ def _ensure_job_access_schema(conn: Connection, db_url: str) -> None:
     if db_url in _job_access_schema_initialized:
         return
     conn.execute(text(_job_access_table_sql(db_url)))
+    _ensure_conversation_id_column(conn, db_url)
     conn.execute(text(_JOB_ACCESS_INDEX_SQL))
+    conn.execute(text(_JOB_ACCESS_CONVERSATION_INDEX_SQL))
     _job_access_schema_initialized.add(db_url)
+
+
+def _ensure_conversation_id_column(conn: Connection, db_url: str) -> None:
+    """Add conversation_id to a pre-existing job_access table (CREATE TABLE IF NOT EXISTS won't).
+
+    Idempotent across upgrades: Postgres supports ADD COLUMN IF NOT EXISTS; SQLite does not, so
+    check PRAGMA table_info first. Best-effort — a concurrent add or older engine degrades cleanly.
+    """
+    try:
+        if _is_postgres(db_url):
+            conn.execute(text("ALTER TABLE job_access ADD COLUMN IF NOT EXISTS conversation_id VARCHAR"))
+        else:
+            cols = {row[1] for row in conn.execute(text("PRAGMA table_info(job_access)")).fetchall()}
+            if "conversation_id" not in cols:
+                conn.execute(text("ALTER TABLE job_access ADD COLUMN conversation_id VARCHAR"))
+    except Exception as e:
+        logger.debug("Could not ensure job_access.conversation_id column: %s", type(e).__name__)
 
 
 def _job_access_table_sql(db_url: str) -> str:
@@ -257,6 +328,7 @@ def _job_access_table_sql(db_url: str) -> str:
         "  owner_auth_type VARCHAR NOT NULL,"
         "  owner_subject VARCHAR NOT NULL,"
         "  owner_email VARCHAR,"
+        "  conversation_id VARCHAR,"
         f"  created_at {created_at_type}"
         ")"
     )
@@ -265,25 +337,27 @@ def _job_access_table_sql(db_url: str) -> str:
 def _job_access_upsert_sql(db_url: str):
     """Return the dialect-appropriate upsert statement for ``job_access``."""
     postgres_upsert = (
-        "INSERT INTO job_access (job_id, owner_auth_type, owner_subject, owner_email) "
-        "VALUES (:job_id, :owner_auth_type, :owner_subject, :owner_email) "
+        "INSERT INTO job_access (job_id, owner_auth_type, owner_subject, owner_email, conversation_id) "
+        "VALUES (:job_id, :owner_auth_type, :owner_subject, :owner_email, :conversation_id) "
         "ON CONFLICT(job_id) DO UPDATE SET "
         "owner_auth_type = excluded.owner_auth_type, "
         "owner_subject = excluded.owner_subject, "
-        "owner_email = excluded.owner_email"
+        "owner_email = excluded.owner_email, "
+        "conversation_id = excluded.conversation_id"
     )
     sqlite_upsert = (
-        "INSERT OR REPLACE INTO job_access (job_id, owner_auth_type, owner_subject, owner_email) "
-        "VALUES (:job_id, :owner_auth_type, :owner_subject, :owner_email)"
+        "INSERT OR REPLACE INTO job_access (job_id, owner_auth_type, owner_subject, owner_email, conversation_id) "
+        "VALUES (:job_id, :owner_auth_type, :owner_subject, :owner_email, :conversation_id)"
     )
     return text(postgres_upsert if _is_postgres(db_url) else sqlite_upsert)
 
 
-def _principal_params(job_id: str, principal: Principal) -> dict[str, str | None]:
-    """Return the SQL bind params for a job's owner identity."""
+def _principal_params(job_id: str, principal: Principal, conversation_id: str | None = None) -> dict[str, str | None]:
+    """Return SQL bind params for a job's owner identity and conversation."""
     return {
         "job_id": job_id,
         "owner_auth_type": principal.type,
         "owner_subject": principal.sub,
         "owner_email": principal.email,
+        "conversation_id": conversation_id,
     }

--- a/frontends/aiq_api/src/aiq_api/jobs/report_context.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/report_context.py
@@ -203,17 +203,24 @@ async def resolve_report_context(job: Any, db_url: str, parent_job_id: str) -> R
     if not report:
         raise HTTPException(409, f"Parent job has no durable report: {parent_job_id}")
 
-    if events is None:
-        # The report is already in hand (from job output); the event log is only
-        # needed to enrich sources. A transient fetch failure here must not abort
-        # report follow-up — fall back to report-only source extraction.
-        try:
-            events = await EventStore.get_events_async(db_url, parent_job_id, 0, _EVENT_SCAN_LIMIT)
-        except Exception:
-            events = []
-    event_sources = _sources_from_events(events)
     report_sources = _extract_sources_from_report_markdown(report)
-    sources = _dedupe_sources([*event_sources, *report_sources])
+
+    if events is None:
+        # The report came from job output. Its own ## Sources section is authoritative for
+        # follow-up context, so only pay the (potentially large) event scan when the report
+        # carries no inline sources. A transient fetch failure must not abort follow-up.
+        if report_sources:
+            sources = report_sources
+        else:
+            try:
+                events = await EventStore.get_events_async(db_url, parent_job_id, 0, _EVENT_SCAN_LIMIT)
+            except Exception:
+                events = []
+            sources = _dedupe_sources([*_sources_from_events(events), *report_sources])
+    else:
+        # The event log was already fetched to reconstruct the report; reuse it for sources.
+        sources = _dedupe_sources([*_sources_from_events(events), *report_sources])
+
     return ReportContext(
         parent_job_id=parent_job_id,
         report_markdown=report,
@@ -238,18 +245,35 @@ def report_context_from_markdown(report_markdown: str, parent_job_id: str = "in-
     )
 
 
+# Cache JobStore instances by (scheduler_address, db_url). JobStore eagerly builds a SQLAlchemy
+# AsyncEngine with its own connection pool, so constructing one per request both wastes work and
+# leaks pooled connections. Engines are designed to be long-lived and shared, and JobStore's
+# sessions are task-scoped (async_scoped_session), so a process-wide cache is safe.
+_JOB_STORE_CACHE: dict[tuple[str, str], Any] = {}
+
+
+def _get_job_store(scheduler_address: str, db_url: str) -> Any:
+    from nat.front_ends.fastapi.async_jobs.job_store import JobStore
+
+    key = (scheduler_address, db_url)
+    store = _JOB_STORE_CACHE.get(key)
+    if store is None:
+        store = JobStore(scheduler_address=scheduler_address, db_url=db_url)
+        _JOB_STORE_CACHE[key] = store
+    return store
+
+
 async def resolve_authorized_report_context(parent_job_id: str, principal: Principal) -> ReportContext:
     """Authorize and reconstruct a parent report context using configured async job storage."""
 
     from nat.front_ends.fastapi.async_jobs.job_store import JobStatus
-    from nat.front_ends.fastapi.async_jobs.job_store import JobStore
 
     scheduler_address = os.environ.get("NAT_DASK_SCHEDULER_ADDRESS")
     if not scheduler_address:
         raise HTTPException(503, "Async job storage is not configured")
 
     db_url = os.environ.get("NAT_JOB_STORE_DB_URL", "sqlite:///./data/jobs.db")
-    job_store = JobStore(scheduler_address=scheduler_address, db_url=db_url)
+    job_store = _get_job_store(scheduler_address, db_url)
     job = await authorize_job_access(job_store, db_url, parent_job_id, principal)
     if getattr(job, "status", None) != JobStatus.SUCCESS.value:
         raise HTTPException(409, f"Parent job is not complete: {parent_job_id}")
@@ -257,7 +281,7 @@ async def resolve_authorized_report_context(parent_job_id: str, principal: Princ
 
 
 def to_initial_files(context: ReportContext, instruction: str | None = None) -> dict[str, str]:
-    """Convert report context into PR 267 DeepAgents virtual filesystem seed files."""
+    """Convert report context into DeepAgents virtual filesystem seed files."""
 
     # Exclude report_markdown from the JSON context: the full report is already seeded
     # verbatim into /shared/original_report.md, so embedding it again here would roughly

--- a/frontends/aiq_api/src/aiq_api/jobs/report_context.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/report_context.py
@@ -87,11 +87,6 @@ def _report_from_events(events: list[dict[str, Any]]) -> str | None:
     return final_report or fallback
 
 
-async def _extract_report_from_events(db_url: str, job_id: str) -> str | None:
-    events = await EventStore.get_events_async(db_url, job_id, 0, _EVENT_SCAN_LIMIT)
-    return _report_from_events(events)
-
-
 def _is_url(value: str | None) -> bool:
     return bool(value and value.lower().startswith(("http://", "https://")))
 
@@ -141,12 +136,7 @@ def _sources_from_events(events: list[dict[str, Any]]) -> list[ReportContextSour
                 tool_name=str(data.get("tool_name") or "parent_report"),
             )
         )
-    return _dedupe_sources(sources)
-
-
-async def _extract_sources_from_events(db_url: str, job_id: str) -> list[ReportContextSource]:
-    events = await EventStore.get_events_async(db_url, job_id, 0, _EVENT_SCAN_LIMIT)
-    return _sources_from_events(events)
+    return sources
 
 
 def _sources_section(report_markdown: str) -> str:
@@ -176,7 +166,7 @@ def _extract_sources_from_report_markdown(report_markdown: str) -> list[ReportCo
             sources.append(ReportContextSource(url=url_match.group(0).rstrip(_URL_TRIM_CHARS), title=ref_text))
         else:
             sources.append(ReportContextSource(citation_key=ref_text, title=ref_text))
-    return _dedupe_sources(sources)
+    return sources
 
 
 def _source_summary_markdown(sources: list[ReportContextSource]) -> str:
@@ -210,7 +200,7 @@ async def resolve_report_context(job: Any, db_url: str, parent_job_id: str) -> R
         # follow-up context, so only pay the (potentially large) event scan when the report
         # carries no inline sources. A transient fetch failure must not abort follow-up.
         if report_sources:
-            sources = report_sources
+            sources = _dedupe_sources(report_sources)
         else:
             try:
                 events = await EventStore.get_events_async(db_url, parent_job_id, 0, _EVENT_SCAN_LIMIT)
@@ -236,7 +226,7 @@ def report_context_from_markdown(report_markdown: str, parent_job_id: str = "in-
     current session rather than as a durable async job. Sources are reconstructed from the report's
     own ``## Sources`` section via the same parser used for job-backed reports.
     """
-    sources = _extract_sources_from_report_markdown(report_markdown)
+    sources = _dedupe_sources(_extract_sources_from_report_markdown(report_markdown))
     return ReportContext(
         parent_job_id=parent_job_id,
         report_markdown=report_markdown,

--- a/frontends/aiq_api/src/aiq_api/jobs/report_context.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/report_context.py
@@ -204,7 +204,13 @@ async def resolve_report_context(job: Any, db_url: str, parent_job_id: str) -> R
         raise HTTPException(409, f"Parent job has no durable report: {parent_job_id}")
 
     if events is None:
-        events = await EventStore.get_events_async(db_url, parent_job_id, 0, _EVENT_SCAN_LIMIT)
+        # The report is already in hand (from job output); the event log is only
+        # needed to enrich sources. A transient fetch failure here must not abort
+        # report follow-up — fall back to report-only source extraction.
+        try:
+            events = await EventStore.get_events_async(db_url, parent_job_id, 0, _EVENT_SCAN_LIMIT)
+        except Exception:
+            events = []
     event_sources = _sources_from_events(events)
     report_sources = _extract_sources_from_report_markdown(report)
     sources = _dedupe_sources([*event_sources, *report_sources])

--- a/frontends/aiq_api/src/aiq_api/jobs/report_context.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/report_context.py
@@ -237,9 +237,12 @@ async def resolve_authorized_report_context(parent_job_id: str, principal: Princ
 def to_initial_files(context: ReportContext, instruction: str | None = None) -> dict[str, str]:
     """Convert report context into PR 267 DeepAgents virtual filesystem seed files."""
 
+    # Exclude report_markdown from the JSON context: the full report is already seeded
+    # verbatim into /shared/original_report.md, so embedding it again here would roughly
+    # double the report tokens carried into the rewrite/research prompt for no benefit.
     files = {
         "/shared/original_report.md": context.report_markdown,
-        "/shared/parent_report_context.json": context.model_dump_json(indent=2),
+        "/shared/parent_report_context.json": context.model_dump_json(indent=2, exclude={"report_markdown"}),
         "/shared/source_summary.md": context.source_summary_markdown,
     }
     if instruction is not None:

--- a/frontends/aiq_api/src/aiq_api/jobs/report_context.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/report_context.py
@@ -222,6 +222,22 @@ async def resolve_report_context(job: Any, db_url: str, parent_job_id: str) -> R
     )
 
 
+def report_context_from_markdown(report_markdown: str, parent_job_id: str = "in-session") -> ReportContext:
+    """Build report context directly from report markdown — no job store, auth, or scheduler.
+
+    Used for report follow-up in the synchronous CLI, where the report was produced inline in the
+    current session rather than as a durable async job. Sources are reconstructed from the report's
+    own ``## Sources`` section via the same parser used for job-backed reports.
+    """
+    sources = _extract_sources_from_report_markdown(report_markdown)
+    return ReportContext(
+        parent_job_id=parent_job_id,
+        report_markdown=report_markdown,
+        source_summary_markdown=_source_summary_markdown(sources),
+        sources=sources,
+    )
+
+
 async def resolve_authorized_report_context(parent_job_id: str, principal: Principal) -> ReportContext:
     """Authorize and reconstruct a parent report context using configured async job storage."""
 

--- a/frontends/aiq_api/src/aiq_api/jobs/report_context.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/report_context.py
@@ -69,8 +69,7 @@ def _event_data(event: dict[str, Any]) -> dict[str, Any]:
     return data if isinstance(data, dict) else {}
 
 
-async def _extract_report_from_events(db_url: str, job_id: str) -> str | None:
-    events = await EventStore.get_events_async(db_url, job_id, 0, _EVENT_SCAN_LIMIT)
+def _report_from_events(events: list[dict[str, Any]]) -> str | None:
     fallback: str | None = None
     final_report: str | None = None
     for event in events:
@@ -86,6 +85,11 @@ async def _extract_report_from_events(db_url: str, job_id: str) -> str | None:
         if data.get("output_category") == "final_report":
             final_report = content.strip()
     return final_report or fallback
+
+
+async def _extract_report_from_events(db_url: str, job_id: str) -> str | None:
+    events = await EventStore.get_events_async(db_url, job_id, 0, _EVENT_SCAN_LIMIT)
+    return _report_from_events(events)
 
 
 def _is_url(value: str | None) -> bool:
@@ -113,8 +117,7 @@ def _dedupe_sources(sources: list[ReportContextSource]) -> list[ReportContextSou
     return deduped
 
 
-async def _extract_sources_from_events(db_url: str, job_id: str) -> list[ReportContextSource]:
-    events = await EventStore.get_events_async(db_url, job_id, 0, _EVENT_SCAN_LIMIT)
+def _sources_from_events(events: list[dict[str, Any]]) -> list[ReportContextSource]:
     sources: list[ReportContextSource] = []
     for event in events:
         if event.get("type") != "artifact.update":
@@ -139,6 +142,11 @@ async def _extract_sources_from_events(db_url: str, job_id: str) -> list[ReportC
             )
         )
     return _dedupe_sources(sources)
+
+
+async def _extract_sources_from_events(db_url: str, job_id: str) -> list[ReportContextSource]:
+    events = await EventStore.get_events_async(db_url, job_id, 0, _EVENT_SCAN_LIMIT)
+    return _sources_from_events(events)
 
 
 def _sources_section(report_markdown: str) -> str:
@@ -185,11 +193,19 @@ def _source_summary_markdown(sources: list[ReportContextSource]) -> str:
 async def resolve_report_context(job: Any, db_url: str, parent_job_id: str) -> ReportContext:
     """Build report context from a previously authorized parent job."""
 
-    report = _extract_report_from_job_output(job) or await _extract_report_from_events(db_url, parent_job_id)
+    report = _extract_report_from_job_output(job)
+    # Durable events are only needed when the report isn't already in job output,
+    # or to reconstruct sources. Fetch the (potentially large) event log at most once.
+    events: list[dict[str, Any]] | None = None
+    if not report:
+        events = await EventStore.get_events_async(db_url, parent_job_id, 0, _EVENT_SCAN_LIMIT)
+        report = _report_from_events(events)
     if not report:
         raise HTTPException(409, f"Parent job has no durable report: {parent_job_id}")
 
-    event_sources = await _extract_sources_from_events(db_url, parent_job_id)
+    if events is None:
+        events = await EventStore.get_events_async(db_url, parent_job_id, 0, _EVENT_SCAN_LIMIT)
+    event_sources = _sources_from_events(events)
     report_sources = _extract_sources_from_report_markdown(report)
     sources = _dedupe_sources([*event_sources, *report_sources])
     return ReportContext(
@@ -229,3 +245,12 @@ def to_initial_files(context: ReportContext, instruction: str | None = None) -> 
     if instruction is not None:
         files["/shared/edit_instruction.txt"] = instruction
     return files
+
+
+def report_output_metadata(parent_job_id: str, action: str) -> dict[str, str]:
+    """Durable output metadata persisted with a report follow-up child job."""
+    return {
+        "parent_job_id": parent_job_id,
+        "interaction_action": action,
+        "result_kind": "report",
+    }

--- a/frontends/aiq_api/src/aiq_api/jobs/report_context.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/report_context.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Durable report context reconstruction for report-aware follow-up."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any
+
+from fastapi import HTTPException
+from pydantic import BaseModel
+from pydantic import Field
+
+from aiq_agent.auth import Principal
+
+from .access import authorize_job_access
+from .event_store import EventStore
+
+_EVENT_SCAN_LIMIT = 10000
+_URL_RE = re.compile(r"https?://[^\s<>)\]]+")
+_SOURCES_HEADING_RE = re.compile(r"^##\s+(sources|references)\s*$", re.IGNORECASE | re.MULTILINE)
+_NEXT_HEADING_RE = re.compile(r"^##\s+\S", re.MULTILINE)
+_CITATION_LINE_RE = re.compile(r"^\s*(?:[-*]\s*)?\[\d+\]\s*(?P<text>.+?)\s*$")
+_URL_TRIM_CHARS = ".,;:"
+
+
+class ReportContextSource(BaseModel):
+    """One source available to a report-aware child interaction."""
+
+    url: str | None = None
+    citation_key: str | None = None
+    title: str | None = None
+    source_type: str = "parent_report"
+    tool_name: str = "parent_report"
+
+
+class ReportContext(BaseModel):
+    """Parent report and compact source context reconstructed from durable state."""
+
+    parent_job_id: str
+    report_markdown: str
+    source_summary_markdown: str
+    sources: list[ReportContextSource] = Field(default_factory=list)
+
+
+def _decode_job_output(output: Any) -> dict[str, Any]:
+    if isinstance(output, dict):
+        return output
+    if isinstance(output, str) and output.strip():
+        try:
+            decoded = json.loads(output)
+        except json.JSONDecodeError:
+            return {}
+        return decoded if isinstance(decoded, dict) else {}
+    return {}
+
+
+def _extract_report_from_job_output(job: Any) -> str | None:
+    output = _decode_job_output(getattr(job, "output", None))
+    report = output.get("report")
+    return report.strip() if isinstance(report, str) and report.strip() else None
+
+
+def _event_data(event: dict[str, Any]) -> dict[str, Any]:
+    data = event.get("data")
+    return data if isinstance(data, dict) else {}
+
+
+async def _extract_report_from_events(db_url: str, job_id: str) -> str | None:
+    events = await EventStore.get_events_async(db_url, job_id, 0, _EVENT_SCAN_LIMIT)
+    fallback: str | None = None
+    final_report: str | None = None
+    for event in events:
+        if event.get("type") != "artifact.update":
+            continue
+        data = _event_data(event)
+        if data.get("type") != "output":
+            continue
+        content = data.get("content")
+        if not isinstance(content, str) or not content.strip():
+            continue
+        fallback = content.strip()
+        if data.get("output_category") == "final_report":
+            final_report = content.strip()
+    return final_report or fallback
+
+
+def _is_url(value: str | None) -> bool:
+    return bool(value and value.lower().startswith(("http://", "https://")))
+
+
+def _normalize_url_key(url: str) -> str:
+    return url.rstrip("/").lower()
+
+
+def _dedupe_sources(sources: list[ReportContextSource]) -> list[ReportContextSource]:
+    seen: set[str] = set()
+    deduped: list[ReportContextSource] = []
+    for source in sources:
+        if source.url:
+            key = f"url:{_normalize_url_key(source.url)}"
+        elif source.citation_key:
+            key = f"citation_key:{source.citation_key.strip().lower()}"
+        else:
+            continue
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(source)
+    return deduped
+
+
+async def _extract_sources_from_events(db_url: str, job_id: str) -> list[ReportContextSource]:
+    events = await EventStore.get_events_async(db_url, job_id, 0, _EVENT_SCAN_LIMIT)
+    sources: list[ReportContextSource] = []
+    for event in events:
+        if event.get("type") != "artifact.update":
+            continue
+        data = _event_data(event)
+        if data.get("type") != "citation_source":
+            continue
+        content = data.get("content")
+        content_text = content.strip() if isinstance(content, str) else None
+        url = data.get("url") or content_text
+        citation_key = data.get("citation_key")
+        if not _is_url(url):
+            url = None
+            citation_key = citation_key or content_text
+        sources.append(
+            ReportContextSource(
+                url=url,
+                citation_key=citation_key.strip() if isinstance(citation_key, str) and citation_key.strip() else None,
+                title=data.get("title") or event.get("name"),
+                source_type=str(data.get("source_type") or "parent_report"),
+                tool_name=str(data.get("tool_name") or "parent_report"),
+            )
+        )
+    return _dedupe_sources(sources)
+
+
+def _sources_section(report_markdown: str) -> str:
+    match = _SOURCES_HEADING_RE.search(report_markdown)
+    if not match:
+        return ""
+    rest = report_markdown[match.end() :]
+    next_heading = _NEXT_HEADING_RE.search(rest)
+    return rest[: next_heading.start()] if next_heading else rest
+
+
+def _extract_sources_from_report_markdown(report_markdown: str) -> list[ReportContextSource]:
+    section = _sources_section(report_markdown)
+    if not section:
+        return []
+    sources: list[ReportContextSource] = []
+    for line in section.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        citation_match = _CITATION_LINE_RE.match(stripped)
+        if not citation_match:
+            continue
+        ref_text = citation_match.group("text").strip()
+        url_match = _URL_RE.search(ref_text)
+        if url_match:
+            sources.append(ReportContextSource(url=url_match.group(0).rstrip(_URL_TRIM_CHARS), title=ref_text))
+        else:
+            sources.append(ReportContextSource(citation_key=ref_text, title=ref_text))
+    return _dedupe_sources(sources)
+
+
+def _source_summary_markdown(sources: list[ReportContextSource]) -> str:
+    if not sources:
+        return "No durable source metadata was found for the parent report."
+    lines = []
+    for index, source in enumerate(sources, start=1):
+        locator = source.url or source.citation_key or "(unknown source)"
+        title = f"{source.title}: " if source.title and source.title != locator else ""
+        lines.append(f"- [{index}] {title}{locator}")
+    return "\n".join(lines)
+
+
+async def resolve_report_context(job: Any, db_url: str, parent_job_id: str) -> ReportContext:
+    """Build report context from a previously authorized parent job."""
+
+    report = _extract_report_from_job_output(job) or await _extract_report_from_events(db_url, parent_job_id)
+    if not report:
+        raise HTTPException(409, f"Parent job has no durable report: {parent_job_id}")
+
+    event_sources = await _extract_sources_from_events(db_url, parent_job_id)
+    report_sources = _extract_sources_from_report_markdown(report)
+    sources = _dedupe_sources([*event_sources, *report_sources])
+    return ReportContext(
+        parent_job_id=parent_job_id,
+        report_markdown=report,
+        source_summary_markdown=_source_summary_markdown(sources),
+        sources=sources,
+    )
+
+
+async def resolve_authorized_report_context(parent_job_id: str, principal: Principal) -> ReportContext:
+    """Authorize and reconstruct a parent report context using configured async job storage."""
+
+    from nat.front_ends.fastapi.async_jobs.job_store import JobStatus
+    from nat.front_ends.fastapi.async_jobs.job_store import JobStore
+
+    scheduler_address = os.environ.get("NAT_DASK_SCHEDULER_ADDRESS")
+    if not scheduler_address:
+        raise HTTPException(503, "Async job storage is not configured")
+
+    db_url = os.environ.get("NAT_JOB_STORE_DB_URL", "sqlite:///./data/jobs.db")
+    job_store = JobStore(scheduler_address=scheduler_address, db_url=db_url)
+    job = await authorize_job_access(job_store, db_url, parent_job_id, principal)
+    if getattr(job, "status", None) != JobStatus.SUCCESS.value:
+        raise HTTPException(409, f"Parent job is not complete: {parent_job_id}")
+    return await resolve_report_context(job, db_url, parent_job_id)
+
+
+def to_initial_files(context: ReportContext, instruction: str | None = None) -> dict[str, str]:
+    """Convert report context into PR 267 DeepAgents virtual filesystem seed files."""
+
+    files = {
+        "/shared/original_report.md": context.report_markdown,
+        "/shared/parent_report_context.json": context.model_dump_json(indent=2),
+        "/shared/source_summary.md": context.source_summary_markdown,
+    }
+    if instruction is not None:
+        files["/shared/edit_instruction.txt"] = instruction
+    return files

--- a/frontends/aiq_api/src/aiq_api/jobs/runner.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/runner.py
@@ -751,9 +751,12 @@ async def _run_agent(
         if state_cls:
             # Build state with available_documents if the class supports it
             state_kwargs = {"messages": [HumanMessage(content=input_text)]}
-            if data_sources is not None:
+            # Only pass optional fields the state actually declares. data_sources also
+            # flows to non-Pydantic states (legacy behavior); files needs a model field.
+            has_fields = hasattr(state_cls, "model_fields")
+            if data_sources is not None and (not has_fields or "data_sources" in state_cls.model_fields):
                 state_kwargs["data_sources"] = data_sources
-            if initial_files and hasattr(state_cls, "model_fields") and "files" in state_cls.model_fields:
+            if initial_files and has_fields and "files" in state_cls.model_fields:
                 state_kwargs["files"] = initial_files
             if available_documents:
                 # Convert dicts to AvailableDocument if the state class expects them

--- a/frontends/aiq_api/src/aiq_api/jobs/runner.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/runner.py
@@ -52,6 +52,7 @@ _DEEP_RESEARCH_AGENT_KWARGS = frozenset(
     }
 )
 _CONFIGURABLE_AGENT_KWARGS = frozenset({"config", "job_id"})
+_JOB_SCOPED_AGENT_KWARGS = frozenset({"job_id"})
 
 
 def _constructor_accepts_explicit_kwargs(agent_cls: type, kwarg_names: frozenset[str]) -> bool:
@@ -690,8 +691,9 @@ def _create_agent_instance(
     Tries in order:
     1. DeepResearcherAgent explicit config pattern
     2. llm_provider + tools + config/job_id pattern
-    3. llm_provider + tools pattern
-    4. llm + tools pattern (simpler agents)
+    3. llm_provider + tools + job_id pattern
+    4. llm_provider + tools pattern
+    5. llm + tools pattern (simpler agents)
     """
     from aiq_agent.agents.deep_researcher.register import DeepResearchAgentConfig
 
@@ -724,6 +726,18 @@ def _create_agent_instance(
                 verbose=verbose,
                 callbacks=callbacks,
                 config=fn_config,
+                job_id=job_id,
+            )
+        except TypeError:
+            pass
+
+    if _constructor_accepts_explicit_kwargs(agent_cls, _JOB_SCOPED_AGENT_KWARGS):
+        try:
+            return agent_cls(
+                llm_provider=llm_provider,
+                tools=tools,
+                verbose=verbose,
+                callbacks=callbacks,
                 job_id=job_id,
             )
         except TypeError:

--- a/frontends/aiq_api/src/aiq_api/jobs/runner.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/runner.py
@@ -38,6 +38,42 @@ from .event_store import EventStore
 logger = logging.getLogger(__name__)
 
 
+_DEEP_RESEARCH_AGENT_KWARGS = frozenset(
+    {
+        "domain_catalog_path",
+        "enable_source_router",
+        "enable_citation_verification",
+        "skills",
+        "sandbox",
+        "job_id",
+        "max_research_concurrency",
+        "max_concurrent_source_tool_calls",
+        "max_source_tool_batch_size",
+    }
+)
+_CONFIGURABLE_AGENT_KWARGS = frozenset({"config", "job_id"})
+
+
+def _constructor_accepts_explicit_kwargs(agent_cls: type, kwarg_names: frozenset[str]) -> bool:
+    """Return true when a class constructor explicitly declares all requested kwargs."""
+    import inspect
+
+    try:
+        signature = inspect.signature(agent_cls)
+    except (TypeError, ValueError):
+        try:
+            signature = inspect.signature(agent_cls.__init__)
+        except (TypeError, ValueError):
+            return False
+
+    accepted_kwargs = {
+        name
+        for name, param in signature.parameters.items()
+        if param.kind in (inspect.Parameter.KEYWORD_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    }
+    return kwarg_names.issubset(accepted_kwargs)
+
+
 def _normalize_trace_id(trace_id: int | str | None) -> int | None:
     """Convert trace ID to integer format.
 
@@ -652,12 +688,16 @@ def _create_agent_instance(
     Create an agent instance, supporting different constructor patterns.
 
     Tries in order:
-    1. llm_provider + tools pattern (DeepResearcherAgent style)
-    2. llm + tools pattern (simpler agents)
+    1. DeepResearcherAgent explicit config pattern
+    2. llm_provider + tools + config/job_id pattern
+    3. llm_provider + tools pattern
+    4. llm + tools pattern (simpler agents)
     """
     from aiq_agent.agents.deep_researcher.register import DeepResearchAgentConfig
 
-    if isinstance(fn_config, DeepResearchAgentConfig):
+    if isinstance(fn_config, DeepResearchAgentConfig) and _constructor_accepts_explicit_kwargs(
+        agent_cls, _DEEP_RESEARCH_AGENT_KWARGS
+    ):
         return agent_cls(
             llm_provider=llm_provider,
             tools=tools,
@@ -675,6 +715,19 @@ def _create_agent_instance(
             max_concurrent_source_tool_calls=fn_config.max_concurrent_source_tool_calls,
             max_source_tool_batch_size=fn_config.max_source_tool_batch_size,
         )
+
+    if _constructor_accepts_explicit_kwargs(agent_cls, _CONFIGURABLE_AGENT_KWARGS):
+        try:
+            return agent_cls(
+                llm_provider=llm_provider,
+                tools=tools,
+                verbose=verbose,
+                callbacks=callbacks,
+                config=fn_config,
+                job_id=job_id,
+            )
+        except TypeError:
+            pass
 
     # Try original deep_researcher pattern (llm_provider + tools + verbose)
     try:

--- a/frontends/aiq_api/src/aiq_api/jobs/runner.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/runner.py
@@ -256,6 +256,8 @@ async def run_agent_job(
     available_documents: list[dict] | None = None,
     data_sources: list[str] | None = None,
     auth_token: str | None = None,
+    initial_files: dict[str, Any] | None = None,
+    output_metadata: dict[str, Any] | None = None,
 ):
     """
     Dask task to run any registered agent with cancellation support and telemetry.
@@ -287,6 +289,8 @@ async def run_agent_job(
         data_sources: Optional list of allowed data sources to enforce in the worker.
         auth_token: Optional auth token propagated from the HTTP request for
             data sources that require authentication (requires_auth: true).
+        initial_files: Optional DeepAgents virtual filesystem files to seed into state.
+        output_metadata: Optional metadata to persist alongside the final report.
     """
 
     # Propagate auth token into the current async task's context so tools
@@ -512,6 +516,7 @@ async def run_agent_job(
                         available_documents=available_documents,
                         data_sources=data_sources,
                         event_store=event_store,
+                        initial_files=initial_files,
                     )
 
                     # Emit WORKFLOW_END event for Phoenix
@@ -545,7 +550,10 @@ async def run_agent_job(
                     # Extract report and update status inside the context manager
                     # so the UI sees completion before exporter flush and cleanup
                     report = _extract_result(result)
-                    await job_store.update_status(job_id, JobStatus.SUCCESS, output={"report": report})
+                    output = {"report": report}
+                    if output_metadata:
+                        output.update(output_metadata)
+                    await job_store.update_status(job_id, JobStatus.SUCCESS, output=output)
                     logger.info("Job %s completed (report: %d chars)", job_id, len(report))
 
     except asyncio.CancelledError:
@@ -711,6 +719,7 @@ async def _run_agent(
     available_documents: list[dict] | None = None,
     data_sources: list[str] | None = None,
     event_store: EventStore | None = None,
+    initial_files: dict[str, Any] | None = None,
 ) -> Any:
     """
     Run the agent, supporting different run() signatures.
@@ -744,6 +753,8 @@ async def _run_agent(
             state_kwargs = {"messages": [HumanMessage(content=input_text)]}
             if data_sources is not None:
                 state_kwargs["data_sources"] = data_sources
+            if initial_files and hasattr(state_cls, "model_fields") and "files" in state_cls.model_fields:
+                state_kwargs["files"] = initial_files
             if available_documents:
                 # Convert dicts to AvailableDocument if the state class expects them
                 try:
@@ -763,6 +774,8 @@ async def _run_agent(
             state = {"messages": [HumanMessage(content=input_text)]}
             if data_sources is not None:
                 state["data_sources"] = data_sources
+            if initial_files:
+                state["files"] = initial_files
             if available_documents:
                 state["available_documents"] = available_documents
 

--- a/frontends/aiq_api/src/aiq_api/jobs/runner.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/runner.py
@@ -550,9 +550,9 @@ async def run_agent_job(
                     # Extract report and update status inside the context manager
                     # so the UI sees completion before exporter flush and cleanup
                     report = _extract_result(result)
-                    output = {"report": report}
-                    if output_metadata:
-                        output.update(output_metadata)
+                    # Apply caller metadata first, then set the canonical report last so a
+                    # stray "report" key in output_metadata can never overwrite the real report.
+                    output = {**(output_metadata or {}), "report": report}
                     await job_store.update_status(job_id, JobStatus.SUCCESS, output=output)
                     logger.info("Job %s completed (report: %d chars)", job_id, len(report))
 

--- a/frontends/aiq_api/src/aiq_api/jobs/submit.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/submit.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from typing import Any
 
 from aiq_agent.auth import Principal
 from aiq_agent.auth import get_current_principal
@@ -120,6 +121,8 @@ async def submit_agent_job(
     available_documents: list[dict] | None = None,
     data_sources: list[str] | None = None,
     auth_token: str | None = None,
+    initial_files: dict[str, Any] | None = None,
+    output_metadata: dict[str, Any] | None = None,
 ) -> str:
     """
     Submit an agent job to the Dask cluster.
@@ -138,6 +141,8 @@ async def submit_agent_job(
         data_sources: Optional list of allowed data sources to enforce in the worker.
         auth_token: Optional auth token to propagate to the Dask worker for
             data sources that require authentication.
+        initial_files: Optional DeepAgents virtual filesystem files to seed into worker state.
+        output_metadata: Optional metadata persisted with the final job output.
 
     Returns:
         The job ID.
@@ -234,6 +239,8 @@ async def submit_agent_job(
                 available_documents,
                 data_sources,
                 auth_token,
+                initial_files,
+                output_metadata,
             ],
         )
         await loop.run_in_executor(None, create_job_access, resolved_job_id, principal, db_url)

--- a/frontends/aiq_api/src/aiq_api/jobs/submit.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/submit.py
@@ -26,6 +26,8 @@ import logging
 import os
 from typing import Any
 
+from sqlalchemy.exc import IntegrityError
+
 from aiq_agent.auth import Principal
 from aiq_agent.auth import get_current_principal
 from aiq_api.auth import get_current_trace_tags
@@ -37,6 +39,24 @@ from .access import rollback_job_submission
 from .runner import run_agent_job
 
 logger = logging.getLogger(__name__)
+
+
+class JobIdConflictError(RuntimeError):
+    """Raised when a caller-supplied job_id collides with an existing job.
+
+    Distinct from generic submission failures so callers can map it to HTTP 409
+    instead of triggering the rollback path, which would delete the pre-existing
+    (victim) job's durable state.
+    """
+
+
+class InternalAgentError(RuntimeError):
+    """Raised when an internal-only (public=False) agent is submitted without opt-in.
+
+    The submission helper is the real trust boundary; trusted internal callers must
+    pass allow_internal=True explicitly rather than relying on every call site (and
+    the HTTP route filter) to remember the gate.
+    """
 
 
 def _resolve_submission_principal(owner: str) -> Principal | None:
@@ -123,6 +143,7 @@ async def submit_agent_job(
     auth_token: str | None = None,
     initial_files: dict[str, Any] | None = None,
     output_metadata: dict[str, Any] | None = None,
+    allow_internal: bool = False,
 ) -> str:
     """
     Submit an agent job to the Dask cluster.
@@ -163,6 +184,11 @@ async def submit_agent_job(
 
     # Get agent configuration from registry
     agent_config = get_agent_config(agent_type)
+
+    # Enforce the internal-agent gate at the submission boundary (defense in depth):
+    # internal-only agents may only be launched by trusted callers that opt in.
+    if not agent_config.public and not allow_internal:
+        raise InternalAgentError(f"Agent type is internal-only and cannot be submitted directly: {agent_type}")
 
     # @environment_variable NAT_DASK_SCHEDULER_ADDRESS
     # @category Server
@@ -220,6 +246,22 @@ async def submit_agent_job(
     resolved_job_id = job_store.ensure_job_id(job_id)
     loop = asyncio.get_running_loop()
 
+    async def _rollback_partial_submission() -> None:
+        """Best-effort cleanup of a job_info row we created before submission failed."""
+        try:
+            await loop.run_in_executor(None, rollback_job_submission, resolved_job_id, db_url)
+            logger.warning(
+                "Rolled back partial async job submission for %s. "
+                "The Dask worker may still be running and should be investigated if it continues writing state.",
+                resolved_job_id,
+            )
+        except Exception as cleanup_error:
+            logger.warning(
+                "Failed to roll back partial async job submission for %s: %s",
+                resolved_job_id,
+                cleanup_error,
+            )
+
     try:
         await job_store.submit_job(
             job_id=resolved_job_id,
@@ -243,21 +285,27 @@ async def submit_agent_job(
                 output_metadata,
             ],
         )
+    except IntegrityError as e:
+        # A caller-supplied job_id collided with an existing job. NAT's _create_job
+        # inserts job_info first, so the collision fails before any state of OURS is
+        # created. The colliding job belongs to someone else — we must NOT run the
+        # rollback path, which unconditionally deletes that job's info/events/access
+        # rows. Surface a conflict so the route can return HTTP 409.
+        logger.info("Rejected colliding job_id %s on async submit", resolved_job_id)
+        raise JobIdConflictError(f"Job already exists: {resolved_job_id}") from e
+    except Exception:
+        # NAT's submit_job commits the job_info row before it hands the task to Dask,
+        # so a post-commit failure (scheduler unreachable, serialization error,
+        # Variable.set timeout) leaves an ownerless job_info row. Roll it back.
+        await _rollback_partial_submission()
+        raise
+
+    try:
         await loop.run_in_executor(None, create_job_access, resolved_job_id, principal, db_url)
     except Exception:
-        try:
-            await loop.run_in_executor(None, rollback_job_submission, resolved_job_id, db_url)
-            logger.warning(
-                "Rolled back partial async job submission for %s after access persistence failure. "
-                "The Dask worker may still be running and should be investigated if it continues writing state.",
-                resolved_job_id,
-            )
-        except Exception as cleanup_error:
-            logger.warning(
-                "Failed to roll back partial async job submission for %s after access persistence failure: %s",
-                resolved_job_id,
-                cleanup_error,
-            )
+        # We successfully created this job above, then ownership persistence failed;
+        # roll back our own partial state. (Safe: this id was newly created by us.)
+        await _rollback_partial_submission()
         raise
 
     logger.info(

--- a/frontends/aiq_api/src/aiq_api/jobs/submit.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/submit.py
@@ -76,6 +76,16 @@ def _resolve_submission_principal(owner: str) -> Principal | None:
     return _make_no_auth_principal(owner)
 
 
+def _current_conversation_id() -> str | None:
+    """Best-effort read of the originating conversation id from the NAT context."""
+    try:
+        from nat.builder.context import ContextState
+
+        return ContextState.get().conversation_id.get()
+    except Exception:
+        return None
+
+
 def _get_parent_trace_context() -> tuple[
     str | None,  # parent_span_id
     str | None,  # parent_function_id
@@ -300,8 +310,14 @@ async def submit_agent_job(
         await _rollback_partial_submission()
         raise
 
+    # Conversation that originated this job (from the request's conversation-id), recorded so
+    # report follow-up can default to "the last report in this conversation". None when the
+    # client sent no conversation-id (e.g. a CLI that doesn't thread one) — then no linkage.
+    submission_conversation_id = _current_conversation_id()
     try:
-        await loop.run_in_executor(None, create_job_access, resolved_job_id, principal, db_url)
+        await loop.run_in_executor(
+            None, create_job_access, resolved_job_id, principal, db_url, submission_conversation_id
+        )
     except Exception:
         # We successfully created this job above, then ownership persistence failed;
         # roll back our own partial state. (Safe: this id was newly created by us.)

--- a/frontends/aiq_api/src/aiq_api/jobs/submit.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/submit.py
@@ -316,7 +316,7 @@ async def submit_agent_job(
     submission_conversation_id = _current_conversation_id()
     try:
         await loop.run_in_executor(
-            None, create_job_access, resolved_job_id, principal, db_url, submission_conversation_id
+            None, create_job_access, resolved_job_id, principal, db_url, submission_conversation_id, agent_type
         )
     except Exception:
         # We successfully created this job above, then ownership persistence failed;

--- a/frontends/aiq_api/src/aiq_api/registry.py
+++ b/frontends/aiq_api/src/aiq_api/registry.py
@@ -116,3 +116,11 @@ register_agent(
     config_name="shallow_research_agent",
     description="Performs quick single-turn research",
 )
+
+register_agent(
+    agent_type="report_rewriter",
+    class_path="aiq_agent.agents.report_rewriter.agent.ReportRewriterAgent",
+    config_name="deep_research_agent",
+    description="Internal child agent for report edit follow-up",
+    public=False,
+)

--- a/frontends/aiq_api/src/aiq_api/registry.py
+++ b/frontends/aiq_api/src/aiq_api/registry.py
@@ -41,6 +41,9 @@ class AgentConfig:
     description: str = ""
     """Human-readable description of the agent."""
 
+    public: bool = True
+    """Whether this agent should be exposed through public agent listing and submission surfaces."""
+
 
 # Global agent registry
 AGENT_REGISTRY: dict[str, AgentConfig] = {}
@@ -51,6 +54,7 @@ def register_agent(
     class_path: str,
     config_name: str,
     description: str = "",
+    public: bool = True,
 ) -> None:
     """
     Register an agent type for use with the async job system.
@@ -60,6 +64,7 @@ def register_agent(
         class_path: Full module path to the agent class.
         config_name: NAT config function name for this agent.
         description: Human-readable description.
+        public: Whether this agent is visible to public agent listing and direct submission.
 
     Example:
         register_agent(
@@ -73,6 +78,7 @@ def register_agent(
         class_path=class_path,
         config_name=config_name,
         description=description,
+        public=public,
     )
     logger.debug("Registered agent: %s -> %s", agent_type, class_path)
 

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -410,6 +410,8 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
     from ..jobs.access import authorize_job_access
     from ..jobs.access import ensure_job_access_table
     from ..jobs.event_store import EventStore
+    from ..jobs.report_context import _decode_job_output
+    from ..jobs.report_context import report_output_metadata
     from ..jobs.report_context import resolve_report_context
     from ..jobs.report_context import to_initial_files
     from ..jobs.submit import submit_agent_job as submit_authorized_job
@@ -640,11 +642,7 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
                 data_sources=[],
                 auth_token=auth_token,
                 initial_files=to_initial_files(context, instruction=req.input),
-                output_metadata={
-                    "parent_job_id": job_id,
-                    "interaction_action": "edit",
-                    "result_kind": "report",
-                },
+                output_metadata=report_output_metadata(job_id, "edit"),
             )
         except RuntimeError as e:
             raise HTTPException(403, str(e))
@@ -856,27 +854,16 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         principal = require_verified_principal()
         job = await authorize_job_access(job_store, db_url, job_id, principal)
 
-        report = None
-        parent_job_id = None
-        interaction_action = None
-        result_kind = None
-        if job.output:
-            try:
-                output = json.loads(job.output) if isinstance(job.output, str) else job.output
-                report = output.get("report")
-                parent_job_id = output.get("parent_job_id")
-                interaction_action = output.get("interaction_action")
-                result_kind = output.get("result_kind")
-            except (json.JSONDecodeError, AttributeError):
-                pass
+        output = _decode_job_output(job.output)
+        report = output.get("report")
 
         return JobReportResponse(
             job_id=job_id,
             has_report=bool(report),
             report=report,
-            parent_job_id=parent_job_id,
-            interaction_action=interaction_action,
-            result_kind=result_kind,
+            parent_job_id=output.get("parent_job_id"),
+            interaction_action=output.get("interaction_action"),
+            result_kind=output.get("result_kind"),
         )
 
     logger.info("Registered async job routes at /v1/jobs/async")

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -45,6 +45,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import field_validator
 
 from aiq_agent.common.data_source_registry import get_all_sources
 from aiq_agent.common.data_source_registry import get_all_tool_refs
@@ -152,6 +153,14 @@ class JobSubmitRequest(BaseModel):
             "data-source tools; unmapped utility tools remain available."
         ),
     )
+
+    @field_validator("input")
+    @classmethod
+    def _input_not_blank(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("Input must not be blank")
+        return stripped
 
 
 JOB_SUBMIT_EXAMPLES: dict[str, dict] = {
@@ -361,6 +370,17 @@ class ReportEditRequest(BaseModel):
         le=604800,
         description="Child job expiry in seconds (default from config, max 7 days)",
     )
+
+    @field_validator("input")
+    @classmethod
+    def _input_not_blank(cls, value: str) -> str:
+        # min_length=1 still allows whitespace-only; the report rewriter requires a
+        # real instruction, so reject blank input at the boundary instead of
+        # creating a guaranteed-failing child job.
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("Edit instruction must not be blank")
+        return stripped
 
 
 class ReportEditResponse(BaseModel):
@@ -588,7 +608,11 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         except JobIdConflictError:
             raise HTTPException(409, f"Job already exists: {req.job_id}")
         except RuntimeError as e:
-            raise HTTPException(403, str(e))
+            # The principal is resolved above, so a RuntimeError here is an
+            # availability/config failure (e.g. scheduler not configured), not an
+            # authorization error -- surface 503, not 403, and don't echo internals.
+            logger.warning("Async job submission unavailable: %s", e)
+            raise HTTPException(503, "Async job submission is currently unavailable")
         except Exception as e:
             logger.warning("Failed to submit authorized job: %s", e)
             raise HTTPException(500, "Failed to persist async job authorization metadata")
@@ -652,7 +676,10 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         except JobIdConflictError:
             raise HTTPException(409, f"Job already exists: {req.job_id}")
         except RuntimeError as e:
-            raise HTTPException(403, str(e))
+            # Principal is resolved above; a RuntimeError here is an availability/config
+            # failure (e.g. scheduler not configured), not an authorization error.
+            logger.warning("Report edit submission unavailable for parent %s: %s", job_id, e)
+            raise HTTPException(503, "Report edit submission is currently unavailable")
         except Exception as e:
             logger.warning("Failed to submit report edit job for parent %s: %s", job_id, e)
             raise HTTPException(500, "Failed to submit report edit job")

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -414,6 +414,7 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
     from ..jobs.report_context import report_output_metadata
     from ..jobs.report_context import resolve_report_context
     from ..jobs.report_context import to_initial_files
+    from ..jobs.submit import JobIdConflictError
     from ..jobs.submit import submit_agent_job as submit_authorized_job
 
     if not get_all_sources():
@@ -528,6 +529,7 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         ),
         responses={
             400: {"description": "Unknown agent type or invalid request"},
+            409: {"description": "A custom job_id was supplied that collides with an existing job"},
             422: {"description": "One or more unknown or agent-unavailable data source IDs"},
             503: {"description": "Dask scheduler not available"},
         },
@@ -583,6 +585,8 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
                 data_sources=req.data_sources,
                 auth_token=auth_token,
             )
+        except JobIdConflictError:
+            raise HTTPException(409, f"Job already exists: {req.job_id}")
         except RuntimeError as e:
             raise HTTPException(403, str(e))
         except Exception as e:
@@ -614,7 +618,7 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         ),
         responses={
             404: {"description": "Parent job not found"},
-            409: {"description": "Parent job is incomplete or has no durable report"},
+            409: {"description": "Parent job is incomplete, has no durable report, or the child job_id collides"},
             503: {"description": "Dask scheduler not available"},
         },
     )
@@ -643,7 +647,10 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
                 auth_token=auth_token,
                 initial_files=to_initial_files(context, instruction=req.input),
                 output_metadata=report_output_metadata(job_id, "edit"),
+                allow_internal=True,
             )
+        except JobIdConflictError:
+            raise HTTPException(409, f"Job already exists: {req.job_id}")
         except RuntimeError as e:
             raise HTTPException(403, str(e))
         except Exception as e:

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -551,6 +551,7 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
             400: {"description": "Unknown agent type or invalid request"},
             409: {"description": "A custom job_id was supplied that collides with an existing job"},
             422: {"description": "One or more unknown or agent-unavailable data source IDs"},
+            500: {"description": "Failed to persist async job authorization metadata"},
             503: {"description": "Dask scheduler not available"},
         },
     )
@@ -563,7 +564,7 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         except KeyError as e:
             raise HTTPException(400, str(e))
         if not agent_config.public:
-            raise HTTPException(400, f"Agent type is internal-only: {req.agent_type}")
+            raise HTTPException(400, f"Agent type is internal-only and cannot be submitted directly: {req.agent_type}")
 
         expiry = req.expiry_seconds if req.expiry_seconds is not None else default_expiry_seconds
         # Authenticate the caller (raises 401/403 if unverified). The returned principal
@@ -643,6 +644,8 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         responses={
             404: {"description": "Parent job not found"},
             409: {"description": "Parent job is incomplete, has no durable report, or the child job_id collides"},
+            422: {"description": "Request validation failed (e.g. blank edit instruction)"},
+            500: {"description": "Failed to submit the report edit job"},
             503: {"description": "Dask scheduler not available"},
         },
     )

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -340,6 +340,36 @@ class JobReportResponse(BaseModel):
     job_id: str = Field(..., description="Unique job identifier")
     has_report: bool = Field(..., description="Whether the final report is available")
     report: str | None = Field(None, description="Final research report from the agent")
+    parent_job_id: str | None = Field(None, description="Parent report job ID for report follow-up outputs")
+    interaction_action: str | None = Field(None, description="Report interaction action that produced this output")
+    result_kind: str | None = Field(None, description="Kind of result returned by the child job")
+
+
+class ReportEditRequest(BaseModel):
+    """Request to create a revised report from an existing completed report job."""
+
+    input: str = Field(..., min_length=1, description="Edit instruction for the parent report")
+    job_id: str | None = Field(
+        None,
+        pattern=r"^[a-zA-Z0-9_-]+$",
+        max_length=64,
+        description="Optional custom child job ID (auto-generated if omitted)",
+    )
+    expiry_seconds: int | None = Field(
+        None,
+        ge=600,
+        le=604800,
+        description="Child job expiry in seconds (default from config, max 7 days)",
+    )
+
+
+class ReportEditResponse(BaseModel):
+    """Response for an accepted report edit job."""
+
+    job_id: str = Field(..., description="Child job identifier")
+    parent_job_id: str = Field(..., description="Parent report job identifier")
+    status: str = Field(..., description="Child job status")
+    agent_type: str = Field(..., description="Internal agent type used for the child job")
 
 
 class AgentInfo(BaseModel):
@@ -380,6 +410,8 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
     from ..jobs.access import authorize_job_access
     from ..jobs.access import ensure_job_access_table
     from ..jobs.event_store import EventStore
+    from ..jobs.report_context import resolve_report_context
+    from ..jobs.report_context import to_initial_files
     from ..jobs.submit import submit_agent_job as submit_authorized_job
 
     if not get_all_sources():
@@ -506,6 +538,8 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
             agent_config = get_agent_config(req.agent_type)
         except KeyError as e:
             raise HTTPException(400, str(e))
+        if not agent_config.public:
+            raise HTTPException(400, f"Agent type is internal-only: {req.agent_type}")
 
         expiry = req.expiry_seconds if req.expiry_seconds is not None else default_expiry_seconds
         # Authenticate the caller (raises 401/403 if unverified). The returned principal
@@ -565,6 +599,65 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
             job_id=job_id,
             status=JobStatus.SUBMITTED.value,
             agent_type=req.agent_type,
+        )
+
+    @app.post(
+        "/v1/jobs/async/job/{job_id}/report/edit",
+        response_model=ReportEditResponse,
+        tags=["async jobs"],
+        summary="Create a revised report from a completed report job",
+        description=(
+            "Authorize access to a completed parent report, reconstruct durable report context, "
+            "and submit an internal child job that emits a full revised report."
+        ),
+        responses={
+            404: {"description": "Parent job not found"},
+            409: {"description": "Parent job is incomplete or has no durable report"},
+            503: {"description": "Dask scheduler not available"},
+        },
+    )
+    async def edit_job_report(job_id: str, req: ReportEditRequest) -> ReportEditResponse:
+        """Create an internal report-rewrite child job from a completed parent report."""
+        principal = require_verified_principal()
+        parent_job = await authorize_job_access(job_store, db_url, job_id, principal)
+        if getattr(parent_job, "status", None) != JobStatus.SUCCESS.value:
+            raise HTTPException(409, f"Parent job is not complete: {job_id}")
+
+        context = await resolve_report_context(parent_job, db_url, job_id)
+        expiry = req.expiry_seconds if req.expiry_seconds is not None else default_expiry_seconds
+
+        from aiq_agent.auth import get_auth_token
+
+        auth_token = get_auth_token()
+        try:
+            child_job_id = await submit_authorized_job(
+                agent_type="report_rewriter",
+                input_text=req.input,
+                owner=principal.email or principal.sub,
+                principal=principal,
+                job_id=req.job_id,
+                expiry_seconds=expiry,
+                data_sources=[],
+                auth_token=auth_token,
+                initial_files=to_initial_files(context, instruction=req.input),
+                output_metadata={
+                    "parent_job_id": job_id,
+                    "interaction_action": "edit",
+                    "result_kind": "report",
+                },
+            )
+        except RuntimeError as e:
+            raise HTTPException(403, str(e))
+        except Exception as e:
+            logger.warning("Failed to submit report edit job for parent %s: %s", job_id, e)
+            raise HTTPException(500, "Failed to submit report edit job")
+
+        logger.info("Submitted report edit child job %s for parent job %s", child_job_id, job_id)
+        return ReportEditResponse(
+            job_id=child_job_id,
+            parent_job_id=job_id,
+            status=JobStatus.SUBMITTED.value,
+            agent_type="report_rewriter",
         )
 
     @app.get(
@@ -764,14 +857,27 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         job = await authorize_job_access(job_store, db_url, job_id, principal)
 
         report = None
+        parent_job_id = None
+        interaction_action = None
+        result_kind = None
         if job.output:
             try:
                 output = json.loads(job.output) if isinstance(job.output, str) else job.output
                 report = output.get("report")
+                parent_job_id = output.get("parent_job_id")
+                interaction_action = output.get("interaction_action")
+                result_kind = output.get("result_kind")
             except (json.JSONDecodeError, AttributeError):
                 pass
 
-        return JobReportResponse(job_id=job_id, has_report=bool(report), report=report)
+        return JobReportResponse(
+            job_id=job_id,
+            has_report=bool(report),
+            report=report,
+            parent_job_id=parent_job_id,
+            interaction_action=interaction_action,
+            result_kind=result_kind,
+        )
 
     logger.info("Registered async job routes at /v1/jobs/async")
 

--- a/frontends/aiq_api/src/aiq_api/routes/jobs.py
+++ b/frontends/aiq_api/src/aiq_api/routes/jobs.py
@@ -401,6 +401,7 @@ async def register_job_routes(app: FastAPI, builder: WorkflowBuilder, worker: Fa
         agents = [
             AgentInfo(agent_type=agent_type, description=config.description)
             for agent_type, config in AGENT_REGISTRY.items()
+            if config.public
         ]
         return AgentListResponse(agents=agents)
 

--- a/frontends/aiq_api/tests/test_agent_registry_visibility.py
+++ b/frontends/aiq_api/tests/test_agent_registry_visibility.py
@@ -36,6 +36,16 @@ def test_register_agent_can_mark_internal(monkeypatch):
     assert registry.AGENT_REGISTRY["report_rewriter"].public is False
 
 
+def test_default_registry_contains_internal_report_rewriter():
+    from aiq_api.registry import AGENT_REGISTRY
+
+    assert AGENT_REGISTRY["report_rewriter"].class_path == (
+        "aiq_agent.agents.report_rewriter.agent.ReportRewriterAgent"
+    )
+    assert AGENT_REGISTRY["report_rewriter"].config_name == "deep_research_agent"
+    assert AGENT_REGISTRY["report_rewriter"].public is False
+
+
 @pytest.mark.asyncio
 async def test_list_agents_excludes_internal_agents(monkeypatch):
     import aiq_api.routes.jobs as jobs_routes

--- a/frontends/aiq_api/tests/test_agent_registry_visibility.py
+++ b/frontends/aiq_api/tests/test_agent_registry_visibility.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_agent_config_defaults_to_public():
+    from aiq_api.registry import AgentConfig
+
+    config = AgentConfig(
+        class_path="aiq_agent.agents.deep_researcher.agent.DeepResearcherAgent",
+        config_name="deep_research_agent",
+    )
+
+    assert config.public is True
+
+
+def test_register_agent_can_mark_internal(monkeypatch):
+    import aiq_api.registry as registry
+
+    monkeypatch.setattr(registry, "AGENT_REGISTRY", {})
+
+    registry.register_agent(
+        agent_type="report_rewriter",
+        class_path="aiq_agent.agents.report_rewriter.agent.ReportRewriterAgent",
+        config_name="deep_research_agent",
+        public=False,
+    )
+
+    assert registry.AGENT_REGISTRY["report_rewriter"].public is False
+
+
+@pytest.mark.asyncio
+async def test_list_agents_excludes_internal_agents(monkeypatch):
+    import aiq_api.routes.jobs as jobs_routes
+    from aiq_api.registry import AgentConfig
+
+    monkeypatch.setattr(
+        jobs_routes,
+        "AGENT_REGISTRY",
+        {
+            "deep_researcher": AgentConfig(
+                class_path="aiq_agent.agents.deep_researcher.agent.DeepResearcherAgent",
+                config_name="deep_research_agent",
+                description="Deep",
+            ),
+            "report_rewriter": AgentConfig(
+                class_path="aiq_agent.agents.report_rewriter.agent.ReportRewriterAgent",
+                config_name="deep_research_agent",
+                description="Internal",
+                public=False,
+            ),
+        },
+    )
+
+    app = FastAPI()
+    await jobs_routes.register_job_routes(
+        app,
+        builder=SimpleNamespace(),
+        worker=SimpleNamespace(_dask_available=False, _job_store=None),
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/v1/jobs/async/agents")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "agents": [
+            {
+                "agent_type": "deep_researcher",
+                "description": "Deep",
+            }
+        ]
+    }

--- a/frontends/aiq_api/tests/test_agent_registry_visibility.py
+++ b/frontends/aiq_api/tests/test_agent_registry_visibility.py
@@ -22,7 +22,7 @@ def test_agent_config_defaults_to_public():
 
 
 def test_register_agent_can_mark_internal(monkeypatch):
-    import aiq_api.registry as registry
+    from aiq_api import registry
 
     monkeypatch.setattr(registry, "AGENT_REGISTRY", {})
 

--- a/frontends/aiq_api/tests/test_job_access.py
+++ b/frontends/aiq_api/tests/test_job_access.py
@@ -113,9 +113,44 @@ class TestJobAccessStorage:
 class TestLatestReportJobForConversation:
     """Backend fallback: resolve the conversation's most recent completed report job."""
 
-    def _seed(self, db_url, job_id, principal, conversation_id, *, status, is_expired=False, created_at=None):
+    def _seed(
+        self,
+        db_url,
+        job_id,
+        principal,
+        conversation_id,
+        *,
+        status,
+        is_expired=False,
+        created_at=None,
+        agent_type="deep_researcher",
+    ):
         _insert_job_info(db_url, job_id, status=status, is_expired=is_expired, created_at=created_at)
-        create_job_access(job_id, principal, db_url, conversation_id=conversation_id)
+        create_job_access(job_id, principal, db_url, conversation_id=conversation_id, agent_type=agent_type)
+
+    def test_excludes_non_report_agent(self, db_url):
+        """A newer non-report job (e.g. shallow_researcher) must not become the active report."""
+        from datetime import timedelta
+
+        from aiq_api.jobs.access import get_latest_report_job_for_conversation
+
+        p = Principal(type="jwt", sub="user-1")
+        base = datetime.now(UTC)
+        self._seed(
+            db_url,
+            "report",
+            p,
+            "conv-A",
+            status="success",
+            created_at=base - timedelta(hours=1),
+            agent_type="deep_researcher",
+        )
+        self._seed(
+            db_url, "shallow-newer", p, "conv-A", status="success", created_at=base, agent_type="shallow_researcher"
+        )
+
+        # The newer shallow job is excluded; the report job still wins.
+        assert get_latest_report_job_for_conversation("conv-A", p, db_url) == "report"
 
     def test_returns_latest_success_for_conversation_and_owner(self, db_url):
         from datetime import timedelta

--- a/frontends/aiq_api/tests/test_job_access.py
+++ b/frontends/aiq_api/tests/test_job_access.py
@@ -48,7 +48,14 @@ def clear_event_store_caches():
     job_access._job_access_schema_initialized.clear()
 
 
-def _insert_job_info(db_url: str, job_id: str, *, is_expired: bool = False) -> None:
+def _insert_job_info(
+    db_url: str,
+    job_id: str,
+    *,
+    is_expired: bool = False,
+    status: str = "running",
+    created_at: datetime | None = None,
+) -> None:
     from sqlalchemy import text
 
     engine = EventStore._get_or_create_sync_engine(db_url)
@@ -69,14 +76,14 @@ def _insert_job_info(db_url: str, job_id: str, *, is_expired: bool = False) -> N
                 ")"
             )
         )
-        now = datetime.now(UTC).replace(tzinfo=None)
+        ts = (created_at or datetime.now(UTC)).replace(tzinfo=None)
         conn.execute(
             text(
                 "INSERT OR REPLACE INTO job_info "
                 "(job_id, status, created_at, updated_at, expiry_seconds, is_expired) "
-                "VALUES (:job_id, 'running', :ts, :ts, 3600, :is_expired)"
+                "VALUES (:job_id, :status, :ts, :ts, 3600, :is_expired)"
             ),
-            {"job_id": job_id, "ts": now, "is_expired": is_expired},
+            {"job_id": job_id, "status": status, "ts": ts, "is_expired": is_expired},
         )
         conn.commit()
 
@@ -92,6 +99,76 @@ class TestJobAccessStorage:
         assert access["owner_auth_type"] == "jwt"
         assert access["owner_subject"] == "user-1"
         assert access["owner_email"] == "alice@example.com"
+
+    def test_create_job_access_persists_conversation_id(self, db_url):
+        principal = Principal(type="jwt", sub="user-1", email="alice@example.com")
+
+        create_job_access("job-1", principal, db_url, conversation_id="conv-A")
+
+        access = get_job_access("job-1", db_url)
+        assert access is not None
+        assert access["conversation_id"] == "conv-A"
+
+
+class TestLatestReportJobForConversation:
+    """Backend fallback: resolve the conversation's most recent completed report job."""
+
+    def _seed(self, db_url, job_id, principal, conversation_id, *, status, is_expired=False, created_at=None):
+        _insert_job_info(db_url, job_id, status=status, is_expired=is_expired, created_at=created_at)
+        create_job_access(job_id, principal, db_url, conversation_id=conversation_id)
+
+    def test_returns_latest_success_for_conversation_and_owner(self, db_url):
+        from datetime import timedelta
+
+        from aiq_api.jobs.access import get_latest_report_job_for_conversation
+
+        p = Principal(type="jwt", sub="user-1")
+        base = datetime.now(UTC)
+        self._seed(db_url, "old", p, "conv-A", status="success", created_at=base - timedelta(hours=2))
+        self._seed(db_url, "new", p, "conv-A", status="success", created_at=base - timedelta(minutes=1))
+
+        assert get_latest_report_job_for_conversation("conv-A", p, db_url) == "new"
+
+    def test_ignores_non_success_expired_and_other_conversation(self, db_url):
+        from aiq_api.jobs.access import get_latest_report_job_for_conversation
+
+        p = Principal(type="jwt", sub="user-1")
+        self._seed(db_url, "running", p, "conv-A", status="running")
+        self._seed(db_url, "expired", p, "conv-A", status="success", is_expired=True)
+        self._seed(db_url, "other-conv", p, "conv-B", status="success")
+
+        assert get_latest_report_job_for_conversation("conv-A", p, db_url) is None
+
+    def test_owner_enforced_when_auth_required(self, db_url, monkeypatch):
+        from aiq_api.jobs.access import get_latest_report_job_for_conversation
+
+        monkeypatch.setenv("REQUIRE_AUTH", "true")
+        owner = Principal(type="jwt", sub="user-1")
+        self._seed(db_url, "owned-by-1", owner, "conv-A", status="success")
+
+        intruder = Principal(type="jwt", sub="user-2")
+        assert get_latest_report_job_for_conversation("conv-A", intruder, db_url) is None
+        assert get_latest_report_job_for_conversation("conv-A", owner, db_url) == "owned-by-1"
+
+    def test_owner_not_enforced_under_no_auth(self, db_url, monkeypatch):
+        """Mirrors authorize_job_access: under REQUIRE_AUTH=false ownership is not enforced;
+        conversation_id is the only boundary."""
+        from aiq_api.jobs.access import get_latest_report_job_for_conversation
+
+        monkeypatch.setenv("REQUIRE_AUTH", "false")
+        owner = Principal(type="anonymous", sub="anonymous")
+        self._seed(db_url, "anon-job", owner, "conv-A", status="success")
+
+        # A different synthesized principal still resolves the conversation's report.
+        other = Principal(type="internal", sub="internal")
+        assert get_latest_report_job_for_conversation("conv-A", other, db_url) == "anon-job"
+
+    def test_none_for_empty_or_unknown_conversation(self, db_url):
+        from aiq_api.jobs.access import get_latest_report_job_for_conversation
+
+        p = Principal(type="jwt", sub="user-1")
+        assert get_latest_report_job_for_conversation("", p, db_url) is None
+        assert get_latest_report_job_for_conversation("nope", p, db_url) is None
 
     def test_cleanup_removes_expired_and_orphaned_access_rows(self, db_url):
         ensure_job_access_table(db_url)

--- a/frontends/aiq_api/tests/test_job_access.py
+++ b/frontends/aiq_api/tests/test_job_access.py
@@ -112,6 +112,25 @@ class TestJobAccessStorage:
 
 
 class TestAuthorizeJobAccess:
+    @pytest.fixture(autouse=True)
+    def _enforce_auth(self, monkeypatch):
+        # authorize_job_access only consults the ownership table when REQUIRE_AUTH=true.
+        # Pin it on so these tests deterministically exercise the enforced path instead
+        # of silently passing/failing based on the ambient environment.
+        monkeypatch.setenv("REQUIRE_AUTH", "true")
+
+    def test_no_auth_mode_allows_any_caller(self, db_url, monkeypatch):
+        """With auth disabled, ownership is intentionally not enforced (documented posture)."""
+        monkeypatch.setenv("REQUIRE_AUTH", "false")
+        _insert_job_info(db_url, "job-1")
+        # No job_access row and a different principal -> still allowed under no-auth.
+        job = SimpleNamespace(job_id="job-1", status="running", created_at=None, error=None)
+        job_store = SimpleNamespace(get_job=AsyncMock(return_value=job))
+
+        result = asyncio.run(authorize_job_access(job_store, db_url, "job-1", Principal(type="anonymous", sub="anon")))
+
+        assert result is job
+
     def test_owner_can_access_job(self, db_url):
         _insert_job_info(db_url, "job-1")
         principal = Principal(type="jwt", sub="user-1")
@@ -151,3 +170,25 @@ class TestAuthorizeJobAccess:
             asyncio.run(authorize_job_access(job_store, db_url, "job-1", Principal(type="jwt", sub="user-1")))
 
         assert exc.value.status_code == 404
+
+
+class TestRequireVerifiedPrincipal:
+    """The report follow-up surfaces depend on this resolving correctly per REQUIRE_AUTH."""
+
+    def test_no_auth_synthesizes_a_usable_principal(self, monkeypatch):
+        from aiq_api.jobs.access import require_verified_principal
+
+        monkeypatch.setenv("REQUIRE_AUTH", "false")
+        principal = require_verified_principal()
+        # No 401/403 in no-auth mode; a stable, non-None principal is returned so
+        # chat/HTTP report follow-up works for anonymous callers.
+        assert principal is not None
+        assert principal.sub
+
+    def test_auth_required_without_verified_principal_raises_403(self, monkeypatch):
+        from aiq_api.jobs.access import require_verified_principal
+
+        monkeypatch.setenv("REQUIRE_AUTH", "true")
+        with pytest.raises(HTTPException) as exc:
+            require_verified_principal()
+        assert exc.value.status_code == 403

--- a/frontends/aiq_api/tests/test_job_submit_data_sources.py
+++ b/frontends/aiq_api/tests/test_job_submit_data_sources.py
@@ -166,7 +166,7 @@ async def test_submit_job_rejects_internal_agent(submit_app, monkeypatch):
         )
 
     assert response.status_code == 400
-    assert response.json()["detail"] == "Agent type is internal-only: report_rewriter"
+    assert response.json()["detail"] == "Agent type is internal-only and cannot be submitted directly: report_rewriter"
     submitted_job.assert_not_awaited()
 
 

--- a/frontends/aiq_api/tests/test_job_submit_data_sources.py
+++ b/frontends/aiq_api/tests/test_job_submit_data_sources.py
@@ -144,6 +144,33 @@ async def test_submit_job_forwards_selected_data_sources(submit_app):
 
 
 @pytest.mark.asyncio
+async def test_submit_job_rejects_internal_agent(submit_app, monkeypatch):
+    app, submitted_job, _builder = submit_app
+    import aiq_api.routes.jobs as jobs_routes
+
+    monkeypatch.setattr(
+        jobs_routes,
+        "get_agent_config",
+        lambda _agent_type: AgentConfig(
+            class_path="aiq_agent.agents.report_rewriter.agent.ReportRewriterAgent",
+            config_name="report_rewriter_agent",
+            description="Internal report rewriter",
+            public=False,
+        ),
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={"agent_type": "report_rewriter", "input": "revise"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Agent type is internal-only: report_rewriter"
+    submitted_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_submit_job_omitted_data_sources_keeps_all_sources(submit_app):
     app, submitted_job, builder = submit_app
 

--- a/frontends/aiq_api/tests/test_report_context.py
+++ b/frontends/aiq_api/tests/test_report_context.py
@@ -170,3 +170,26 @@ def test_to_initial_files_uses_shared_paths_only():
     assert files["/shared/source_summary.md"] == "- https://example.com"
     assert files["/shared/edit_instruction.txt"] == "Remove the appendix."
     assert "/report.md" not in files
+
+
+def test_report_context_from_markdown_builds_jobless_context():
+    """In-session (CLI) report context: built from markdown, no job store / auth / scheduler."""
+    from aiq_api.jobs.report_context import report_context_from_markdown
+
+    md = "# Findings\n\nThe key risk is X.\n\n## Sources\n\n[1] https://example.com/a\n[2] https://example.com/b\n"
+    ctx = report_context_from_markdown(md)
+
+    assert ctx.report_markdown == md
+    assert ctx.parent_job_id == "in-session"
+    urls = {s.url for s in ctx.sources}
+    assert "https://example.com/a" in urls
+    assert "https://example.com/b" in urls
+    assert ctx.source_summary_markdown.strip()
+
+
+def test_report_context_from_markdown_no_sources_section():
+    from aiq_api.jobs.report_context import report_context_from_markdown
+
+    ctx = report_context_from_markdown("# Findings\n\nNo sources here.")
+    assert ctx.sources == []
+    assert "No durable source metadata" in ctx.source_summary_markdown

--- a/frontends/aiq_api/tests/test_report_context.py
+++ b/frontends/aiq_api/tests/test_report_context.py
@@ -15,66 +15,60 @@ def test_extract_report_from_job_output_prefers_job_output():
     assert _extract_report_from_job_output(job) == "# Stored report"
 
 
-@pytest.mark.asyncio
-async def test_extract_report_from_events_prefers_final_report(monkeypatch):
+def test_report_from_events_prefers_final_report():
     from aiq_api.jobs import report_context
 
-    async def _events(_db_url: str, _job_id: str, _after_id: int, _limit: int):
-        return [
-            {"type": "artifact.update", "data": {"type": "output", "content": "draft"}},
-            {
-                "type": "artifact.update",
-                "data": {"type": "output", "content": "# Final", "output_category": "final_report"},
-            },
-        ]
+    events = [
+        {"type": "artifact.update", "data": {"type": "output", "content": "draft"}},
+        {
+            "type": "artifact.update",
+            "data": {"type": "output", "content": "# Final", "output_category": "final_report"},
+        },
+    ]
 
-    monkeypatch.setattr(report_context.EventStore, "get_events_async", _events)
-
-    assert await report_context._extract_report_from_events("sqlite:///unused.db", "job-1") == "# Final"
+    assert report_context._report_from_events(events) == "# Final"
 
 
-@pytest.mark.asyncio
-async def test_extract_sources_from_events_dedupes_urls_and_citation_keys(monkeypatch):
+def test_sources_from_events_preserves_duplicates_until_context_boundary():
     from aiq_api.jobs import report_context
 
-    async def _events(_db_url: str, _job_id: str, _after_id: int, _limit: int):
-        return [
-            {
-                "type": "artifact.update",
-                "name": "Example",
-                "data": {"type": "citation_source", "content": "https://example.com/", "url": "https://example.com/"},
+    events = [
+        {
+            "type": "artifact.update",
+            "name": "Example",
+            "data": {"type": "citation_source", "content": "https://example.com/", "url": "https://example.com/"},
+        },
+        {
+            "type": "artifact.update",
+            "name": "Example again",
+            "data": {"type": "citation_source", "content": "https://example.com", "url": "https://example.com"},
+        },
+        {
+            "type": "artifact.update",
+            "name": "internal.pdf",
+            "data": {
+                "type": "citation_source",
+                "content": "internal.pdf, p.3",
+                "citation_key": "internal.pdf, p.3",
             },
-            {
-                "type": "artifact.update",
-                "name": "Example again",
-                "data": {"type": "citation_source", "content": "https://example.com", "url": "https://example.com"},
+        },
+        {
+            "type": "artifact.update",
+            "name": "internal.pdf duplicate",
+            "data": {
+                "type": "citation_source",
+                "content": "internal.pdf, p.3",
+                "citation_key": "internal.pdf, p.3",
             },
-            {
-                "type": "artifact.update",
-                "name": "internal.pdf",
-                "data": {
-                    "type": "citation_source",
-                    "content": "internal.pdf, p.3",
-                    "citation_key": "internal.pdf, p.3",
-                },
-            },
-            {
-                "type": "artifact.update",
-                "name": "internal.pdf duplicate",
-                "data": {
-                    "type": "citation_source",
-                    "content": "internal.pdf, p.3",
-                    "citation_key": "internal.pdf, p.3",
-                },
-            },
-        ]
+        },
+    ]
 
-    monkeypatch.setattr(report_context.EventStore, "get_events_async", _events)
-
-    sources = await report_context._extract_sources_from_events("sqlite:///unused.db", "job-1")
+    sources = report_context._sources_from_events(events)
 
     assert [(source.url, source.citation_key) for source in sources] == [
         ("https://example.com/", None),
+        ("https://example.com", None),
+        (None, "internal.pdf, p.3"),
         (None, "internal.pdf, p.3"),
     ]
 
@@ -102,6 +96,22 @@ Not a source: https://ignored.example
         ("https://example.com/path", None),
         (None, "internal.pdf, p.3"),
     ]
+
+
+def test_extract_sources_from_report_markdown_preserves_duplicates_until_context_boundary():
+    from aiq_api.jobs.report_context import _extract_sources_from_report_markdown
+
+    report = """# Report
+
+## Sources
+
+[1] https://example.com/path
+[2] https://example.com/path/
+"""
+
+    sources = _extract_sources_from_report_markdown(report)
+
+    assert [source.url for source in sources] == ["https://example.com/path", "https://example.com/path/"]
 
 
 @pytest.mark.asyncio
@@ -234,6 +244,15 @@ def test_report_context_from_markdown_builds_jobless_context():
     assert "https://example.com/a" in urls
     assert "https://example.com/b" in urls
     assert ctx.source_summary_markdown.strip()
+
+
+def test_report_context_from_markdown_dedupes_sources_at_context_boundary():
+    from aiq_api.jobs.report_context import report_context_from_markdown
+
+    md = "# Findings\n\n## Sources\n\n[1] https://example.com/a\n[2] https://example.com/a/\n"
+    ctx = report_context_from_markdown(md)
+
+    assert [source.url for source in ctx.sources] == ["https://example.com/a"]
 
 
 def test_report_context_from_markdown_no_sources_section():

--- a/frontends/aiq_api/tests/test_report_context.py
+++ b/frontends/aiq_api/tests/test_report_context.py
@@ -152,6 +152,55 @@ async def test_resolve_report_context_fetches_events_once_in_fallback(monkeypatc
     assert calls["n"] == 1
 
 
+@pytest.mark.asyncio
+async def test_resolve_report_context_skips_event_scan_when_output_has_inline_sources(monkeypatch):
+    """Report in job.output with its own ## Sources -> skip the (potentially large) event scan."""
+    from aiq_api.jobs import report_context
+
+    calls = {"n": 0}
+
+    async def _events(_db_url: str, _job_id: str, _after_id: int, _limit: int):
+        calls["n"] += 1
+        return []
+
+    monkeypatch.setattr(report_context.EventStore, "get_events_async", _events)
+
+    report = "# Report\n\nBody [1].\n\n## Sources\n\n[1] https://example.com/path\n"
+    job = type("Job", (), {"output": {"report": report}})()
+
+    ctx = await report_context.resolve_report_context(job, "sqlite:///unused.db", "job-1")
+
+    assert calls["n"] == 0
+    assert [s.url for s in ctx.sources] == ["https://example.com/path"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_report_context_scans_events_when_output_report_lacks_sources(monkeypatch):
+    """Report in job.output but no inline ## Sources -> fall back to the event scan for enrichment."""
+    from aiq_api.jobs import report_context
+
+    calls = {"n": 0}
+
+    async def _events(_db_url: str, _job_id: str, _after_id: int, _limit: int):
+        calls["n"] += 1
+        return [
+            {
+                "type": "artifact.update",
+                "name": "Ex",
+                "data": {"type": "citation_source", "url": "https://events.example/x"},
+            },
+        ]
+
+    monkeypatch.setattr(report_context.EventStore, "get_events_async", _events)
+
+    job = type("Job", (), {"output": {"report": "# Report\n\nNo sources section here.\n"}})()
+
+    ctx = await report_context.resolve_report_context(job, "sqlite:///unused.db", "job-1")
+
+    assert calls["n"] == 1
+    assert [s.url for s in ctx.sources] == ["https://events.example/x"]
+
+
 def test_to_initial_files_uses_shared_paths_only():
     from aiq_api.jobs.report_context import ReportContext
     from aiq_api.jobs.report_context import ReportContextSource
@@ -193,3 +242,49 @@ def test_report_context_from_markdown_no_sources_section():
     ctx = report_context_from_markdown("# Findings\n\nNo sources here.")
     assert ctx.sources == []
     assert "No durable source metadata" in ctx.source_summary_markdown
+
+
+@pytest.mark.asyncio
+async def test_resolve_authorized_report_context_caches_job_store(monkeypatch):
+    """JobStore is built once per (scheduler_address, db_url), not per request.
+
+    JobStore eagerly builds a SQLAlchemy AsyncEngine (own connection pool), so per-request
+    construction wastes work and leaks pooled connections.
+    """
+    from aiq_api.jobs import report_context
+
+    report_context._JOB_STORE_CACHE.clear()
+
+    monkeypatch.setenv("NAT_DASK_SCHEDULER_ADDRESS", "tcp://localhost:8786")
+    monkeypatch.setenv("NAT_JOB_STORE_DB_URL", "sqlite:///unused.db")
+
+    constructions = {"n": 0}
+
+    class _FakeJobStore:
+        def __init__(self, *, scheduler_address, db_url):
+            constructions["n"] += 1
+
+    class _FakeJobStatus:
+        SUCCESS = type("E", (), {"value": "success"})
+
+    import nat.front_ends.fastapi.async_jobs.job_store as js
+
+    monkeypatch.setattr(js, "JobStore", _FakeJobStore)
+    monkeypatch.setattr(js, "JobStatus", _FakeJobStatus)
+
+    job = type("Job", (), {"status": "success"})()
+
+    async def _authorize(_store, _db_url, _job_id, _principal):
+        return job
+
+    async def _resolve(_job, _db_url, _job_id):
+        return report_context.ReportContext(parent_job_id=_job_id, report_markdown="# R", source_summary_markdown="")
+
+    monkeypatch.setattr(report_context, "authorize_job_access", _authorize)
+    monkeypatch.setattr(report_context, "resolve_report_context", _resolve)
+
+    await report_context.resolve_authorized_report_context("job-1", None)
+    await report_context.resolve_authorized_report_context("job-1", None)
+
+    assert constructions["n"] == 1
+    report_context._JOB_STORE_CACHE.clear()

--- a/frontends/aiq_api/tests/test_report_context.py
+++ b/frontends/aiq_api/tests/test_report_context.py
@@ -52,12 +52,20 @@ async def test_extract_sources_from_events_dedupes_urls_and_citation_keys(monkey
             {
                 "type": "artifact.update",
                 "name": "internal.pdf",
-                "data": {"type": "citation_source", "content": "internal.pdf, p.3", "citation_key": "internal.pdf, p.3"},
+                "data": {
+                    "type": "citation_source",
+                    "content": "internal.pdf, p.3",
+                    "citation_key": "internal.pdf, p.3",
+                },
             },
             {
                 "type": "artifact.update",
                 "name": "internal.pdf duplicate",
-                "data": {"type": "citation_source", "content": "internal.pdf, p.3", "citation_key": "internal.pdf, p.3"},
+                "data": {
+                    "type": "citation_source",
+                    "content": "internal.pdf, p.3",
+                    "citation_key": "internal.pdf, p.3",
+                },
             },
         ]
 
@@ -100,10 +108,10 @@ Not a source: https://ignored.example
 async def test_resolve_report_context_raises_409_without_report(monkeypatch):
     from aiq_api.jobs import report_context
 
-    async def _no_event_report(_db_url: str, _job_id: str):
-        return None
+    async def _no_events(_db_url: str, _job_id: str, _after_id: int, _limit: int):
+        return []
 
-    monkeypatch.setattr(report_context, "_extract_report_from_events", _no_event_report)
+    monkeypatch.setattr(report_context.EventStore, "get_events_async", _no_events)
 
     job = type("Job", (), {"output": None})()
 
@@ -111,6 +119,37 @@ async def test_resolve_report_context_raises_409_without_report(monkeypatch):
         await report_context.resolve_report_context(job, "sqlite:///unused.db", "job-1")
 
     assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_resolve_report_context_fetches_events_once_in_fallback(monkeypatch):
+    """When the report is reconstructed from events, the event log is fetched once, not twice."""
+    from aiq_api.jobs import report_context
+
+    calls = {"n": 0}
+
+    async def _events(_db_url: str, _job_id: str, _after_id: int, _limit: int):
+        calls["n"] += 1
+        return [
+            {
+                "type": "artifact.update",
+                "data": {"type": "output", "content": "# Final", "output_category": "final_report"},
+            },
+            {
+                "type": "artifact.update",
+                "name": "Ex",
+                "data": {"type": "citation_source", "url": "https://example.com"},
+            },
+        ]
+
+    monkeypatch.setattr(report_context.EventStore, "get_events_async", _events)
+
+    job = type("Job", (), {"output": None})()
+    ctx = await report_context.resolve_report_context(job, "sqlite:///unused.db", "job-1")
+
+    assert ctx.report_markdown == "# Final"
+    assert [s.url for s in ctx.sources] == ["https://example.com"]
+    assert calls["n"] == 1
 
 
 def test_to_initial_files_uses_shared_paths_only():

--- a/frontends/aiq_api/tests/test_report_context.py
+++ b/frontends/aiq_api/tests/test_report_context.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+
+def test_extract_report_from_job_output_prefers_job_output():
+    from aiq_api.jobs.report_context import _extract_report_from_job_output
+
+    job = type("Job", (), {"output": {"report": "# Stored report"}})()
+
+    assert _extract_report_from_job_output(job) == "# Stored report"
+
+
+@pytest.mark.asyncio
+async def test_extract_report_from_events_prefers_final_report(monkeypatch):
+    from aiq_api.jobs import report_context
+
+    async def _events(_db_url: str, _job_id: str, _after_id: int, _limit: int):
+        return [
+            {"type": "artifact.update", "data": {"type": "output", "content": "draft"}},
+            {
+                "type": "artifact.update",
+                "data": {"type": "output", "content": "# Final", "output_category": "final_report"},
+            },
+        ]
+
+    monkeypatch.setattr(report_context.EventStore, "get_events_async", _events)
+
+    assert await report_context._extract_report_from_events("sqlite:///unused.db", "job-1") == "# Final"
+
+
+@pytest.mark.asyncio
+async def test_extract_sources_from_events_dedupes_urls_and_citation_keys(monkeypatch):
+    from aiq_api.jobs import report_context
+
+    async def _events(_db_url: str, _job_id: str, _after_id: int, _limit: int):
+        return [
+            {
+                "type": "artifact.update",
+                "name": "Example",
+                "data": {"type": "citation_source", "content": "https://example.com/", "url": "https://example.com/"},
+            },
+            {
+                "type": "artifact.update",
+                "name": "Example again",
+                "data": {"type": "citation_source", "content": "https://example.com", "url": "https://example.com"},
+            },
+            {
+                "type": "artifact.update",
+                "name": "internal.pdf",
+                "data": {"type": "citation_source", "content": "internal.pdf, p.3", "citation_key": "internal.pdf, p.3"},
+            },
+            {
+                "type": "artifact.update",
+                "name": "internal.pdf duplicate",
+                "data": {"type": "citation_source", "content": "internal.pdf, p.3", "citation_key": "internal.pdf, p.3"},
+            },
+        ]
+
+    monkeypatch.setattr(report_context.EventStore, "get_events_async", _events)
+
+    sources = await report_context._extract_sources_from_events("sqlite:///unused.db", "job-1")
+
+    assert [(source.url, source.citation_key) for source in sources] == [
+        ("https://example.com/", None),
+        (None, "internal.pdf, p.3"),
+    ]
+
+
+def test_extract_sources_from_report_markdown_finds_urls_and_citation_keys():
+    from aiq_api.jobs.report_context import _extract_sources_from_report_markdown
+
+    report = """# Report
+
+Body [1].
+
+## Sources
+
+[1] Example: https://example.com/path
+[2] internal.pdf, p.3
+
+## Appendix
+
+Not a source: https://ignored.example
+"""
+
+    sources = _extract_sources_from_report_markdown(report)
+
+    assert [(source.url, source.citation_key) for source in sources] == [
+        ("https://example.com/path", None),
+        (None, "internal.pdf, p.3"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_resolve_report_context_raises_409_without_report(monkeypatch):
+    from aiq_api.jobs import report_context
+
+    async def _no_event_report(_db_url: str, _job_id: str):
+        return None
+
+    monkeypatch.setattr(report_context, "_extract_report_from_events", _no_event_report)
+
+    job = type("Job", (), {"output": None})()
+
+    with pytest.raises(HTTPException) as exc:
+        await report_context.resolve_report_context(job, "sqlite:///unused.db", "job-1")
+
+    assert exc.value.status_code == 409
+
+
+def test_to_initial_files_uses_shared_paths_only():
+    from aiq_api.jobs.report_context import ReportContext
+    from aiq_api.jobs.report_context import ReportContextSource
+    from aiq_api.jobs.report_context import to_initial_files
+
+    context = ReportContext(
+        parent_job_id="job-1",
+        report_markdown="# Report",
+        source_summary_markdown="- https://example.com",
+        sources=[ReportContextSource(url="https://example.com")],
+    )
+
+    files = to_initial_files(context, instruction="Remove the appendix.")
+
+    assert files["/shared/original_report.md"] == "# Report"
+    assert files["/shared/source_summary.md"] == "- https://example.com"
+    assert files["/shared/edit_instruction.txt"] == "Remove the appendix."
+    assert "/report.md" not in files

--- a/frontends/aiq_api/tests/test_report_edit.py
+++ b/frontends/aiq_api/tests/test_report_edit.py
@@ -133,6 +133,24 @@ async def test_report_edit_rejects_parent_without_durable_report(report_edit_app
 
 
 @pytest.mark.asyncio
+async def test_report_edit_denies_cross_user_access_with_404(report_edit_app):
+    """A non-owner is rejected (404 from authorization) before any child job is submitted."""
+    from fastapi import HTTPException
+
+    app, _parent_job, authorize_job_access, submit_agent_job, _principal, _job_store = report_edit_app
+    authorize_job_access.side_effect = HTTPException(status_code=404, detail="Job not found: parent-job-1")
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/job/parent-job-1/report/edit",
+            json={"input": "Remove the final paragraph."},
+        )
+
+    assert response.status_code == 404
+    submit_agent_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_job_report_response_includes_report_interaction_metadata(report_edit_app):
     app, child_job, _authorize_job_access, _submit_agent_job, _principal, _job_store = report_edit_app
     child_job.output = {

--- a/frontends/aiq_api/tests/test_report_edit.py
+++ b/frontends/aiq_api/tests/test_report_edit.py
@@ -151,6 +151,38 @@ async def test_report_edit_denies_cross_user_access_with_404(report_edit_app):
 
 
 @pytest.mark.asyncio
+async def test_report_edit_job_id_collision_returns_409(report_edit_app):
+    """A caller-supplied job_id that collides returns 409, never a 500/data-loss path."""
+    from aiq_api.jobs.submit import JobIdConflictError
+
+    app, _parent_job, _authorize_job_access, submit_agent_job, _principal, _job_store = report_edit_app
+    submit_agent_job.side_effect = JobIdConflictError("Job already exists: existing-child")
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/job/parent-job-1/report/edit",
+            json={"input": "Remove the final paragraph.", "job_id": "existing-child"},
+        )
+
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_report_edit_submits_internal_agent_with_allow_internal(report_edit_app):
+    """The endpoint must opt in to the internal report_rewriter agent explicitly."""
+    app, _parent_job, _authorize_job_access, submit_agent_job, _principal, _job_store = report_edit_app
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/job/parent-job-1/report/edit",
+            json={"input": "Shorten it."},
+        )
+
+    assert response.status_code == 200
+    assert submit_agent_job.await_args.kwargs["allow_internal"] is True
+
+
+@pytest.mark.asyncio
 async def test_job_report_response_includes_report_interaction_metadata(report_edit_app):
     app, child_job, _authorize_job_access, _submit_agent_job, _principal, _job_store = report_edit_app
     child_job.output = {

--- a/frontends/aiq_api/tests/test_report_edit.py
+++ b/frontends/aiq_api/tests/test_report_edit.py
@@ -151,6 +151,21 @@ async def test_report_edit_denies_cross_user_access_with_404(report_edit_app):
 
 
 @pytest.mark.asyncio
+async def test_report_edit_rejects_blank_input(report_edit_app):
+    """Whitespace-only edit instructions are rejected at the boundary (422), not submitted."""
+    app, _parent_job, _authorize_job_access, submit_agent_job, _principal, _job_store = report_edit_app
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/job/parent-job-1/report/edit",
+            json={"input": "   "},
+        )
+
+    assert response.status_code == 422
+    submit_agent_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_report_edit_job_id_collision_returns_409(report_edit_app):
     """A caller-supplied job_id that collides returns 409, never a 500/data-loss path."""
     from aiq_api.jobs.submit import JobIdConflictError
@@ -184,7 +199,7 @@ async def test_report_edit_submits_internal_agent_with_allow_internal(report_edi
 
 @pytest.mark.asyncio
 async def test_job_report_response_includes_report_interaction_metadata(report_edit_app):
-    app, child_job, _authorize_job_access, _submit_agent_job, _principal, _job_store = report_edit_app
+    app, child_job, authorize_job_access, _submit_agent_job, principal, job_store = report_edit_app
     child_job.output = {
         "report": "# Revised",
         "parent_job_id": "parent-job-1",
@@ -204,3 +219,6 @@ async def test_job_report_response_includes_report_interaction_metadata(report_e
         "interaction_action": "edit",
         "result_kind": "report",
     }
+    # The GET report route must authorize the caller for THIS job id (the fixture
+    # mock returns the same object for any id, so prove the access check happened).
+    authorize_job_access.assert_awaited_once_with(job_store, "sqlite:///./test.db", "child-job-1", principal)

--- a/frontends/aiq_api/tests/test_report_edit.py
+++ b/frontends/aiq_api/tests/test_report_edit.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from aiq_agent.auth import Principal
+
+
+@pytest.fixture
+async def report_edit_app(monkeypatch):
+    """Build a minimal async-jobs app with patched storage and submission side effects."""
+    import aiq_agent.auth
+    import aiq_api.routes.jobs as jobs_routes
+    from aiq_api.jobs import access
+    from aiq_api.jobs import event_store
+    from aiq_api.jobs import submit
+
+    principal = Principal(type="jwt", sub="user-1", email="user@example.com")
+    parent_job = SimpleNamespace(
+        status="success",
+        output={
+            "report": "# Parent Report\n\nKeep this.\n\n## Sources\n\n[1] https://example.com/source",
+        },
+        error=None,
+        created_at=None,
+    )
+    job_store = MagicMock()
+    authorize_job_access = AsyncMock(return_value=parent_job)
+    submit_agent_job = AsyncMock(return_value="child-job-1")
+
+    monkeypatch.setattr(jobs_routes, "_start_periodic_cleanup", MagicMock())
+    monkeypatch.setattr(jobs_routes, "_reap_ghost_jobs", AsyncMock())
+    monkeypatch.setattr(jobs_routes, "require_verified_principal", lambda: principal)
+    monkeypatch.setattr(access, "authorize_job_access", authorize_job_access)
+    monkeypatch.setattr(access, "ensure_job_access_table", MagicMock())
+    monkeypatch.setattr(event_store.EventStore, "_ensure_table_exists", MagicMock())
+    monkeypatch.setattr(event_store.EventStore, "get_events_async", AsyncMock(return_value=[]))
+    monkeypatch.setattr(submit, "submit_agent_job", submit_agent_job)
+    monkeypatch.setattr(aiq_agent.auth, "get_auth_token", lambda: "token-1")
+
+    worker = SimpleNamespace(
+        _dask_available=True,
+        _job_store=job_store,
+        _scheduler_address="tcp://localhost:8786",
+        _db_url="sqlite:///./test.db",
+        _config_file_path="config.yml",
+        _log_level=20,
+        _use_dask_threads=False,
+        _front_end_config=SimpleNamespace(expiry_seconds=86400),
+    )
+    builder = MagicMock()
+
+    app = FastAPI()
+    await jobs_routes.register_job_routes(app, builder, worker)
+    return app, parent_job, authorize_job_access, submit_agent_job, principal, job_store
+
+
+@pytest.mark.asyncio
+async def test_report_edit_authorizes_parent_and_submits_internal_child(report_edit_app):
+    app, parent_job, authorize_job_access, submit_agent_job, principal, job_store = report_edit_app
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/job/parent-job-1/report/edit",
+            json={"input": "Remove the final paragraph."},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "job_id": "child-job-1",
+        "parent_job_id": "parent-job-1",
+        "status": "submitted",
+        "agent_type": "report_rewriter",
+    }
+    authorize_job_access.assert_awaited_once_with(job_store, "sqlite:///./test.db", "parent-job-1", principal)
+    submit_agent_job.assert_awaited_once()
+    kwargs = submit_agent_job.await_args.kwargs
+    assert kwargs["agent_type"] == "report_rewriter"
+    assert kwargs["input_text"] == "Remove the final paragraph."
+    assert kwargs["owner"] == "user@example.com"
+    assert kwargs["principal"] == principal
+    assert kwargs["data_sources"] == []
+    assert kwargs["auth_token"] == "token-1"
+    assert kwargs["initial_files"]["/shared/original_report.md"] == parent_job.output["report"]
+    assert kwargs["initial_files"]["/shared/edit_instruction.txt"] == "Remove the final paragraph."
+    assert json.loads(kwargs["initial_files"]["/shared/parent_report_context.json"])["parent_job_id"] == "parent-job-1"
+    assert kwargs["output_metadata"] == {
+        "parent_job_id": "parent-job-1",
+        "interaction_action": "edit",
+        "result_kind": "report",
+    }
+
+
+@pytest.mark.asyncio
+async def test_report_edit_rejects_incomplete_parent(report_edit_app):
+    app, parent_job, _authorize_job_access, submit_agent_job, _principal, _job_store = report_edit_app
+    parent_job.status = "running"
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/job/parent-job-1/report/edit",
+            json={"input": "Remove the final paragraph."},
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Parent job is not complete: parent-job-1"
+    submit_agent_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_report_edit_rejects_parent_without_durable_report(report_edit_app):
+    app, parent_job, _authorize_job_access, submit_agent_job, _principal, _job_store = report_edit_app
+    parent_job.output = {}
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/jobs/async/job/parent-job-1/report/edit",
+            json={"input": "Remove the final paragraph."},
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Parent job has no durable report: parent-job-1"
+    submit_agent_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_job_report_response_includes_report_interaction_metadata(report_edit_app):
+    app, child_job, _authorize_job_access, _submit_agent_job, _principal, _job_store = report_edit_app
+    child_job.output = {
+        "report": "# Revised",
+        "parent_job_id": "parent-job-1",
+        "interaction_action": "edit",
+        "result_kind": "report",
+    }
+
+    with TestClient(app) as client:
+        response = client.get("/v1/jobs/async/job/child-job-1/report")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "job_id": "child-job-1",
+        "has_report": True,
+        "report": "# Revised",
+        "parent_job_id": "parent-job-1",
+        "interaction_action": "edit",
+        "result_kind": "report",
+    }

--- a/frontends/aiq_api/tests/test_submit_collision.py
+++ b/frontends/aiq_api/tests/test_submit_collision.py
@@ -117,3 +117,28 @@ async def test_post_create_submit_failure_rolls_back(patched_submit, monkeypatch
         )
 
     rollback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_submit_records_conversation_id_on_job_access(patched_submit, monkeypatch):
+    """The originating conversation id is persisted with the job for report-follow-up lookups."""
+    submit_mod, job_store_mod, _rollback, create_access = patched_submit
+
+    async def _submit_job_ok(*args, **kwargs):
+        return "ok"
+
+    monkeypatch.setattr(job_store_mod, "JobStore", _fake_job_store_factory(_submit_job_ok))
+    monkeypatch.setattr(submit_mod, "_current_conversation_id", lambda: "conv-XYZ")
+
+    await submit_mod.submit_agent_job(
+        agent_type="deep_researcher",
+        input_text="hello",
+        owner="user@example.com",
+        principal=Principal(type="jwt", sub="user-1", email="user@example.com"),
+        job_id="job-1",
+    )
+
+    create_access.assert_called_once()
+    # create_job_access(job_id, principal, db_url, conversation_id) -> conversation id is the 4th positional arg
+    assert create_access.call_args.args[0] == "job-1"
+    assert create_access.call_args.args[3] == "conv-XYZ"

--- a/frontends/aiq_api/tests/test_submit_collision.py
+++ b/frontends/aiq_api/tests/test_submit_collision.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for caller-supplied job_id collision handling in submit_agent_job.
+
+A colliding job_id must NOT trigger the rollback path (which unconditionally
+deletes job_info/job_events/job_access for that id), or any caller who knows an
+existing job id could destroy that job's durable state.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from aiq_agent.auth import Principal
+
+
+def _fake_job_store_factory(submit_job):
+    class _FakeJobStore:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def ensure_job_id(self, job_id):
+            return job_id or "generated-id"
+
+        async def submit_job(self, *args, **kwargs):
+            return await submit_job(*args, **kwargs)
+
+    return _FakeJobStore
+
+
+@pytest.fixture
+def patched_submit(monkeypatch):
+    import aiq_api.jobs.submit as submit_mod
+    import nat.front_ends.fastapi.async_jobs.job_store as job_store_mod
+
+    monkeypatch.setenv("NAT_DASK_SCHEDULER_ADDRESS", "tcp://localhost:8786")
+    monkeypatch.setenv("REQUIRE_AUTH", "false")
+
+    rollback = MagicMock()
+    create_access = MagicMock()
+    monkeypatch.setattr(submit_mod, "rollback_job_submission", rollback)
+    monkeypatch.setattr(submit_mod, "create_job_access", create_access)
+    return submit_mod, job_store_mod, rollback, create_access
+
+
+@pytest.mark.asyncio
+async def test_colliding_job_id_raises_conflict_without_rollback(patched_submit, monkeypatch):
+    submit_mod, job_store_mod, rollback, _create_access = patched_submit
+
+    async def _submit_job_collision(*args, **kwargs):
+        raise IntegrityError("INSERT INTO job_info", {}, Exception("UNIQUE constraint failed: job_info.job_id"))
+
+    monkeypatch.setattr(job_store_mod, "JobStore", _fake_job_store_factory(_submit_job_collision))
+
+    with pytest.raises(submit_mod.JobIdConflictError):
+        await submit_mod.submit_agent_job(
+            agent_type="deep_researcher",
+            input_text="hello",
+            owner="user@example.com",
+            principal=Principal(type="jwt", sub="user-1", email="user@example.com"),
+            job_id="victim-job-id",
+        )
+
+    # The colliding job already existed and is NOT ours — we must never delete it.
+    rollback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_access_persistence_failure_still_rolls_back(patched_submit, monkeypatch):
+    submit_mod, job_store_mod, rollback, create_access = patched_submit
+
+    async def _submit_job_ok(*args, **kwargs):
+        return "ok"
+
+    monkeypatch.setattr(job_store_mod, "JobStore", _fake_job_store_factory(_submit_job_ok))
+    # create_job_access runs in an executor; make it raise to simulate access persistence failure.
+    create_access.side_effect = RuntimeError("db down")
+
+    with pytest.raises(RuntimeError):
+        await submit_mod.submit_agent_job(
+            agent_type="deep_researcher",
+            input_text="hello",
+            owner="user@example.com",
+            principal=Principal(type="jwt", sub="user-1", email="user@example.com"),
+            job_id="our-own-new-job",
+        )
+
+    # We created this job, then access persistence failed -> roll back our partial state.
+    rollback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_post_create_submit_failure_rolls_back(patched_submit, monkeypatch):
+    """A non-collision submit_job failure (e.g. scheduler/Dask error) after the job_info
+    row is committed must still roll back, or it leaves an orphaned ownerless job."""
+    submit_mod, job_store_mod, rollback, _create_access = patched_submit
+
+    async def _submit_job_dask_failure(*args, **kwargs):
+        # NAT's submit_job commits job_info before submitting to Dask, so this
+        # mirrors a Variable.set timeout / scheduler-unreachable error that fires
+        # AFTER the row exists.
+        raise RuntimeError("Task abc-job unknown to scheduler.")
+
+    monkeypatch.setattr(job_store_mod, "JobStore", _fake_job_store_factory(_submit_job_dask_failure))
+
+    with pytest.raises(RuntimeError):
+        await submit_mod.submit_agent_job(
+            agent_type="deep_researcher",
+            input_text="hello",
+            owner="user@example.com",
+            principal=Principal(type="jwt", sub="user-1", email="user@example.com"),
+            job_id="our-own-new-job",
+        )
+
+    rollback.assert_called_once()

--- a/frontends/aiq_api/tests/test_submit_internal_agent.py
+++ b/frontends/aiq_api/tests/test_submit_internal_agent.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""submit_agent_job must enforce the internal (public=False) agent gate itself.
+
+The HTTP /submit route filters internal agents, but the submission helper is the
+real trust boundary: any caller that forwards a caller-influenced agent_type must
+not be able to launch an internal-only agent without explicitly opting in.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aiq_agent.auth import Principal
+
+
+@pytest.mark.asyncio
+async def test_submit_internal_agent_rejected_without_allow_internal(monkeypatch):
+    import aiq_api.jobs.submit as submit_mod
+
+    monkeypatch.setenv("NAT_DASK_SCHEDULER_ADDRESS", "tcp://localhost:8786")
+    monkeypatch.setenv("REQUIRE_AUTH", "false")
+
+    # report_rewriter is registered with public=False.
+    with pytest.raises(submit_mod.InternalAgentError):
+        await submit_mod.submit_agent_job(
+            agent_type="report_rewriter",
+            input_text="rewrite",
+            owner="user@example.com",
+            principal=Principal(type="jwt", sub="user-1", email="user@example.com"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_submit_internal_agent_allowed_with_allow_internal(monkeypatch):
+    import aiq_api.jobs.submit as submit_mod
+    import nat.front_ends.fastapi.async_jobs.job_store as job_store_mod
+
+    monkeypatch.setenv("NAT_DASK_SCHEDULER_ADDRESS", "tcp://localhost:8786")
+    monkeypatch.setenv("REQUIRE_AUTH", "false")
+
+    submitted = {}
+
+    class _FakeJobStore:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def ensure_job_id(self, job_id):
+            return job_id or "child-1"
+
+        async def submit_job(self, *args, **kwargs):
+            submitted["called"] = True
+
+    monkeypatch.setattr(job_store_mod, "JobStore", _FakeJobStore)
+    monkeypatch.setattr(submit_mod, "create_job_access", lambda *a, **k: None)
+
+    job_id = await submit_mod.submit_agent_job(
+        agent_type="report_rewriter",
+        input_text="rewrite",
+        owner="user@example.com",
+        principal=Principal(type="jwt", sub="user-1", email="user@example.com"),
+        allow_internal=True,
+    )
+    assert job_id == "child-1"
+    assert submitted.get("called") is True

--- a/frontends/benchmarks/deepresearch_bench/configs/config_deep_research_bench.yml
+++ b/frontends/benchmarks/deepresearch_bench/configs/config_deep_research_bench.yml
@@ -56,7 +56,7 @@ functions:
     source_router_llm: nemotron_super_llm
     researcher_llm: nemotron_super_llm
     planner_llm: gpt_oss_llm
-    writer_llm: gpt_oss_llm
+    writer_llm: nemotron_super_llm
     max_loops: 2
     tools:
       - paper_search_tool

--- a/frontends/benchmarks/deepresearch_bench/configs/config_deep_research_bench_profiling.yml
+++ b/frontends/benchmarks/deepresearch_bench/configs/config_deep_research_bench_profiling.yml
@@ -61,7 +61,7 @@ functions:
     source_router_llm: nemotron_super_llm
     researcher_llm: nemotron_super_llm
     planner_llm: nemotron_super_llm
-    writer_llm: gpt_oss_llm
+    writer_llm: nemotron_super_llm
     max_loops: 2
     tools:
       - paper_search_tool

--- a/frontends/benchmarks/deepsearch_qa/configs/config_deepsearch_qa.yml
+++ b/frontends/benchmarks/deepsearch_qa/configs/config_deepsearch_qa.yml
@@ -54,7 +54,7 @@ functions:
     source_router_llm: nemotron_super_llm
     researcher_llm: nemotron_super_llm
     planner_llm: gpt_oss_llm
-    writer_llm: gpt_oss_llm
+    writer_llm: nemotron_super_llm
     max_loops: 2
     tools:
       - web_search_tool

--- a/frontends/benchmarks/freshqa/configs/config_full_workflow.yml
+++ b/frontends/benchmarks/freshqa/configs/config_full_workflow.yml
@@ -72,7 +72,7 @@ functions:
     source_router_llm: nemotron_super_llm
     researcher_llm: nemotron_super_llm
     planner_llm: gpt_oss_llm
-    writer_llm: gpt_oss_llm
+    writer_llm: nemotron_super_llm
     max_loops: 2
     tools:
       - web_search_tool

--- a/frontends/ui/src/adapters/api/websocket-client.spec.ts
+++ b/frontends/ui/src/adapters/api/websocket-client.spec.ts
@@ -200,6 +200,28 @@ describe('NATWebSocketClient auth observability', () => {
     expect(MockWebSocket.instances).toHaveLength(1)
   })
 
+  test('sendMessage includes active report job id when provided', async () => {
+    const client = new NATWebSocketClient({
+      conversationId: 'conv-1',
+      websocketUrl: 'ws://localhost/websocket',
+      callbacks: {},
+    })
+
+    await client.connect()
+    const ws = MockWebSocket.instances[0]
+    ws.onopen?.(new Event('open'))
+
+    client.sendMessage('What changed?', ['web_search'], 'job-123')
+
+    const sent = JSON.parse(ws.send.mock.calls[0][0] as string)
+    const textContent = sent.content.messages[0].content[0].text
+    expect(JSON.parse(textContent)).toEqual({
+      query: 'What changed?',
+      data_sources: ['web_search'],
+      active_report_job_id: 'job-123',
+    })
+  })
+
   test('does not emit RUM error for non-auth websocket errors', async () => {
     const addError = vi.fn()
     ;(window as unknown as Record<string, unknown>).DD_RUM = { addError }

--- a/frontends/ui/src/adapters/api/websocket-client.ts
+++ b/frontends/ui/src/adapters/api/websocket-client.ts
@@ -223,12 +223,18 @@ export class NATWebSocketClient {
    * Send a user chat message
    * @param content - The message text content (query)
    * @param enabledDataSources - Optional array of enabled data source IDs to include in the query
+   * @param activeReportJobId - Optional completed report job ID for report-aware follow-up
    */
-  sendMessage = (content: string, enabledDataSources?: string[]): string | null => {
+  sendMessage = (
+    content: string,
+    enabledDataSources?: string[],
+    activeReportJobId?: string
+  ): string | null => {
     // Format the text content as JSON with query and data_sources
     const textContent = JSON.stringify({
       query: content,
       data_sources: enabledDataSources ?? [],
+      ...(activeReportJobId ? { active_report_job_id: activeReportJobId } : {}),
     })
 
     const messageId = this.generateMessageId()

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
@@ -1222,7 +1222,11 @@ describe('useWebSocketChat', () => {
 
     // Simulate response with deep research escalation signal
     act(() => {
-      capturedCallbacks.onResponse?.('Deep research job submitted. Job ID: abc123-def456', 'complete', false)
+      capturedCallbacks.onResponse?.(
+        JSON.stringify({ type: 'job_escalation', kind: 'deep_research', job_id: 'abc123-def456' }),
+        'complete',
+        false
+      )
     })
 
     // Should detect deep research and call banner with 'starting' status
@@ -1294,7 +1298,11 @@ describe('useWebSocketChat', () => {
     // Report edit submits a child report_rewriter job that produces a full report,
     // pollable through the same SSE path as deep research.
     act(() => {
-      capturedCallbacks.onResponse?.('Report edit job submitted. Job ID: abcd1234-ef56', 'complete', false)
+      capturedCallbacks.onResponse?.(
+        JSON.stringify({ type: 'job_escalation', kind: 'report_edit', job_id: 'abcd1234-ef56' }),
+        'complete',
+        false
+      )
     })
 
     expect(mockAddDeepResearchBanner).toHaveBeenCalledWith('starting', 'abcd1234-ef56')

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
@@ -343,6 +343,37 @@ describe('useWebSocketChat', () => {
     expect(mockSetLoading).toHaveBeenCalledWith(false)
   })
 
+  test('sendMessage includes active report job id from latest completed report message', () => {
+    mockWsClient.isConnected.mockReturnValue(true)
+    mockStoreState.currentConversation = {
+      id: 'conv-1',
+      userId: 'user-1',
+      messages: [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          content: 'Report ready',
+          messageType: 'agent_response',
+          deepResearchJobId: 'job-123',
+          showViewReport: true,
+          reportContent: '# Report',
+        },
+      ],
+    }
+
+    const { result } = renderWebSocketHook()
+
+    act(() => {
+      result.current.sendMessage('What is the biggest risk?')
+    })
+
+    expect(mockWsClient.sendMessage).toHaveBeenCalledWith(
+      'What is the biggest risk?',
+      expect.any(Array),
+      'job-123',
+    )
+  })
+
   test('sendMessage while the existing socket is connecting buffers instead of creating a parallel client', () => {
     mockWsClient.isConnected.mockReturnValue(false)
     const { result } = renderWebSocketHook()

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.spec.ts
@@ -1239,6 +1239,79 @@ describe('useWebSocketChat', () => {
     )
     expect(mockStartDeepResearch).toHaveBeenCalledWith('abc123-def456', 'msg-1')
   })
+
+  test('detects report-edit escalation and starts SSE streaming for the child job', () => {
+    const mockStartDeepResearch = vi.fn()
+    const mockUpdateConversationTitle = vi.fn()
+    const localMockAddAgentResponseWithMeta = vi.fn(() => 'msg-1')
+    vi.mocked(useChatStore).mockImplementation((selector?: (s: any) => any) => {
+      const state = {
+        ...mockStoreState,
+        addUserMessage: mockAddUserMessage,
+        addAgentResponse: mockAddAgentResponse,
+        addAgentResponseWithMeta: localMockAddAgentResponseWithMeta,
+        addThinkingStep: mockAddThinkingStep,
+        appendToThinkingStep: mockAppendToThinkingStep,
+        completeThinkingStep: mockCompleteThinkingStep,
+        updateThinkingStepByFunctionName: mockUpdateThinkingStepByFunctionName,
+        findThinkingStepByFunctionName: mockFindThinkingStepByFunctionName,
+        setReportContent: mockSetReportContent,
+        addStatusCard: mockAddStatusCard,
+        addAgentPrompt: mockAddAgentPrompt,
+        addErrorCard: mockAddErrorCard,
+        setCurrentStatus: mockSetCurrentStatus,
+        setPendingInteraction: mockSetPendingInteraction,
+        clearPendingInteraction: mockClearPendingInteraction,
+        setLoading: mockSetLoading,
+        setStreaming: mockSetStreaming,
+        clearThinkingSteps: mockClearThinkingSteps,
+        clearReportContent: mockClearReportContent,
+        createConversation: mockCreateConversation,
+        setCurrentUser: mockSetCurrentUser,
+        getUserConversations: mockGetUserConversations,
+        selectConversation: mockSelectConversation,
+        respondToPrompt: mockRespondToPrompt,
+        addPlanMessage: mockAddPlanMessage,
+        updatePlanMessageResponse: mockUpdatePlanMessageResponse,
+        addDeepResearchBanner: mockAddDeepResearchBanner,
+        startDeepResearch: mockStartDeepResearch,
+        updateConversationTitle: mockUpdateConversationTitle,
+      }
+      return selector ? selector(state) : state
+    })
+
+    // A real conversation with a prior user message: a report edit must NOT rename
+    // the existing report conversation to the edit instruction.
+    mockStoreState.currentConversation = {
+      id: 'conv-1',
+      userId: 'user-1',
+      messages: [{ id: 'u1', role: 'user', content: 'Rewrite this report to be shorter' }],
+    } as unknown as typeof mockStoreState.currentConversation
+
+    renderWebSocketHook()
+    mockStoreState.isStreaming = true
+
+    // Report edit submits a child report_rewriter job that produces a full report,
+    // pollable through the same SSE path as deep research.
+    act(() => {
+      capturedCallbacks.onResponse?.('Report edit job submitted. Job ID: abcd1234-ef56', 'complete', false)
+    })
+
+    expect(mockAddDeepResearchBanner).toHaveBeenCalledWith('starting', 'abcd1234-ef56')
+    expect(localMockAddAgentResponseWithMeta).toHaveBeenCalledWith(
+      '',
+      false,
+      expect.objectContaining({
+        deepResearchJobId: 'abcd1234-ef56',
+        deepResearchJobStatus: 'submitted',
+        isDeepResearchActive: true,
+      })
+    )
+    expect(mockStartDeepResearch).toHaveBeenCalledWith('abcd1234-ef56', 'msg-1')
+    // Report edits reuse the deep-research escalation plumbing but must not rename
+    // the conversation to the edit instruction (deep-research-only behavior).
+    expect(mockUpdateConversationTitle).not.toHaveBeenCalled()
+  })
 })
 
 /**

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -61,6 +61,35 @@ const EMPTY_MESSAGES: ChatMessage[] = []
 const EMPTY_CONVERSATIONS: Conversation[] = []
 
 /**
+ * Structured async-job escalation signal parsed from a system_response `content` string.
+ *
+ * The backend (chat_researcher/agent.py `_job_escalation_message`) emits a compact JSON
+ * payload rather than a prose sentence so escalation detection is immune to wording or
+ * punctuation changes:
+ *   {"type":"job_escalation","kind":"deep_research"|"report_edit","job_id":"<id>"}
+ */
+interface JobEscalation {
+  kind: 'deep_research' | 'report_edit'
+  jobId: string
+}
+
+function parseJobEscalation(content?: string): JobEscalation | null {
+  if (!content) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(content)
+  } catch {
+    return null
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null
+  const obj = parsed as Record<string, unknown>
+  if (obj.type !== 'job_escalation') return null
+  if (obj.kind !== 'deep_research' && obj.kind !== 'report_edit') return null
+  if (typeof obj.job_id !== 'string' || obj.job_id.length === 0) return null
+  return { kind: obj.kind, jobId: obj.job_id }
+}
+
+/**
  * Buffer entry for an outgoing payload that has to bridge a socket
  * rotation. Discriminated by `kind` because both chat messages and HITL
  * interaction responses can hit `auth_expired` at the backend, and the
@@ -618,16 +647,15 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
 
         // Check for an async-job escalation signal. Two backend paths produce a
         // pollable child job whose report is fetched over the same SSE/report
-        // endpoints, so both escalate the same way:
-        //   - "Deep research job submitted. Job ID: {uuid}"   (deep_researcher)
-        //   - "Report edit job submitted. Job ID: {uuid}"     (report_rewriter)
-        const deepResearchMatch = content?.match(
-          /(Deep research|Report edit) job submitted\. Job ID: ([a-f0-9-]+)/i
-        )
+        // endpoints, so both escalate the same way. The backend emits a structured
+        // JSON payload (see _job_escalation_message in chat_researcher/agent.py)
+        // rather than a prose sentence, so detection is robust to wording/punctuation:
+        //   {"type":"job_escalation","kind":"deep_research"|"report_edit","job_id":"<id>"}
+        const escalation = parseJobEscalation(content)
 
-        if (deepResearchMatch) {
-          const isReportEdit = /^report edit$/i.test(deepResearchMatch[1])
-          const jobId = deepResearchMatch[2]
+        if (escalation) {
+          const isReportEdit = escalation.kind === 'report_edit'
+          const jobId = escalation.jobId
           // Get current state for plan messages and conversation
           const state = useChatStore.getState()
           const currentPlanMessages = state.planMessages

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -68,7 +68,13 @@ const EMPTY_CONVERSATIONS: Conversation[] = []
  * right `NATWebSocketClient` method.
  */
 type PendingOutgoing =
-  | { kind: 'message'; content: string; dataSources: string[]; deliveryRetryCount?: number }
+  | {
+      kind: 'message'
+      content: string
+      dataSources: string[]
+      activeReportJobId?: string
+      deliveryRetryCount?: number
+    }
   | { kind: 'interaction'; interactionId: string; parentId: string; response: string; deliveryRetryCount?: number }
 
 type UnacknowledgedOutgoing = {
@@ -116,6 +122,18 @@ const WS_REFRESH_SOFT_GUARD_SECONDS = 60
  * because a single passing message proves the post-rotation auth is alive.
  */
 const MAX_CONSECUTIVE_AUTH_EXPIRED = 3
+
+export const getActiveReportJobId = (conversation: Conversation | null): string | undefined => {
+  if (!conversation) return undefined
+  const reportMessage = [...conversation.messages].reverse().find(
+    (message) =>
+      message.messageType === 'agent_response' &&
+      Boolean(message.deepResearchJobId) &&
+      !message.deepResearchReportExpired &&
+      (message.showViewReport || Boolean(message.reportContent?.trim()))
+  )
+  return reportMessage?.deepResearchJobId
+}
 
 /**
  * One silent replay is enough to cover the stale-open socket race observed in
@@ -537,13 +555,18 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
       const client = wsClientRef.current
       if (!client?.isConnected()) return false
 
-      const outboundId = payload.kind === 'message'
-        ? client.sendMessage(payload.content, payload.dataSources)
-        : client.sendInteractionResponse(
+      let outboundId: string | null
+      if (payload.kind === 'message') {
+        outboundId = payload.activeReportJobId
+          ? client.sendMessage(payload.content, payload.dataSources, payload.activeReportJobId)
+          : client.sendMessage(payload.content, payload.dataSources)
+      } else {
+        outboundId = client.sendInteractionResponse(
           payload.interactionId,
           payload.parentId,
           payload.response,
         )
+      }
 
       if (!outboundId) return false
       trackSentOutgoing(payload, outboundId)
@@ -1158,6 +1181,7 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         kind: 'message',
         content,
         dataSources: dataSourcesForMessage,
+        activeReportJobId: getActiveReportJobId(storeState.currentConversation),
       }
 
       // Helper to actually send the message

--- a/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
+++ b/frontends/ui/src/features/chat/hooks/use-websocket-chat.ts
@@ -616,22 +616,28 @@ export const useWebSocketChat = (options: UseWebSocketChatOptions = {}): UseWebS
         }
         acknowledgeOutgoingDelivery(parentId)
 
-        // Check for deep research escalation signal
-        // Backend sends: "Deep research job submitted. Job ID: {uuid}"
+        // Check for an async-job escalation signal. Two backend paths produce a
+        // pollable child job whose report is fetched over the same SSE/report
+        // endpoints, so both escalate the same way:
+        //   - "Deep research job submitted. Job ID: {uuid}"   (deep_researcher)
+        //   - "Report edit job submitted. Job ID: {uuid}"     (report_rewriter)
         const deepResearchMatch = content?.match(
-          /Deep research job submitted\. Job ID: ([a-f0-9-]+)/i
+          /(Deep research|Report edit) job submitted\. Job ID: ([a-f0-9-]+)/i
         )
 
         if (deepResearchMatch) {
-          const jobId = deepResearchMatch[1]
+          const isReportEdit = /^report edit$/i.test(deepResearchMatch[1])
+          const jobId = deepResearchMatch[2]
           // Get current state for plan messages and conversation
           const state = useChatStore.getState()
           const currentPlanMessages = state.planMessages
           const currentConversation = state.currentConversation
 
           // Derive a conversation title from the plan (preferred) or fall
-          // back to the last user message.
-          if (currentConversation) {
+          // back to the last user message. Report edits run inside an existing
+          // report conversation, so they must NOT rename it to the edit
+          // instruction -- only new deep-research runs derive a title.
+          if (currentConversation && !isReportEdit) {
             let extractedTitle: string | null = null
 
             // First, look at all plan messages for a title

--- a/frontends/ui/src/features/layout/components/InputArea.spec.tsx
+++ b/frontends/ui/src/features/layout/components/InputArea.spec.tsx
@@ -410,29 +410,22 @@ describe('InputArea', () => {
     expect(screen.getByRole('textbox')).not.toBeDisabled()
   })
 
-  test('shows research completed placeholder when deep research is done', () => {
+  test('allows follow-up input when deep research is done', async () => {
+    const user = userEvent.setup()
     mockDeepResearchStatus = 'success'
     mockIsDeepResearchStreaming = false
     mockDeepResearchOwnerConversationId = 'session-1'
 
     render(<InputArea isAuthenticated={true} connectionMode="websocket" />)
 
-    expect(
-      screen.getByPlaceholderText('Research completed. Create a new session for further questions.')
-    ).toBeInTheDocument()
-    expect(screen.getByRole('textbox')).toBeDisabled()
-  })
+    const textbox = screen.getByRole('textbox')
+    expect(textbox).not.toBeDisabled()
+    expect(screen.getByPlaceholderText('Check data sources and ask a research question...')).toBeInTheDocument()
 
-  test('shows research completed tooltip on send button when research is done', () => {
-    mockDeepResearchStatus = 'success'
-    mockIsDeepResearchStreaming = false
-    mockDeepResearchOwnerConversationId = 'session-1'
+    await user.type(textbox, 'Make the report shorter')
+    await user.click(screen.getByRole('button', { name: /send message/i }))
 
-    render(<InputArea isAuthenticated={true} connectionMode="websocket" />)
-
-    expect(
-      screen.getByRole('button', { name: /research completed - create new session/i })
-    ).toBeInTheDocument()
+    expect(mockSendMessage).toHaveBeenCalledWith('Make the report shorter')
   })
 
   test('shows research in progress send button when deep research is active and streaming', () => {

--- a/frontends/ui/src/features/layout/components/InputArea.tsx
+++ b/frontends/ui/src/features/layout/components/InputArea.tsx
@@ -71,8 +71,7 @@ export const InputArea: FC<InputAreaProps> = memo(function InputArea({
   const currentConversation = useChatStore((state) => state.currentConversation)
   const ensureSession = useChatStore((state) => state.ensureSession)
 
-  // Deep research completion state - disables new submissions after research completes
-  const deepResearchStatus = useChatStore((state) => state.deepResearchStatus)
+  // Deep research state gates concurrent jobs, but completed reports can be followed up in-session.
   const isDeepResearchStreaming = useChatStore((state) => state.isDeepResearchStreaming)
   const deepResearchOwnerConversationId = useChatStore(
     (state) => state.deepResearchOwnerConversationId
@@ -89,30 +88,6 @@ export const InputArea: FC<InputAreaProps> = memo(function InputArea({
         (m.deepResearchJobStatus === 'submitted' || m.deepResearchJobStatus === 'running')
     )
   })
-
-  // Check for completed deep research in conversation messages (persisted state)
-  // This handles the case where ephemeral state has been reset (page refresh, session switch)
-  const hasCompletedDeepResearch = useChatStore((state) => {
-    if (!state.currentConversation?.messages) return false
-    return state.currentConversation.messages.some(
-      (m) =>
-        m.messageType === 'agent_response' &&
-        m.deepResearchJobId &&
-        (m.deepResearchJobStatus === 'success' ||
-          m.deepResearchJobStatus === 'failure' ||
-          m.deepResearchJobStatus === 'interrupted')
-    )
-  })
-
-  // Research session is complete when:
-  // 1. Ephemeral state shows terminal status AND stream has finished, OR
-  // 2. Persisted message has terminal deep research job status
-  const isResearchSessionComplete =
-    (!isDeepResearchStreaming &&
-      (deepResearchStatus === 'success' ||
-        deepResearchStatus === 'failure' ||
-        deepResearchStatus === 'interrupted')) ||
-    hasCompletedDeepResearch
 
   // Research session is in progress when:
   // 1. Ephemeral state is streaming, OR
@@ -198,18 +173,16 @@ export const InputArea: FC<InputAreaProps> = memo(function InputArea({
   // Disable input when:
   // 1. Not authenticated
   // 2. Session is busy AND not in HITL response mode (user must be able to type approve/reject)
-  // 3. Deep research has completed/failed
+  // 3. Deep research is actively running
 
   const isDisabledByAuth = !isAuthenticated
-  const disabled = isDisabledByAuth || (isBusy && !isResponseMode) || isResearchSessionComplete
+  const disabled = isDisabledByAuth || ((isBusy || isResearchSessionInProgress) && !isResponseMode)
 
   // Dynamic placeholder based on state
   // Note: isResponseMode is checked before isBusy because the user needs to
   // see the response prompt even when the session is "busy" due to HITL.
   const getPlaceholder = (): string => {
     if (!isAuthenticated) return 'Sign in to start researching'
-    if (isResearchSessionComplete)
-      return 'Research completed. Create a new session for further questions.'
     if (isResponseMode) return 'Type your response to the agent...'
     if (isBusy) return 'Please wait...'
     return placeholder
@@ -478,30 +451,10 @@ export const InputArea: FC<InputAreaProps> = memo(function InputArea({
               <Paperclip className="h-4 w-4" />
             </Button>
 
-            {/* Send button - wrapped in Popover when research session is complete/in-progress.
+            {/* Send button - wrapped in Popover when research is in progress.
                 Exception: isResponseMode always shows the normal send button so users can
                 submit HITL responses (approve/reject) even during active research. */}
-            {isResearchSessionComplete && !isResponseMode ? (
-              <Popover
-                side="top"
-                align="end"
-                slotContent={
-                  <Text kind="body/regular/sm" className="max-w-xs p-3">
-                    Research completed. For further questions or reports, please create a new
-                    session.
-                  </Text>
-                }
-              >
-                <Button
-                  kind="primary"
-                  size="small"
-                  aria-label="Research completed - create new session"
-                  title="Research completed"
-                >
-                  <Paperplane className="h-4 w-4" />
-                </Button>
-              </Popover>
-            ) : isResearchSessionInProgress && !isResponseMode ? (
+            {isResearchSessionInProgress && !isResponseMode ? (
               <Popover
                 side="top"
                 align="end"

--- a/skills/aiq-research/SKILL.md
+++ b/skills/aiq-research/SKILL.md
@@ -165,39 +165,36 @@ When `research_poll` completes successfully, fetch and present the full report. 
 If the job status is `failed`, `failure`, or `cancelled`, show the error from the status response and ask whether the
 user wants to retry with a narrower query or different approach.
 
-### Step 6 - Follow up: ask about or redo a report
+### Step 6 - Follow up: ask about, edit, or extend a report
 
-After a report is presented, the user often wants to go deeper or adjust scope.
-Reuse the existing backend flow — the same auth boundary, polling, and report
-retrieval from Steps 1-5 apply; there is no separate follow-up endpoint.
+After a report is presented, the user often wants to ask about it, revise it, or
+go deeper. The backend routes follow-up automatically from the chat message plus
+the **conversation** it belongs to — there is no separate follow-up endpoint and
+**you do not pass a report id**. The only requirement is that the follow-up turns
+share the **same conversation** as the original report.
 
-**Ask** — a follow-up question about a report already in hand:
-
-- For a question answerable from the report you already have, answer directly
-  from its content and citations; do not call the backend again.
-- For a question that needs new investigation, send a fresh request that carries
-  the needed context from the prior question and report into the new query
-  text, then present the new result:
-
-  ```bash
-  python3 $SKILL_DIR/scripts/aiq.py chat "<FOLLOW_UP_QUESTION> (context: <PRIOR_TOPIC>)"
-  ```
-
-  If this returns a `deep_research_running` job ID, poll it with `research_poll`
-  exactly as in Step 3.
-
-**Redo** — re-run research with adjusted scope (a narrower query, a corrected
-question, or a different depth):
+**Pin one conversation id for the whole sequence.** Each `aiq.py` call is a
+separate process, so export a stable conversation id once and reuse it for the
+original research and every follow-up. The helper sends it as the `conversation-id`
+header; the backend then defaults to "the last completed report in this
+conversation" when routing the follow-up:
 
 ```bash
-python3 $SKILL_DIR/scripts/aiq.py research "<REFINED_QUERY>" [agent_type]
+export AIQ_CONVERSATION_ID=$(python3 -c "import uuid;print(uuid.uuid4())")
+
+python3 $SKILL_DIR/scripts/aiq.py research "<TOPIC>"     # original report (poll to completion)
+python3 $SKILL_DIR/scripts/aiq.py chat "what are the key risks in this report?"   # ask
+python3 $SKILL_DIR/scripts/aiq.py chat "rewrite it to be shorter"                 # edit (returns a job id)
+python3 $SKILL_DIR/scripts/aiq.py chat "find the latest 2025 updates building on this"  # delta research
 ```
 
-- Choose `agent_type` to match the desired depth (for example a deep agent for a
-  thorough pass, or `shallow_researcher` for a quick one); list options with
-  `agents` if unsure.
-- Treat a redo as a new job: state the target endpoint again before sending
-  (Step 2), then poll and present as in Steps 3-5.
+- **Ask** is answered inline from the prior report; **edit** and **delta**
+  return a `Job ID` — poll it with `research_poll` exactly as in Step 3.
+- Send the natural follow-up question; **do not** hand-inline the prior report
+  text into the query — the backend supplies that context from the conversation.
+- If you do NOT reuse a conversation id (no `AIQ_CONVERSATION_ID`), each call is a
+  brand-new conversation and the backend has no prior report to follow up on, so
+  it runs fresh research instead.
 
 Do not send credentials or secret values in follow-up query text, and keep
 citations and source URLs intact in every follow-up answer.

--- a/skills/aiq-research/SKILL.md
+++ b/skills/aiq-research/SKILL.md
@@ -165,36 +165,39 @@ When `research_poll` completes successfully, fetch and present the full report. 
 If the job status is `failed`, `failure`, or `cancelled`, show the error from the status response and ask whether the
 user wants to retry with a narrower query or different approach.
 
-### Step 6 - Follow up: ask about, edit, or extend a report
+### Step 6 - Follow up: ask about or redo a report
 
-After a report is presented, the user often wants to ask about it, revise it, or
-go deeper. The backend routes follow-up automatically from the chat message plus
-the **conversation** it belongs to — there is no separate follow-up endpoint and
-**you do not pass a report id**. The only requirement is that the follow-up turns
-share the **same conversation** as the original report.
+After a report is presented, the user often wants to go deeper or adjust scope.
+Reuse the existing backend flow — the same auth boundary, polling, and report
+retrieval from Steps 1-5 apply; there is no separate follow-up endpoint.
 
-**Pin one conversation id for the whole sequence.** Each `aiq.py` call is a
-separate process, so export a stable conversation id once and reuse it for the
-original research and every follow-up. The helper sends it as the `conversation-id`
-header; the backend then defaults to "the last completed report in this
-conversation" when routing the follow-up:
+**Ask** — a follow-up question about a report already in hand:
+
+- For a question answerable from the report you already have, answer directly
+  from its content and citations; do not call the backend again.
+- For a question that needs new investigation, send a fresh request that carries
+  the needed context from the prior question and report into the new query
+  text, then present the new result:
+
+  ```bash
+  python3 $SKILL_DIR/scripts/aiq.py chat "<FOLLOW_UP_QUESTION> (context: <PRIOR_TOPIC>)"
+  ```
+
+  If this returns a `deep_research_running` job ID, poll it with `research_poll`
+  exactly as in Step 3.
+
+**Redo** — re-run research with adjusted scope (a narrower query, a corrected
+question, or a different depth):
 
 ```bash
-export AIQ_CONVERSATION_ID=$(python3 -c "import uuid;print(uuid.uuid4())")
-
-python3 $SKILL_DIR/scripts/aiq.py research "<TOPIC>"     # original report (poll to completion)
-python3 $SKILL_DIR/scripts/aiq.py chat "what are the key risks in this report?"   # ask
-python3 $SKILL_DIR/scripts/aiq.py chat "rewrite it to be shorter"                 # edit (returns a job id)
-python3 $SKILL_DIR/scripts/aiq.py chat "find the latest 2025 updates building on this"  # delta research
+python3 $SKILL_DIR/scripts/aiq.py research "<REFINED_QUERY>" [agent_type]
 ```
 
-- **Ask** is answered inline from the prior report; **edit** and **delta**
-  return a `Job ID` — poll it with `research_poll` exactly as in Step 3.
-- Send the natural follow-up question; **do not** hand-inline the prior report
-  text into the query — the backend supplies that context from the conversation.
-- If you do NOT reuse a conversation id (no `AIQ_CONVERSATION_ID`), each call is a
-  brand-new conversation and the backend has no prior report to follow up on, so
-  it runs fresh research instead.
+- Choose `agent_type` to match the desired depth (for example a deep agent for a
+  thorough pass, or `shallow_researcher` for a quick one); list options with
+  `agents` if unsure.
+- Treat a redo as a new job: state the target endpoint again before sending
+  (Step 2), then poll and present as in Steps 3-5.
 
 Do not send credentials or secret values in follow-up query text, and keep
 citations and source URLs intact in every follow-up answer.

--- a/skills/aiq-research/scripts/aiq.py
+++ b/skills/aiq-research/scripts/aiq.py
@@ -29,6 +29,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from collections.abc import Iterator
 from typing import Any
 
@@ -53,6 +54,12 @@ DEFAULT_SERVER_URL = "http://localhost:8000"
 AIQ_SERVER_URL = os.environ.get("AIQ_SERVER_URL", DEFAULT_SERVER_URL)
 
 _HEADLESS_HEADERS = {"Content-Type": "application/json", "X-AIQ-Mode": "headless"}
+
+# Stable conversation id so the backend can default report follow-up to "the last report in this
+# conversation" without the client managing active_report_job_id. Each `python3 aiq.py ...` call is
+# a separate process, so a per-process UUID only links turns within one invocation; export
+# AIQ_CONVERSATION_ID once to link a multi-command follow-up sequence (see SKILL.md Step 6).
+_SESSION_CONVERSATION_ID = os.environ.get("AIQ_CONVERSATION_ID") or str(uuid.uuid4())
 DEFAULT_AGENT_TYPE = "shallow_researcher"
 _LOCAL_BACKEND_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "host.docker.internal"})
 
@@ -152,7 +159,8 @@ def _api_request(
     url = f"{_validate_base_url(AIQ_SERVER_URL)}{path}"
     data = None if body is None else json.dumps(body).encode("utf-8")
     if method == "POST":
-        request_payload = {"url": url, "headers": dict(_HEADLESS_HEADERS), "method": method, "data": data}
+        headers = {**_HEADLESS_HEADERS, "conversation-id": _SESSION_CONVERSATION_ID}
+        request_payload = {"url": url, "headers": headers, "method": method, "data": data}
     else:
         request_payload = {"url": url, "method": method}
     req = urllib.request.Request(**request_payload)

--- a/skills/aiq-research/scripts/aiq.py
+++ b/skills/aiq-research/scripts/aiq.py
@@ -29,7 +29,6 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-import uuid
 from collections.abc import Iterator
 from typing import Any
 
@@ -54,12 +53,6 @@ DEFAULT_SERVER_URL = "http://localhost:8000"
 AIQ_SERVER_URL = os.environ.get("AIQ_SERVER_URL", DEFAULT_SERVER_URL)
 
 _HEADLESS_HEADERS = {"Content-Type": "application/json", "X-AIQ-Mode": "headless"}
-
-# Stable conversation id so the backend can default report follow-up to "the last report in this
-# conversation" without the client managing active_report_job_id. Each `python3 aiq.py ...` call is
-# a separate process, so a per-process UUID only links turns within one invocation; export
-# AIQ_CONVERSATION_ID once to link a multi-command follow-up sequence (see SKILL.md Step 6).
-_SESSION_CONVERSATION_ID = os.environ.get("AIQ_CONVERSATION_ID") or str(uuid.uuid4())
 DEFAULT_AGENT_TYPE = "shallow_researcher"
 _LOCAL_BACKEND_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "host.docker.internal"})
 
@@ -159,8 +152,7 @@ def _api_request(
     url = f"{_validate_base_url(AIQ_SERVER_URL)}{path}"
     data = None if body is None else json.dumps(body).encode("utf-8")
     if method == "POST":
-        headers = {**_HEADLESS_HEADERS, "conversation-id": _SESSION_CONVERSATION_ID}
-        request_payload = {"url": url, "headers": headers, "method": method, "data": data}
+        request_payload = {"url": url, "headers": dict(_HEADLESS_HEADERS), "method": method, "data": data}
     else:
         request_payload = {"url": url, "method": method}
     req = urllib.request.Request(**request_payload)

--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -88,6 +88,8 @@ class ChatResearcherAgent:
         callbacks: list[BaseCallbackHandler] | None = None,
         max_history: int = 5,
         deep_research_job_submitter: Callable[[Any], Awaitable[str]] | None = None,
+        report_ask_fn: Callable[[ChatResearcherState], Awaitable[str]] | None = None,
+        report_edit_job_submitter: Callable[[ChatResearcherState], Awaitable[str]] | None = None,
         checkpointer: BaseCheckpointSaver | None = None,
         validate_deep_research_tools_fn: Callable[[list[str] | None], tuple[bool, str]] | None = None,
     ) -> None:
@@ -104,6 +106,8 @@ class ChatResearcherAgent:
             callbacks: Optional list of callback handlers
             max_history: Maximum number of messages to keep in history
             deep_research_job_submitter: Optional function to submit deep research as async job
+            report_ask_fn: Optional function to answer questions against the active parent report
+            report_edit_job_submitter: Optional function to submit report edit child jobs
             checkpointer: Optional checkpointer for persistent state (defaults to MemorySaver)
         """
         self.intent_classifier_fn = intent_classifier_fn
@@ -115,6 +119,8 @@ class ChatResearcherAgent:
         self.callbacks = callbacks or []
         self.max_history = max_history
         self.deep_research_job_submitter = deep_research_job_submitter
+        self.report_ask_fn = report_ask_fn
+        self.report_edit_job_submitter = report_edit_job_submitter
         self.checkpointer = checkpointer
         self.validate_deep_research_tools_fn = validate_deep_research_tools_fn
 
@@ -323,10 +329,26 @@ class ChatResearcherAgent:
             else:
                 return {"messages": [result.messages[-1]]}
 
+        async def report_ask_node(state: ChatResearcherState) -> dict[str, Any]:
+            if self.report_ask_fn is None:
+                return {"messages": [AIMessage(content="Report follow-up is not available in this workflow.")]}
+            answer = await self.report_ask_fn(state)
+            return {"messages": [AIMessage(content=answer)]}
+
+        async def report_edit_node(state: ChatResearcherState) -> dict[str, Any]:
+            if self.report_edit_job_submitter is None:
+                return {"messages": [AIMessage(content="Report edit is not available in this workflow.")]}
+            job_id = await self.report_edit_job_submitter(state)
+            return {"messages": [AIMessage(content=f"Report edit job submitted. Job ID: {job_id}")]}
+
         def route_after_orchestration(state: ChatResearcherState) -> str:
             """From combined orchestration: meta -> END (response already in messages), else by depth."""
             if state.user_intent and state.user_intent.intent == "meta":
                 return "END"
+            if state.active_report_job_id and state.user_intent and state.user_intent.target == "report":
+                if state.user_intent.report_action == "edit":
+                    return "report_edit"
+                return "report_ask"
             if state.depth_decision and state.depth_decision.decision == "deep":
                 return "clarifier"
             return "shallow_research"
@@ -372,6 +394,8 @@ class ChatResearcherAgent:
         graph.add_node("shallow_research", shallow_research_node)
         graph.add_node("clarifier", clarifier_node)
         graph.add_node("deep_research", deep_research_node)
+        graph.add_node("report_ask", report_ask_node)
+        graph.add_node("report_edit", report_edit_node)
 
         graph.set_entry_point("intent_classifier")
 
@@ -382,6 +406,8 @@ class ChatResearcherAgent:
                 "END": END,
                 "clarifier": "clarifier",
                 "shallow_research": "shallow_research",
+                "report_ask": "report_ask",
+                "report_edit": "report_edit",
             },
         )
 
@@ -395,6 +421,8 @@ class ChatResearcherAgent:
         )
 
         graph.add_edge("deep_research", END)
+        graph.add_edge("report_ask", END)
+        graph.add_edge("report_edit", END)
 
         return graph.compile(checkpointer=self.checkpointer)
 

--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -424,6 +424,7 @@ class ChatResearcherAgent:
                 "available_documents": state.available_documents,
                 "shallow_result": None,  # reset at turn boundary to avoid stale checkpoint state
                 "skip_clarifier": state.skip_clarifier,
+                "active_report_job_id": state.active_report_job_id,
             }
             messages = state.messages
 

--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -337,7 +337,11 @@ class ChatResearcherAgent:
             except Exception as e:
                 # The node has no HTTP scope, so a raised exception would surface as an
                 # opaque workflow error / empty completion. Degrade to a chat message.
-                logger.warning("Report ask failed for report %s: %s", state.active_report_job_id, e)
+                logger.warning(
+                    "Report ask failed for report %s (error_type=%s)",
+                    state.active_report_job_id,
+                    type(e).__name__,
+                )
                 return {
                     "messages": [
                         AIMessage(content="I couldn't access that report to answer your question. Please try again.")
@@ -351,7 +355,11 @@ class ChatResearcherAgent:
             try:
                 job_id = await self.report_edit_job_submitter(state)
             except Exception as e:
-                logger.warning("Report edit submission failed for report %s: %s", state.active_report_job_id, e)
+                logger.warning(
+                    "Report edit submission failed for report %s (error_type=%s)",
+                    state.active_report_job_id,
+                    type(e).__name__,
+                )
                 return {"messages": [AIMessage(content="I couldn't start the report edit. Please try again.")]}
             return {"messages": [AIMessage(content=f"Report edit job submitted. Job ID: {job_id}")]}
 

--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -325,13 +325,6 @@ class ChatResearcherAgent:
                         type(e).__name__,
                     )
                     seed_files = {}
-                if seed_files:
-                    research_query = (
-                        f"{research_query}\n\n"
-                        "Use the seeded parent report context in /shared/original_report.md and "
-                        "/shared/source_summary.md. Reuse the parent report where sufficient and perform "
-                        "new research only for the requested delta."
-                    )
             logger.info(
                 "Inline deep research: use_parent_report_context=%s has_report=%s seeded_files=%d",
                 bool(getattr(state.user_intent, "use_parent_report_context", False)) if state.user_intent else False,

--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -327,7 +327,14 @@ class ChatResearcherAgent:
                 final_message = AIMessage(content=error_message)
                 return {"messages": [final_message]}
             else:
-                return {"messages": [result.messages[-1]]}
+                report_message = result.messages[-1]
+                report_md = report_message.content
+                # Capture the inline report so follow-up turns in this (synchronous) session can
+                # reference it without an async job. Checkpointed via the keep-if-set reducer.
+                return {
+                    "messages": [report_message],
+                    "last_report_markdown": report_md if isinstance(report_md, str) else str(report_md),
+                }
 
         async def report_ask_node(state: ChatResearcherState) -> dict[str, Any]:
             if self.report_ask_fn is None:
@@ -367,7 +374,10 @@ class ChatResearcherAgent:
             """From combined orchestration: meta -> END (response already in messages), else by depth."""
             if state.user_intent and state.user_intent.intent == "meta":
                 return "END"
-            if state.active_report_job_id and state.user_intent and state.user_intent.target == "report":
+            # A report is available either as an async job (UI/server) or produced inline in this
+            # session (synchronous CLI). Either lets the router serve report follow-up.
+            has_report = bool(state.active_report_job_id or state.last_report_markdown)
+            if has_report and state.user_intent and state.user_intent.target == "report":
                 if state.user_intent.report_action == "edit":
                     return "report_edit"
                 return "report_ask"
@@ -475,6 +485,9 @@ class ChatResearcherAgent:
                 "shallow_result": None,  # reset at turn boundary to avoid stale checkpoint state
                 "skip_clarifier": state.skip_clarifier,
                 "active_report_job_id": state.active_report_job_id,
+                # Pass through; the keep-if-set reducer preserves a prior in-session report when
+                # this turn supplies None, so report follow-up works across turns without a job.
+                "last_report_markdown": state.last_report_markdown,
             }
             messages = state.messages
 

--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -332,13 +332,27 @@ class ChatResearcherAgent:
         async def report_ask_node(state: ChatResearcherState) -> dict[str, Any]:
             if self.report_ask_fn is None:
                 return {"messages": [AIMessage(content="Report follow-up is not available in this workflow.")]}
-            answer = await self.report_ask_fn(state)
+            try:
+                answer = await self.report_ask_fn(state)
+            except Exception as e:
+                # The node has no HTTP scope, so a raised exception would surface as an
+                # opaque workflow error / empty completion. Degrade to a chat message.
+                logger.warning("Report ask failed for report %s: %s", state.active_report_job_id, e)
+                return {
+                    "messages": [
+                        AIMessage(content="I couldn't access that report to answer your question. Please try again.")
+                    ]
+                }
             return {"messages": [AIMessage(content=answer)]}
 
         async def report_edit_node(state: ChatResearcherState) -> dict[str, Any]:
             if self.report_edit_job_submitter is None:
                 return {"messages": [AIMessage(content="Report edit is not available in this workflow.")]}
-            job_id = await self.report_edit_job_submitter(state)
+            try:
+                job_id = await self.report_edit_job_submitter(state)
+            except Exception as e:
+                logger.warning("Report edit submission failed for report %s: %s", state.active_report_job_id, e)
+                return {"messages": [AIMessage(content="I couldn't start the report edit. Please try again.")]}
             return {"messages": [AIMessage(content=f"Report edit job submitted. Job ID: {job_id}")]}
 
         def route_after_orchestration(state: ChatResearcherState) -> str:

--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -104,6 +104,8 @@ class ChatResearcherAgent:
         deep_research_job_submitter: Callable[[Any], Awaitable[str]] | None = None,
         report_ask_fn: Callable[[ChatResearcherState], Awaitable[str]] | None = None,
         report_edit_job_submitter: Callable[[ChatResearcherState], Awaitable[str]] | None = None,
+        report_edit_fn: Callable[[ChatResearcherState], Awaitable[str]] | None = None,
+        report_seed_files_fn: Callable[[ChatResearcherState], Awaitable[dict[str, Any] | None]] | None = None,
         checkpointer: BaseCheckpointSaver | None = None,
         validate_deep_research_tools_fn: Callable[[list[str] | None], tuple[bool, str]] | None = None,
     ) -> None:
@@ -135,6 +137,8 @@ class ChatResearcherAgent:
         self.deep_research_job_submitter = deep_research_job_submitter
         self.report_ask_fn = report_ask_fn
         self.report_edit_job_submitter = report_edit_job_submitter
+        self.report_edit_fn = report_edit_fn
+        self.report_seed_files_fn = report_seed_files_fn
         self.checkpointer = checkpointer
         self.validate_deep_research_tools_fn = validate_deep_research_tools_fn
 
@@ -304,12 +308,38 @@ class ChatResearcherAgent:
                 return {"messages": [AIMessage(content=escalation)]}
 
             research_query = state.original_query or get_latest_user_query(state.messages)
+            seed_files: dict[str, Any] = {}
+            if (
+                self.report_seed_files_fn is not None
+                and state.user_intent is not None
+                and getattr(state.user_intent, "use_parent_report_context", False)
+                and (state.active_report_job_id or state.last_report_markdown)
+            ):
+                # Delta research: seed the parent report into the deep agent's virtual filesystem so it
+                # reuses it and researches only the requested delta. Best-effort -- a seed failure falls
+                # back to fresh research rather than aborting the turn.
+                try:
+                    seed_files = await self.report_seed_files_fn(state) or {}
+                except Exception as e:
+                    logger.warning(
+                        "Parent report seed unavailable for delta (error_type=%s); running fresh research",
+                        type(e).__name__,
+                    )
+                    seed_files = {}
+                if seed_files:
+                    research_query = (
+                        f"{research_query}\n\n"
+                        "Use the seeded parent report context in /shared/original_report.md and "
+                        "/shared/source_summary.md. Reuse the parent report where sufficient and perform "
+                        "new research only for the requested delta."
+                    )
             deep_state = DeepResearchAgentState(
                 messages=trimmed_messages + [HumanMessage(content=research_query)],
                 data_sources=state.data_sources,
                 clarifier_result=state.clarifier_result,
                 available_documents=state.available_documents,
                 user_info=state.user_info,
+                files=seed_files,
             )
             try:
                 result = await self.deep_research_fn(deep_state)
@@ -371,19 +401,30 @@ class ChatResearcherAgent:
             return {"messages": [AIMessage(content=answer)]}
 
         async def report_edit_node(state: ChatResearcherState) -> dict[str, Any]:
-            if self.report_edit_job_submitter is None:
-                return {"messages": [AIMessage(content="Report edit is not available in this workflow.")]}
-            try:
-                job_id = await self.report_edit_job_submitter(state)
-            except Exception as e:
-                logger.warning(
-                    "Report edit submission failed for report %s (error_type=%s)",
-                    state.active_report_job_id,
-                    type(e).__name__,
-                )
-                return {"messages": [AIMessage(content="I couldn't start the report edit. Please try again.")]}
-            escalation = _job_escalation_message(_ESCALATION_KIND_REPORT_EDIT, job_id)
-            return {"messages": [AIMessage(content=escalation)]}
+            # Async path (server): submit a report_rewriter child job; the UI streams its result.
+            if self.report_edit_job_submitter is not None:
+                try:
+                    job_id = await self.report_edit_job_submitter(state)
+                except Exception as e:
+                    logger.warning(
+                        "Report edit submission failed for report %s (error_type=%s)",
+                        state.active_report_job_id,
+                        type(e).__name__,
+                    )
+                    return {"messages": [AIMessage(content="I couldn't start the report edit. Please try again.")]}
+                escalation = _job_escalation_message(_ESCALATION_KIND_REPORT_EDIT, job_id)
+                return {"messages": [AIMessage(content=escalation)]}
+            # Inline path (synchronous CLI): rewrite the in-session report directly -- no job or
+            # scheduler. The revised report becomes the reply and replaces last_report_markdown so
+            # subsequent follow-ups operate on the edited copy.
+            if self.report_edit_fn is not None:
+                try:
+                    revised = await self.report_edit_fn(state)
+                except Exception as e:
+                    logger.warning("Inline report edit failed (error_type=%s)", type(e).__name__)
+                    return {"messages": [AIMessage(content="I couldn't edit the report. Please try again.")]}
+                return {"messages": [AIMessage(content=revised)], "last_report_markdown": revised}
+            return {"messages": [AIMessage(content="Report edit is not available in this workflow.")]}
 
         def route_after_orchestration(state: ChatResearcherState) -> str:
             """From combined orchestration: meta -> END (response already in messages), else by depth."""

--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -301,7 +301,6 @@ class ChatResearcherAgent:
             return {"messages": [], "shallow_result": None}
 
         async def deep_research_node(state: ChatResearcherState) -> dict[str, Any]:
-            trimmed_messages: list[BaseMessage] = trim_message_history(state.messages, self.max_history)
             if self.deep_research_job_submitter is not None:
                 job_id = await self.deep_research_job_submitter(state)
                 escalation = _job_escalation_message(_ESCALATION_KIND_DEEP_RESEARCH, job_id)
@@ -333,8 +332,17 @@ class ChatResearcherAgent:
                         "/shared/source_summary.md. Reuse the parent report where sufficient and perform "
                         "new research only for the requested delta."
                     )
+            logger.info(
+                "Inline deep research: use_parent_report_context=%s has_report=%s seeded_files=%d",
+                bool(getattr(state.user_intent, "use_parent_report_context", False)) if state.user_intent else False,
+                bool(state.active_report_job_id or state.last_report_markdown),
+                len(seed_files),
+            )
+            # Mirror the async job: feed the deep researcher a clean query (plus the approved plan and any
+            # seeded parent-report files), NOT the prior chat history. Forwarding accumulated report
+            # messages bloats the writer's context and can make it fail to emit a final report.
             deep_state = DeepResearchAgentState(
-                messages=trimmed_messages + [HumanMessage(content=research_query)],
+                messages=[HumanMessage(content=research_query)],
                 data_sources=state.data_sources,
                 clarifier_result=state.clarifier_result,
                 available_documents=state.available_documents,
@@ -364,7 +372,14 @@ class ChatResearcherAgent:
                 if _AuthError and isinstance(e, _AuthError):
                     logger.warning("Auth error in deep research: %s", e)
                     return {"messages": [AIMessage(content=str(e))]}
-                raise
+                # Inline (synchronous CLI) path: a raised exception would crash the whole CLI turn.
+                # Degrade to a chat message instead (the error is logged for debugging).
+                logger.error("Inline deep research failed (error_type=%s)", type(e).__name__, exc_info=True)
+                return {
+                    "messages": [
+                        AIMessage(content="I ran into an error while producing that report. Please try again.")
+                    ]
+                }
             if not result.messages:
                 error_message = "An error occurred during deep research."
                 logger.error(error_message)

--- a/src/aiq_agent/agents/chat_researcher/agent.py
+++ b/src/aiq_agent/agents/chat_researcher/agent.py
@@ -23,6 +23,7 @@ This is the main orchestrator agent that coordinates the full research workflow:
 4. Optional escalation from shallow to deep
 """
 
+import json
 import logging
 from collections.abc import Awaitable
 from collections.abc import Callable
@@ -56,6 +57,19 @@ from .models import ShallowResult
 from .utils import trim_message_history
 
 logger = logging.getLogger(__name__)
+
+
+# Async-job escalation signal. The chat WebSocket frame carries only a string ``content`` field,
+# so the signal the UI consumes to start SSE streaming for a child job is encoded as a compact
+# JSON object rather than a prose sentence -- this keeps detection robust to wording/punctuation
+# changes. Mirrored by the UI parser in frontends/ui/src/features/chat/hooks/use-websocket-chat.ts.
+_ESCALATION_KIND_DEEP_RESEARCH = "deep_research"
+_ESCALATION_KIND_REPORT_EDIT = "report_edit"
+
+
+def _job_escalation_message(kind: str, job_id: str) -> str:
+    """Serialize an async-job escalation signal as a structured JSON payload."""
+    return json.dumps({"type": "job_escalation", "kind": kind, "job_id": job_id})
 
 
 class ChatResearcherAgent:
@@ -286,8 +300,8 @@ class ChatResearcherAgent:
             trimmed_messages: list[BaseMessage] = trim_message_history(state.messages, self.max_history)
             if self.deep_research_job_submitter is not None:
                 job_id = await self.deep_research_job_submitter(state)
-                response = f"Deep research job submitted. Job ID: {job_id}"
-                return {"messages": [AIMessage(content=response)]}
+                escalation = _job_escalation_message(_ESCALATION_KIND_DEEP_RESEARCH, job_id)
+                return {"messages": [AIMessage(content=escalation)]}
 
             research_query = state.original_query or get_latest_user_query(state.messages)
             deep_state = DeepResearchAgentState(
@@ -368,7 +382,8 @@ class ChatResearcherAgent:
                     type(e).__name__,
                 )
                 return {"messages": [AIMessage(content="I couldn't start the report edit. Please try again.")]}
-            return {"messages": [AIMessage(content=f"Report edit job submitted. Job ID: {job_id}")]}
+            escalation = _job_escalation_message(_ESCALATION_KIND_REPORT_EDIT, job_id)
+            return {"messages": [AIMessage(content=escalation)]}
 
         def route_after_orchestration(state: ChatResearcherState) -> str:
             """From combined orchestration: meta -> END (response already in messages), else by depth."""

--- a/src/aiq_agent/agents/chat_researcher/models/intent.py
+++ b/src/aiq_agent/agents/chat_researcher/models/intent.py
@@ -20,6 +20,9 @@ from typing import Literal
 
 from pydantic import BaseModel
 
+RouteTarget = Literal["meta", "report", "new_research"]
+ReportAction = Literal["ask", "edit"]
+
 
 class IntentResult(BaseModel):
     """
@@ -32,4 +35,7 @@ class IntentResult(BaseModel):
     """
 
     intent: Literal["meta", "research"]
+    target: RouteTarget = "new_research"
+    report_action: ReportAction | None = None
+    use_parent_report_context: bool = False
     raw: dict[str, Any] | None = None

--- a/src/aiq_agent/agents/chat_researcher/models/intent.py
+++ b/src/aiq_agent/agents/chat_researcher/models/intent.py
@@ -31,6 +31,9 @@ class IntentResult(BaseModel):
     Attributes:
         intent: Classified intent - either 'meta' (greetings, chit-chat, capabilities)
                 or 'research' (queries requiring data lookup and sources).
+        target: Python-derived workflow target for the selected semantic route.
+        report_action: Python-derived report interaction action, when target is ``report``.
+        use_parent_report_context: Whether a deep-research route should seed the active report.
         raw: Optional raw classification response from the LLM.
     """
 

--- a/src/aiq_agent/agents/chat_researcher/models/state.py
+++ b/src/aiq_agent/agents/chat_researcher/models/state.py
@@ -29,6 +29,16 @@ from .intent import IntentResult
 from .result import ShallowResult
 
 
+def _keep_if_set(old: str | None, new: str | None) -> str | None:
+    """Reducer that keeps the prior value unless a new non-empty one is provided.
+
+    ``register.py`` builds a fresh state each turn, so a plain field would be clobbered to
+    None and never persist across turns. This lets ``last_report_markdown`` carry the
+    in-session report forward (and be overwritten when a newer report is produced).
+    """
+    return new if new else old
+
+
 class ChatResearcherState(BaseModel):
     """
     State for the main chat researcher workflow graph.
@@ -62,3 +72,6 @@ class ChatResearcherState(BaseModel):
     available_documents: list[AvailableDocument] | None = None
     skip_clarifier: bool = False
     active_report_job_id: str | None = None
+    # The most recent report produced inline in this session (synchronous CLI mode), carried
+    # across turns by the keep-if-set reducer so report follow-up works without an async job.
+    last_report_markdown: Annotated[str | None, _keep_if_set] = None

--- a/src/aiq_agent/agents/chat_researcher/models/state.py
+++ b/src/aiq_agent/agents/chat_researcher/models/state.py
@@ -61,3 +61,4 @@ class ChatResearcherState(BaseModel):
     original_query: str | None = None
     available_documents: list[AvailableDocument] | None = None
     skip_clarifier: bool = False
+    active_report_job_id: str | None = None

--- a/src/aiq_agent/agents/chat_researcher/nodes/intent_classifier.py
+++ b/src/aiq_agent/agents/chat_researcher/nodes/intent_classifier.py
@@ -140,7 +140,7 @@ class IntentClassifier:
             current_datetime=current_datetime,
             user_info=user_info,
             tools=self.tools_info,
-            active_report_job_id=state.active_report_job_id,
+            active_report_available=bool(state.active_report_job_id or state.last_report_markdown),
         )
         trimmed_conversation = trim_message_history(list(state.messages), max_tokens=self.max_history)
         messages: list[BaseMessage] = [SystemMessage(content=system_content)] + trimmed_conversation
@@ -166,7 +166,7 @@ class IntentClassifier:
             meta_response = parsed.get("meta_response")
             research_depth = (parsed.get("research_depth") or "shallow").strip().lower()
             depth_reasoning = parsed.get("depth_reasoning") or ""
-            active_report = bool(state.active_report_job_id)
+            active_report = bool(state.active_report_job_id or state.last_report_markdown)
             target = _normalize_target(parsed.get("target"))
             report_action = _normalize_report_action(parsed.get("report_action"))
             use_parent_report_context = _normalize_bool(parsed.get("use_parent_report_context")) and active_report

--- a/src/aiq_agent/agents/chat_researcher/nodes/intent_classifier.py
+++ b/src/aiq_agent/agents/chat_researcher/nodes/intent_classifier.py
@@ -169,7 +169,7 @@ class IntentClassifier:
             active_report = bool(state.active_report_job_id)
             target = _normalize_target(parsed.get("target"))
             report_action = _normalize_report_action(parsed.get("report_action"))
-            use_parent_report_context = bool(parsed.get("use_parent_report_context")) and active_report
+            use_parent_report_context = _normalize_bool(parsed.get("use_parent_report_context")) and active_report
 
             if intent == "meta":
                 target = "meta"
@@ -263,3 +263,18 @@ def _normalize_target(raw_target: Any) -> str:
 def _normalize_report_action(raw_action: Any) -> str | None:
     action = raw_action.strip().lower() if isinstance(raw_action, str) else None
     return action if action in ("ask", "edit") else None
+
+
+def _normalize_bool(raw_value: Any) -> bool:
+    """Coerce LLM JSON values to bool, treating string booleans correctly.
+
+    json.loads usually yields real booleans, but models occasionally emit string
+    booleans (e.g. "false"); plain bool("false") would be True, so handle them.
+    """
+    if isinstance(raw_value, bool):
+        return raw_value
+    if isinstance(raw_value, str):
+        return raw_value.strip().lower() in {"true", "1", "yes"}
+    if isinstance(raw_value, (int, float)):
+        return raw_value != 0
+    return False

--- a/src/aiq_agent/agents/chat_researcher/nodes/intent_classifier.py
+++ b/src/aiq_agent/agents/chat_researcher/nodes/intent_classifier.py
@@ -44,6 +44,17 @@ _LLM_UNAVAILABLE_MESSAGE = (
     "Please check your LLM API key and that the configured model is available for your account."
 )
 _LLM_TIMEOUT_MESSAGE = "The model service took too long to respond and the request timed out. "
+_REPORT_TARGET_HINTS = (
+    "this report",
+    "the report",
+    "based on this",
+    "what did we conclude",
+    "summarize this",
+    "rewrite",
+    "redo",
+    "remove",
+    "make this",
+)
 
 
 def _is_llm_api_unavailable(err: BaseException) -> bool:
@@ -62,6 +73,11 @@ def _is_timeout_error(err: BaseException) -> bool:
         return True
     msg = str(err).strip().lower()
     return "504" in msg or "gateway time-out" in msg or "gateway timeout" in msg
+
+
+def _looks_report_targeted(query: str) -> bool:
+    query_lower = query.lower()
+    return any(hint in query_lower for hint in _REPORT_TARGET_HINTS)
 
 
 class IntentClassifier:
@@ -112,6 +128,7 @@ class IntentClassifier:
             current_datetime=current_datetime,
             user_info=user_info,
             tools=self.tools_info,
+            active_report_job_id=state.active_report_job_id,
         )
         trimmed_conversation = trim_message_history(list(state.messages), max_tokens=self.max_history)
         messages: list[BaseMessage] = [SystemMessage(content=system_content)] + trimmed_conversation
@@ -137,9 +154,37 @@ class IntentClassifier:
             meta_response = parsed.get("meta_response")
             research_depth = (parsed.get("research_depth") or "shallow").strip().lower()
             depth_reasoning = parsed.get("depth_reasoning") or ""
+            active_report = bool(state.active_report_job_id)
+            target = _normalize_target(parsed.get("target"), intent)
+            report_action = _normalize_report_action(parsed.get("report_action"))
+            use_parent_report_context = bool(parsed.get("use_parent_report_context")) and active_report
+
+            if intent == "meta":
+                target = "meta"
+                report_action = None
+                use_parent_report_context = False
+            elif target == "report":
+                use_parent_report_context = False
+                if not active_report:
+                    target = "new_research"
+                    report_action = None
+                elif report_action is None:
+                    if _looks_report_targeted(query):
+                        report_action = "ask"
+                    else:
+                        target = "new_research"
+            else:
+                target = "new_research"
+                report_action = None
 
             update: dict[str, Any] = {
-                "user_intent": IntentResult(intent=intent, raw=parsed),
+                "user_intent": IntentResult(
+                    intent=intent,
+                    target=target,
+                    report_action=report_action,
+                    use_parent_report_context=use_parent_report_context,
+                    raw=parsed,
+                ),
             }
 
             if intent == "meta":
@@ -147,7 +192,7 @@ class IntentClassifier:
                     meta_response if isinstance(meta_response, str) and meta_response.strip() else "I'm here to help."
                 )
                 update["messages"] = [AIMessage(content=meta_text)]
-            else:
+            elif target != "report":
                 update["depth_decision"] = DepthDecision(
                     decision=research_depth if research_depth in ("shallow", "deep") else "shallow",
                     raw_reasoning=str(depth_reasoning),
@@ -186,3 +231,15 @@ class IntentClassifier:
                 "user_intent": IntentResult(intent="meta", raw=None),
                 "messages": [AIMessage(content=err_msg)],
             }
+
+
+def _normalize_target(raw_target: Any, intent: str) -> str:
+    if intent == "meta":
+        return "meta"
+    target = raw_target.strip().lower() if isinstance(raw_target, str) else "new_research"
+    return target if target in ("report", "new_research") else "new_research"
+
+
+def _normalize_report_action(raw_action: Any) -> str | None:
+    action = raw_action.strip().lower() if isinstance(raw_action, str) else None
+    return action if action in ("ask", "edit") else None

--- a/src/aiq_agent/agents/chat_researcher/nodes/intent_classifier.py
+++ b/src/aiq_agent/agents/chat_researcher/nodes/intent_classifier.py
@@ -44,24 +44,11 @@ _LLM_UNAVAILABLE_MESSAGE = (
     "Please check your LLM API key and that the configured model is available for your account."
 )
 _LLM_TIMEOUT_MESSAGE = "The model service took too long to respond and the request timed out. "
-_REPORT_ASK_HINTS = (
-    "this report",
-    "the report",
-    "based on this",
-    "what did we conclude",
-    "summarize this",
-)
-_REPORT_EDIT_HINTS = (
-    "rewrite",
-    "redo",
-    "remove",
-    "delete",
-    "make this",
-    "shorter",
-    "change tone",
-    "revise",
-)
-_REPORT_TARGET_HINTS = _REPORT_ASK_HINTS + _REPORT_EDIT_HINTS
+_ROUTE_REPORT_ASK = "report_ask"
+_ROUTE_REPORT_COSMETIC_EDIT = "report_cosmetic_edit"
+_ROUTE_REPORT_DELTA_RESEARCH = "report_delta_research"
+_ROUTE_STANDALONE_RESEARCH = "standalone_research"
+_ROUTE_META = "meta"
 
 
 def _is_llm_api_unavailable(err: BaseException) -> bool:
@@ -80,16 +67,6 @@ def _is_timeout_error(err: BaseException) -> bool:
         return True
     msg = str(err).strip().lower()
     return "504" in msg or "gateway time-out" in msg or "gateway timeout" in msg
-
-
-def _looks_report_targeted(query: str) -> bool:
-    query_lower = query.lower()
-    return any(hint in query_lower for hint in _REPORT_TARGET_HINTS)
-
-
-def _looks_report_edit(query: str) -> bool:
-    query_lower = query.lower()
-    return any(hint in query_lower for hint in _REPORT_EDIT_HINTS)
 
 
 class IntentClassifier:
@@ -165,8 +142,9 @@ class IntentClassifier:
             intent = raw_intent if raw_intent in ("meta", "research") else "research"
             meta_response = parsed.get("meta_response")
             research_depth = (parsed.get("research_depth") or "shallow").strip().lower()
-            depth_reasoning = parsed.get("depth_reasoning") or ""
+            depth_reasoning = parsed.get("route_reasoning") or parsed.get("depth_reasoning") or ""
             active_report = bool(state.active_report_job_id or state.last_report_markdown)
+            route = _normalize_route(parsed.get("route"))
             target = _normalize_target(parsed.get("target"))
             report_action = _normalize_report_action(parsed.get("report_action"))
             use_parent_report_context = _normalize_bool(parsed.get("use_parent_report_context")) and active_report
@@ -175,26 +153,27 @@ class IntentClassifier:
                 target = "meta"
                 report_action = None
                 use_parent_report_context = False
+            elif route is not None:
+                target, report_action, use_parent_report_context, research_depth, depth_reasoning = _route_to_fields(
+                    route=route,
+                    active_report=active_report,
+                    research_depth=research_depth,
+                    depth_reasoning=str(depth_reasoning),
+                )
             elif target == "report":
                 use_parent_report_context = False
                 if not active_report:
                     target = "new_research"
                     report_action = None
                 elif report_action is None:
-                    if _looks_report_edit(query):
-                        report_action = "edit"
-                    elif _looks_report_targeted(query):
-                        report_action = "ask"
-                    else:
-                        # The model chose target=report but gave no report_action and the
-                        # query matched no ask/edit hint. Fall back to fresh research, but
-                        # log it so this silent downgrade is observable in traces.
-                        logger.debug(
-                            "Report target requested without a resolvable report_action; "
-                            "falling back to new_research (query=%r)",
-                            query,
-                        )
-                        target = "new_research"
+                    # Legacy schema compatibility: if the model did not emit the new
+                    # semantic route or an explicit report action, do not maintain a
+                    # second keyword classifier in Python. Fall back to research.
+                    logger.debug(
+                        "Legacy report target without report_action; falling back to new_research (query=%r)",
+                        query,
+                    )
+                    target = "new_research"
             else:
                 target = "new_research"
                 report_action = None
@@ -263,6 +242,47 @@ def _normalize_target(raw_target: Any) -> str:
 def _normalize_report_action(raw_action: Any) -> str | None:
     action = raw_action.strip().lower() if isinstance(raw_action, str) else None
     return action if action in ("ask", "edit") else None
+
+
+def _normalize_route(raw_route: Any) -> str | None:
+    route = raw_route.strip().lower() if isinstance(raw_route, str) else None
+    if route in (
+        _ROUTE_REPORT_ASK,
+        _ROUTE_REPORT_COSMETIC_EDIT,
+        _ROUTE_REPORT_DELTA_RESEARCH,
+        _ROUTE_STANDALONE_RESEARCH,
+        _ROUTE_META,
+    ):
+        return route
+    return None
+
+
+def _route_to_fields(
+    *,
+    route: str,
+    active_report: bool,
+    research_depth: str,
+    depth_reasoning: str,
+) -> tuple[str, str | None, bool, str, str]:
+    """Map the LLM-owned semantic route onto the existing workflow fields."""
+    if route == _ROUTE_META:
+        return "meta", None, False, research_depth, depth_reasoning
+
+    if route == _ROUTE_REPORT_ASK:
+        if active_report:
+            return "report", "ask", False, research_depth, depth_reasoning
+        return "new_research", None, False, research_depth, depth_reasoning
+
+    if route == _ROUTE_REPORT_COSMETIC_EDIT:
+        if active_report:
+            return "report", "edit", False, research_depth, depth_reasoning
+        return "new_research", None, False, research_depth, depth_reasoning
+
+    if route == _ROUTE_REPORT_DELTA_RESEARCH:
+        reasoning = depth_reasoning or "Requires fresh evidence against the active report."
+        return "new_research", None, active_report, "deep", reasoning
+
+    return "new_research", None, False, research_depth, depth_reasoning
 
 
 def _normalize_bool(raw_value: Any) -> bool:

--- a/src/aiq_agent/agents/chat_researcher/nodes/intent_classifier.py
+++ b/src/aiq_agent/agents/chat_researcher/nodes/intent_classifier.py
@@ -146,15 +146,17 @@ class IntentClassifier:
                 }
 
             raw_intent = (parsed.get("intent") or "research").strip().lower()
-            intent = raw_intent if raw_intent in ("meta", "research") else "research"
+            route = _normalize_route(parsed.get("route"))
+            if route == _ROUTE_META:
+                intent = "meta"
+            elif route is not None:
+                intent = "research"
+            else:
+                intent = raw_intent if raw_intent in ("meta", "research") else "research"
             meta_response = parsed.get("meta_response")
             research_depth = (parsed.get("research_depth") or "shallow").strip().lower()
             depth_reasoning = parsed.get("route_reasoning") or parsed.get("depth_reasoning") or ""
             active_report = bool(state.active_report_job_id or state.last_report_markdown)
-            route = _normalize_route(parsed.get("route"))
-            target = _normalize_target(parsed.get("target"))
-            report_action = _normalize_report_action(parsed.get("report_action"))
-            use_parent_report_context = _normalize_bool(parsed.get("use_parent_report_context")) and active_report
 
             if intent == "meta":
                 target = "meta"
@@ -167,23 +169,10 @@ class IntentClassifier:
                     research_depth=research_depth,
                     depth_reasoning=str(depth_reasoning),
                 )
-            elif target == "report":
-                use_parent_report_context = False
-                if not active_report:
-                    target = "new_research"
-                    report_action = None
-                elif report_action is None:
-                    # Legacy schema compatibility: if the model did not emit the new
-                    # semantic route or an explicit report action, do not maintain a
-                    # second keyword classifier in Python. Fall back to research.
-                    logger.debug(
-                        "Legacy report target without report_action; falling back to new_research (query=%r)",
-                        query,
-                    )
-                    target = "new_research"
             else:
                 target = "new_research"
                 report_action = None
+                use_parent_report_context = False
 
             update: dict[str, Any] = {
                 "user_intent": IntentResult(
@@ -270,16 +259,6 @@ class IntentClassifier:
         return repaired if isinstance(repaired, dict) else None
 
 
-def _normalize_target(raw_target: Any) -> str:
-    target = raw_target.strip().lower() if isinstance(raw_target, str) else "new_research"
-    return target if target in ("report", "new_research") else "new_research"
-
-
-def _normalize_report_action(raw_action: Any) -> str | None:
-    action = raw_action.strip().lower() if isinstance(raw_action, str) else None
-    return action if action in ("ask", "edit") else None
-
-
 def _normalize_route(raw_route: Any) -> str | None:
     route = raw_route.strip().lower() if isinstance(raw_route, str) else None
     if route in (
@@ -301,9 +280,6 @@ def _route_to_fields(
     depth_reasoning: str,
 ) -> tuple[str, str | None, bool, str, str]:
     """Map the LLM-owned semantic route onto the existing workflow fields."""
-    if route == _ROUTE_META:
-        return "meta", None, False, research_depth, depth_reasoning
-
     if route == _ROUTE_REPORT_ASK:
         if active_report:
             return "report", "ask", False, research_depth, depth_reasoning
@@ -318,19 +294,7 @@ def _route_to_fields(
         reasoning = depth_reasoning or "Requires fresh evidence against the active report."
         return "new_research", None, active_report, "deep", reasoning
 
-    return "new_research", None, False, research_depth, depth_reasoning
+    if route == _ROUTE_STANDALONE_RESEARCH:
+        return "new_research", None, False, research_depth, depth_reasoning
 
-
-def _normalize_bool(raw_value: Any) -> bool:
-    """Coerce LLM JSON values to bool, treating string booleans correctly.
-
-    json.loads usually yields real booleans, but models occasionally emit string
-    booleans (e.g. "false"); plain bool("false") would be True, so handle them.
-    """
-    if isinstance(raw_value, bool):
-        return raw_value
-    if isinstance(raw_value, str):
-        return raw_value.strip().lower() in {"true", "1", "yes"}
-    if isinstance(raw_value, (int, float)):
-        return raw_value != 0
-    return False
+    raise ValueError(f"Unsupported research route: {route}")

--- a/src/aiq_agent/agents/chat_researcher/nodes/intent_classifier.py
+++ b/src/aiq_agent/agents/chat_researcher/nodes/intent_classifier.py
@@ -44,17 +44,24 @@ _LLM_UNAVAILABLE_MESSAGE = (
     "Please check your LLM API key and that the configured model is available for your account."
 )
 _LLM_TIMEOUT_MESSAGE = "The model service took too long to respond and the request timed out. "
-_REPORT_TARGET_HINTS = (
+_REPORT_ASK_HINTS = (
     "this report",
     "the report",
     "based on this",
     "what did we conclude",
     "summarize this",
+)
+_REPORT_EDIT_HINTS = (
     "rewrite",
     "redo",
     "remove",
+    "delete",
     "make this",
+    "shorter",
+    "change tone",
+    "revise",
 )
+_REPORT_TARGET_HINTS = _REPORT_ASK_HINTS + _REPORT_EDIT_HINTS
 
 
 def _is_llm_api_unavailable(err: BaseException) -> bool:
@@ -78,6 +85,11 @@ def _is_timeout_error(err: BaseException) -> bool:
 def _looks_report_targeted(query: str) -> bool:
     query_lower = query.lower()
     return any(hint in query_lower for hint in _REPORT_TARGET_HINTS)
+
+
+def _looks_report_edit(query: str) -> bool:
+    query_lower = query.lower()
+    return any(hint in query_lower for hint in _REPORT_EDIT_HINTS)
 
 
 class IntentClassifier:
@@ -169,7 +181,9 @@ class IntentClassifier:
                     target = "new_research"
                     report_action = None
                 elif report_action is None:
-                    if _looks_report_targeted(query):
+                    if _looks_report_edit(query):
+                        report_action = "edit"
+                    elif _looks_report_targeted(query):
                         report_action = "ask"
                     else:
                         target = "new_research"

--- a/src/aiq_agent/agents/chat_researcher/nodes/intent_classifier.py
+++ b/src/aiq_agent/agents/chat_researcher/nodes/intent_classifier.py
@@ -167,7 +167,7 @@ class IntentClassifier:
             research_depth = (parsed.get("research_depth") or "shallow").strip().lower()
             depth_reasoning = parsed.get("depth_reasoning") or ""
             active_report = bool(state.active_report_job_id)
-            target = _normalize_target(parsed.get("target"), intent)
+            target = _normalize_target(parsed.get("target"))
             report_action = _normalize_report_action(parsed.get("report_action"))
             use_parent_report_context = bool(parsed.get("use_parent_report_context")) and active_report
 
@@ -247,9 +247,7 @@ class IntentClassifier:
             }
 
 
-def _normalize_target(raw_target: Any, intent: str) -> str:
-    if intent == "meta":
-        return "meta"
+def _normalize_target(raw_target: Any) -> str:
     target = raw_target.strip().lower() if isinstance(raw_target, str) else "new_research"
     return target if target in ("report", "new_research") else "new_research"
 

--- a/src/aiq_agent/agents/chat_researcher/nodes/intent_classifier.py
+++ b/src/aiq_agent/agents/chat_researcher/nodes/intent_classifier.py
@@ -34,7 +34,6 @@ from aiq_agent.common import render_prompt_template
 from ..models import ChatResearcherState
 from ..models import DepthDecision
 from ..models import IntentResult
-from ..utils import trim_message_history
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +43,7 @@ _LLM_UNAVAILABLE_MESSAGE = (
     "Please check your LLM API key and that the configured model is available for your account."
 )
 _LLM_TIMEOUT_MESSAGE = "The model service took too long to respond and the request timed out. "
+_REPAIR_TIMEOUT_SECONDS = 15
 _ROUTE_REPORT_ASK = "report_ask"
 _ROUTE_REPORT_COSMETIC_EDIT = "report_cosmetic_edit"
 _ROUTE_REPORT_DELTA_RESEARCH = "report_delta_research"
@@ -119,8 +119,9 @@ class IntentClassifier:
             tools=self.tools_info,
             active_report_available=bool(state.active_report_job_id or state.last_report_markdown),
         )
-        trimmed_conversation = trim_message_history(list(state.messages), max_tokens=self.max_history)
-        messages: list[BaseMessage] = [SystemMessage(content=system_content)] + trimmed_conversation
+        # Keep the router isolated from prior assistant report bodies. The prompt already contains
+        # the latest query and report availability, which is the bounded context needed here.
+        messages: list[BaseMessage] = [SystemMessage(content=system_content)]
 
         try:
             config = {"callbacks": self.callbacks} if self.callbacks else {}
@@ -131,11 +132,17 @@ class IntentClassifier:
 
             response_text = (response.content or "").strip()
             parsed = extract_json(response_text)
+            if not parsed or not isinstance(parsed, dict):
+                parsed = await self._repair_json_response(
+                    system_content=system_content,
+                    invalid_response=response_text,
+                    config=config,
+                )
 
             if not parsed or not isinstance(parsed, dict):
                 return {
                     "user_intent": IntentResult(intent="research", raw=None),
-                    "depth_decision": DepthDecision(decision="shallow", raw_reasoning="Parse failed"),
+                    "depth_decision": DepthDecision(decision="deep", raw_reasoning="Parse failed"),
                 }
 
             raw_intent = (parsed.get("intent") or "research").strip().lower()
@@ -232,6 +239,35 @@ class IntentClassifier:
                 "user_intent": IntentResult(intent="meta", raw=None),
                 "messages": [AIMessage(content=err_msg)],
             }
+
+    async def _repair_json_response(
+        self,
+        *,
+        system_content: str,
+        invalid_response: str,
+        config: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        repair_prompt = (
+            f"{system_content}\n\n"
+            "The previous classifier response was invalid because it was not one valid JSON object.\n"
+            "Return only one valid JSON object matching the schema above. Do not include markdown, prose, "
+            "analysis, code fences, or a rewritten report.\n\n"
+            f"Invalid response:\n{invalid_response[:4000]}"
+        )
+        try:
+            response = await asyncio.wait_for(
+                self.llm.ainvoke([SystemMessage(content=repair_prompt)], config=config),
+                timeout=min(self.llm_timeout, _REPAIR_TIMEOUT_SECONDS),
+            )
+        except TimeoutError:
+            logger.warning("Intent classifier JSON repair timed out.")
+            return None
+        except Exception as e:
+            logger.warning("Intent classifier JSON repair failed: %s", e)
+            return None
+
+        repaired = extract_json((response.content or "").strip())
+        return repaired if isinstance(repaired, dict) else None
 
 
 def _normalize_target(raw_target: Any) -> str:

--- a/src/aiq_agent/agents/chat_researcher/nodes/intent_classifier.py
+++ b/src/aiq_agent/agents/chat_researcher/nodes/intent_classifier.py
@@ -186,6 +186,14 @@ class IntentClassifier:
                     elif _looks_report_targeted(query):
                         report_action = "ask"
                     else:
+                        # The model chose target=report but gave no report_action and the
+                        # query matched no ask/edit hint. Fall back to fresh research, but
+                        # log it so this silent downgrade is observable in traces.
+                        logger.debug(
+                            "Report target requested without a resolvable report_action; "
+                            "falling back to new_research (query=%r)",
+                            query,
+                        )
                         target = "new_research"
             else:
                 target = "new_research"

--- a/src/aiq_agent/agents/chat_researcher/prompts/intent_classification.j2
+++ b/src/aiq_agent/agents/chat_researcher/prompts/intent_classification.j2
@@ -16,20 +16,30 @@ Generate a direct response to the user.
 4. **Constraints**: No emojis. Do not answer research questions here.
 
 #### IF INTENT IS "RESEARCH":
-Determine the routing target and depth.
-- **target = "report"** only when an active report is available and the user is asking about or editing that report.
-- **target = "new_research"** for generic factual questions, new topics, or requests needing fresh evidence.
-- If no active report is available, never choose target = "report".
+Determine the semantic route and depth.
+- **route = "report_ask"** only when an active report is available and the user asks a question answerable from that existing report.
+- **route = "report_cosmetic_edit"** only when an active report is available and the user asks for mechanical or aesthetic edits that do not require new evidence.
+- **route = "report_delta_research"** only when an active report is available and the user asks for fresh evidence, deeper analysis, or a new analytical perspective on the same report topic.
+- **route = "standalone_research"** for generic factual questions, new topics, unrelated report requests, or when no active report is available.
 
-Report actions when target = "report":
-- **ask**: answer about the existing report, e.g. "what are the risks in this report?", "summarize this report", "what did we conclude?"
-- **edit**: produce a revised child report, e.g. "remove a section", "rewrite this subsection", "make this shorter", "redo the report", "change tone".
+Route examples:
+- "what are the risks in this report?" -> route = "report_ask"
+- "summarize this report" -> route = "report_ask"
+- "make this shorter" -> route = "report_cosmetic_edit"
+- "change tone" -> route = "report_cosmetic_edit"
+- "format as bullets" -> route = "report_cosmetic_edit"
+- "rewrite this report from a player-performance POV" -> route = "report_delta_research"
+- "redo this with newer evidence" -> route = "report_delta_research"
+- "can we write a report on this from a supply-chain angle?" -> route = "report_delta_research"
+- "write a separate report on player performance" -> route = "standalone_research"
 
-Parent-context research:
-- If an active report is available and the user asks for latest/current/fresh/deeper/new evidence related to that report, choose target = "new_research", research_depth = "deep", and use_parent_report_context = true.
-- If the user asks a generic unrelated question while a report is active, choose target = "new_research" and use_parent_report_context = false.
+Compatibility fields:
+- For route = "report_ask", set target = "report", report_action = "ask", research_depth = null, use_parent_report_context = false.
+- For route = "report_cosmetic_edit", set target = "report", report_action = "edit", research_depth = null, use_parent_report_context = false.
+- For route = "report_delta_research", set target = "new_research", report_action = null, research_depth = "deep", use_parent_report_context = true.
+- For route = "standalone_research", set target = "new_research", report_action = null, use_parent_report_context = false.
 
-Determine the depth for target = "new_research".
+Determine the depth for standalone_research.
 - **shallow**: Single main question, factual lookup, 2-3 tool calls, no complex comparison.
 - **deep**: Multi-faceted, explicit comparisons, trend analysis, strategy/roadmaps, or "comprehensive" requests.
 - **Tie-break**: If unsure, choose "shallow".
@@ -38,12 +48,13 @@ Determine the depth for target = "new_research".
 You must respond ONLY with a JSON object using this schema:
 {
   "intent": "meta" | "research",
+  "route": "report_ask" | "report_cosmetic_edit" | "report_delta_research" | "standalone_research" | "meta",
   "target": "meta" | "report" | "new_research",
   "report_action": "ask" | "edit" | null,
   "meta_response": "The text response if intent is meta, otherwise null",
   "research_depth": "shallow" | "deep" | null,
   "use_parent_report_context": true | false,
-  "depth_reasoning": "One sentence explanation for depth if research, otherwise null"
+  "route_reasoning": "One sentence explanation for the route and depth, otherwise null"
 }
 
 {#- === KV CACHE BOUNDARY — dynamic content below === -#}

--- a/src/aiq_agent/agents/chat_researcher/prompts/intent_classification.j2
+++ b/src/aiq_agent/agents/chat_researcher/prompts/intent_classification.j2
@@ -16,7 +16,20 @@ Generate a direct response to the user.
 4. **Constraints**: No emojis. Do not answer research questions here.
 
 #### IF INTENT IS "RESEARCH":
-Determine the depth.
+Determine the routing target and depth.
+- **target = "report"** only when an active report is available and the user is asking about or editing that report.
+- **target = "new_research"** for generic factual questions, new topics, or requests needing fresh evidence.
+- If no active report is available, never choose target = "report".
+
+Report actions when target = "report":
+- **ask**: answer about the existing report, e.g. "what are the risks in this report?", "summarize this report", "what did we conclude?"
+- **edit**: produce a revised child report, e.g. "remove a section", "rewrite this subsection", "make this shorter", "redo the report", "change tone".
+
+Parent-context research:
+- If an active report is available and the user asks for latest/current/fresh/deeper/new evidence related to that report, choose target = "new_research", research_depth = "deep", and use_parent_report_context = true.
+- If the user asks a generic unrelated question while a report is active, choose target = "new_research" and use_parent_report_context = false.
+
+Determine the depth for target = "new_research".
 - **shallow**: Single main question, factual lookup, 2-3 tool calls, no complex comparison.
 - **deep**: Multi-faceted, explicit comparisons, trend analysis, strategy/roadmaps, or "comprehensive" requests.
 - **Tie-break**: If unsure, choose "shallow".
@@ -25,8 +38,11 @@ Determine the depth.
 You must respond ONLY with a JSON object using this schema:
 {
   "intent": "meta" | "research",
+  "target": "meta" | "report" | "new_research",
+  "report_action": "ask" | "edit" | null,
   "meta_response": "The text response if intent is meta, otherwise null",
   "research_depth": "shallow" | "deep" | null,
+  "use_parent_report_context": true | false,
   "depth_reasoning": "One sentence explanation for depth if research, otherwise null"
 }
 
@@ -36,6 +52,13 @@ You must respond ONLY with a JSON object using this schema:
 Current Date and Time: {{ current_datetime }}
 {% if user_info and user_info.name %}
 User: **{{ user_info.name }}** ({{ user_info.email or "email not provided" }})
+{% endif %}
+
+{% if active_report_job_id %}
+Active Report Job ID: {{ active_report_job_id }}
+The active report is available as optional context. Do not assume the user wants report mode just because this exists.
+{% else %}
+Active Report Job ID: none
 {% endif %}
 
 Available Tools:

--- a/src/aiq_agent/agents/chat_researcher/prompts/intent_classification.j2
+++ b/src/aiq_agent/agents/chat_researcher/prompts/intent_classification.j2
@@ -41,7 +41,8 @@ Compatibility fields:
 
 Determine the depth for standalone_research.
 - **shallow**: Single main question, factual lookup, 2-3 tool calls, no complex comparison.
-- **deep**: Multi-faceted, explicit comparisons, trend analysis, strategy/roadmaps, or "comprehensive" requests.
+- **deep**: Explicit report-generation requests ("write/create/generate a report"), multi-faceted requests,
+  explicit comparisons, trend analysis, strategy/roadmaps, or "comprehensive" requests.
 - **Tie-break**: If unsure, choose "shallow".
 
 ### OUTPUT FORMAT

--- a/src/aiq_agent/agents/chat_researcher/prompts/intent_classification.j2
+++ b/src/aiq_agent/agents/chat_researcher/prompts/intent_classification.j2
@@ -54,11 +54,11 @@ Current Date and Time: {{ current_datetime }}
 User: **{{ user_info.name }}** ({{ user_info.email or "email not provided" }})
 {% endif %}
 
-{% if active_report_job_id %}
-Active Report Job ID: {{ active_report_job_id }}
+{% if active_report_available %}
+Active report: available
 The active report is available as optional context. Do not assume the user wants report mode just because this exists.
 {% else %}
-Active Report Job ID: none
+Active report: none
 {% endif %}
 
 Available Tools:

--- a/src/aiq_agent/agents/chat_researcher/prompts/intent_classification.j2
+++ b/src/aiq_agent/agents/chat_researcher/prompts/intent_classification.j2
@@ -33,12 +33,6 @@ Route examples:
 - "can we write a report on this from a supply-chain angle?" -> route = "report_delta_research"
 - "write a separate report on player performance" -> route = "standalone_research"
 
-Compatibility fields:
-- For route = "report_ask", set target = "report", report_action = "ask", research_depth = null, use_parent_report_context = false.
-- For route = "report_cosmetic_edit", set target = "report", report_action = "edit", research_depth = null, use_parent_report_context = false.
-- For route = "report_delta_research", set target = "new_research", report_action = null, research_depth = "deep", use_parent_report_context = true.
-- For route = "standalone_research", set target = "new_research", report_action = null, use_parent_report_context = false.
-
 Determine the depth for standalone_research.
 - **shallow**: Single main question, factual lookup, 2-3 tool calls, no complex comparison.
 - **deep**: Explicit report-generation requests ("write/create/generate a report"), multi-faceted requests,
@@ -50,11 +44,8 @@ You must respond ONLY with a JSON object using this schema:
 {
   "intent": "meta" | "research",
   "route": "report_ask" | "report_cosmetic_edit" | "report_delta_research" | "standalone_research" | "meta",
-  "target": "meta" | "report" | "new_research",
-  "report_action": "ask" | "edit" | null,
   "meta_response": "The text response if intent is meta, otherwise null",
   "research_depth": "shallow" | "deep" | null,
-  "use_parent_report_context": true | false,
   "route_reasoning": "One sentence explanation for the route and depth, otherwise null"
 }
 

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -45,7 +45,7 @@ from nat.data_models.component_ref import LLMRef
 from nat.data_models.function import FunctionBaseConfig
 
 from .models import ChatResearcherState
-from .utils import _extract_query_and_sources
+from .utils import _extract_query_context
 
 logger = logging.getLogger(__name__)
 
@@ -369,7 +369,9 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
                 pass
         logger.info("skip_clarifier=%s", skip_clarifier)
 
-        query_text, data_sources = _extract_query_and_sources(query)
+        request_context = _extract_query_context(query)
+        query_text = request_context.query_text
+        data_sources = request_context.data_sources
         logger.info("ChatDeepResearcherAgent: %s", query_text)
         logger.info("ChatDeepResearcherAgent: Data sources: %s", data_sources)
 
@@ -410,6 +412,7 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
                 data_sources=data_sources,
                 available_documents=available_documents,
                 skip_clarifier=skip_clarifier,
+                active_report_job_id=request_context.active_report_job_id,
             )
             result = await agent.run(state, thread_id=nat_context_conversation_id)
         finally:

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -329,6 +329,7 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
         from aiq_agent.auth import get_auth_token
         from aiq_agent.auth import get_current_principal
         from aiq_agent.common import get_latest_user_query
+        from aiq_api.jobs.report_context import report_output_metadata
         from aiq_api.jobs.report_context import to_initial_files
         from aiq_api.jobs.submit import submit_agent_job
 
@@ -345,11 +346,7 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
             data_sources=[],
             auth_token=get_auth_token(),
             initial_files=to_initial_files(report_context, instruction=instruction),
-            output_metadata={
-                "parent_job_id": report_context.parent_job_id,
-                "interaction_action": "edit",
-                "result_kind": "report",
-            },
+            output_metadata=report_output_metadata(report_context.parent_job_id, "edit"),
         )
 
     if config.use_async_deep_research:
@@ -386,15 +383,12 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
                 initial_files = None
                 output_metadata = None
                 if state.active_report_job_id and state.user_intent and state.user_intent.use_parent_report_context:
+                    from aiq_api.jobs.report_context import report_output_metadata
                     from aiq_api.jobs.report_context import to_initial_files
 
                     report_context = await _resolve_report_context_for_state(state)
                     initial_files = to_initial_files(report_context)
-                    output_metadata = {
-                        "parent_job_id": report_context.parent_job_id,
-                        "interaction_action": "research",
-                        "result_kind": "report",
-                    }
+                    output_metadata = report_output_metadata(report_context.parent_job_id, "research")
                     input_text = (
                         f"{input_text}\n\n"
                         "Use the seeded parent report context in /shared/original_report.md and "

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -105,6 +105,40 @@ async def _answer_from_report_context(
     return answer
 
 
+async def _resolve_effective_report_job_id(
+    request_active_id: str | None,
+    conversation_id: str | None,
+    principal: Any,
+    *,
+    is_input_mode: bool,
+) -> str | None:
+    """Resolve which report a follow-up turn should target.
+
+    A client-supplied ``active_report_job_id`` always wins. Otherwise default to the most recent
+    completed report in THIS conversation, so any client (CLI, API, UI on reload) gets report
+    follow-up without having to track the id. Only falls back for a real, client-supplied
+    conversation id — never for --input or server-generated thread ids. Any lookup failure
+    degrades silently to None (fresh research).
+    """
+    if request_active_id:
+        return request_active_id
+    if is_input_mode or not conversation_id:
+        return None
+    try:
+        import os
+
+        from aiq_api.jobs.access import get_latest_report_job_for_conversation
+
+        db_url = os.environ.get("NAT_JOB_STORE_DB_URL", "sqlite:///./data/jobs.db")
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, get_latest_report_job_for_conversation, conversation_id, principal, db_url
+        )
+    except Exception as e:
+        logger.debug("Report-job fallback lookup failed: %s", type(e).__name__)
+        return None
+
+
 ########################################################
 # Intent Classifier
 ########################################################
@@ -545,6 +579,19 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
                 logger.debug("No session context - cannot determine collection")
         except Exception as e:
             logger.warning("Could not fetch available documents: %s", e)
+        # Resolve the report to follow up on: client-supplied id wins, else default to the last
+        # completed report in this conversation (server-side, so any client gets follow-up).
+        _ctx = Context.get()
+        client_conversation_id = _ctx.conversation_id if _ctx else None
+        effective_report_job_id = await _resolve_effective_report_job_id(
+            request_context.active_report_job_id,
+            client_conversation_id,
+            principal,
+            is_input_mode="--input" in sys.argv,
+        )
+        if effective_report_job_id and not request_context.active_report_job_id:
+            logger.info("Defaulting report follow-up to last report %s in conversation", effective_report_job_id)
+
         # Set session-scoped source registry for citation verification across turns.
         # When no conversation ID is available, get_or_create_session_registry returns a
         # fresh per-request registry to prevent anonymous sessions from sharing state.
@@ -557,7 +604,7 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
                 data_sources=data_sources,
                 available_documents=available_documents,
                 skip_clarifier=skip_clarifier,
-                active_report_job_id=request_context.active_report_job_id,
+                active_report_job_id=effective_report_job_id,
             )
             result = await agent.run(state, thread_id=nat_context_conversation_id)
         finally:

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -416,6 +416,7 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
             original_report=report_context.report_markdown,
             edit_instruction=instruction,
             source_summary=report_context.source_summary_markdown,
+            parent_context=report_context.model_dump_json(indent=2, exclude={"report_markdown"}),
         )
 
     async def _build_report_seed_files(state: ChatResearcherState) -> dict[str, str]:

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -70,6 +70,32 @@ def _build_report_ask_prompt(
     )
 
 
+async def _answer_from_report_context(
+    llm: Any,
+    *,
+    question: str,
+    report_markdown: str,
+    source_summary_markdown: str,
+) -> str:
+    """Answer a question strictly from parent report context with one bounded LLM call.
+
+    This deliberately does NOT use the shallow/deep research agents or any data-source
+    tools: report ask must stay bounded to the parent report and never trigger live
+    research (Core Invariant: "answer from parent report context only").
+    """
+    prompt = _build_report_ask_prompt(
+        question=question,
+        report_markdown=report_markdown,
+        source_summary_markdown=source_summary_markdown,
+    )
+    response = await llm.ainvoke([HumanMessage(content=prompt)])
+    content = response.content if hasattr(response, "content") else response
+    answer = content if isinstance(content, str) else str(content)
+    if not answer.strip():
+        return "The report does not contain enough information to answer."
+    return answer
+
+
 ########################################################
 # Intent Classifier
 ########################################################
@@ -266,6 +292,14 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
     verbose = is_verbose(config.verbose)
     callbacks = [VerboseTraceCallback()] if verbose else []
 
+    # LLM for inline report Q&A: prefer the report writer model, fall back to the
+    # deep researcher's orchestrator LLM (always configured). Report ask is a single
+    # bounded LLM call and must never run the tool-enabled research agents.
+    report_qa_llm = await builder.get_llm(
+        deep_research_config.writer_llm or deep_research_config.orchestrator_llm,
+        wrapper_type=LLMFrameworkEnum.LANGCHAIN,
+    )
+
     deep_research_job_submitter = None
 
     async def _resolve_report_context_for_state(state: ChatResearcherState):
@@ -280,27 +314,16 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
         return await resolve_authorized_report_context(state.active_report_job_id, principal)
 
     async def _answer_report_question(state: ChatResearcherState) -> str:
-        from aiq_agent.agents.shallow_researcher.models import ShallowResearchAgentState
         from aiq_agent.common import get_latest_user_query
 
         report_context = await _resolve_report_context_for_state(state)
         question = get_latest_user_query(state.messages)
-        prompt = _build_report_ask_prompt(
+        return await _answer_from_report_context(
+            report_qa_llm,
             question=question,
             report_markdown=report_context.report_markdown,
             source_summary_markdown=report_context.source_summary_markdown,
         )
-        result = await shallow_research_fn.ainvoke(
-            ShallowResearchAgentState(
-                messages=[HumanMessage(content=prompt)],
-                data_sources=state.data_sources,
-                available_documents=state.available_documents,
-            )
-        )
-        if not result.messages:
-            raise RuntimeError("Report QA produced no response")
-        content = result.messages[-1].content
-        return content if isinstance(content, str) else str(content)
 
     async def _submit_report_edit_job(state: ChatResearcherState) -> str:
         from aiq_agent.auth import get_auth_token
@@ -362,11 +385,7 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
 
                 initial_files = None
                 output_metadata = None
-                if (
-                    state.active_report_job_id
-                    and state.user_intent
-                    and state.user_intent.use_parent_report_context
-                ):
+                if state.active_report_job_id and state.user_intent and state.user_intent.use_parent_report_context:
                     from aiq_api.jobs.report_context import to_initial_files
 
                     report_context = await _resolve_report_context_for_state(state)

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -344,6 +344,9 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
     )
 
     deep_research_job_submitter = None
+    # Wired to the async submitter only when a Dask scheduler is available; otherwise edit runs
+    # inline via report_edit_fn (synchronous CLI).
+    report_edit_job_submitter = None
 
     async def _resolve_report_context_for_state(state: ChatResearcherState):
         from aiq_api.jobs.access import require_verified_principal
@@ -395,6 +398,32 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
             output_metadata=report_output_metadata(report_context.parent_job_id, "edit"),
             allow_internal=True,
         )
+
+    async def _inline_report_edit(state: ChatResearcherState) -> str:
+        """Rewrite the in-session report inline (synchronous CLI, no scheduler/job).
+
+        Mirrors the report_rewriter job's single bounded LLM call, sourced from the in-session
+        report (or, if present, the explicit job-backed report) resolved by the same precedence
+        as report ask.
+        """
+        from aiq_agent.agents.report_rewriter.agent import rewrite_report
+        from aiq_agent.common import get_latest_user_query
+
+        report_context = await _resolve_report_context_for_state(state)
+        instruction = get_latest_user_query(state.messages)
+        return await rewrite_report(
+            llm=report_qa_llm,
+            original_report=report_context.report_markdown,
+            edit_instruction=instruction,
+            source_summary=report_context.source_summary_markdown,
+        )
+
+    async def _build_report_seed_files(state: ChatResearcherState) -> dict[str, str]:
+        """Seed files for an inline delta: the parent report context as DeepAgents FS files."""
+        from aiq_api.jobs.report_context import to_initial_files
+
+        report_context = await _resolve_report_context_for_state(state)
+        return to_initial_files(report_context)
 
     if config.use_async_deep_research:
         import os
@@ -468,6 +497,7 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
                 )
 
             deep_research_job_submitter = _submit_deep_job
+            report_edit_job_submitter = _submit_report_edit_job
         else:
             logger.info(
                 "use_async_deep_research is enabled but NAT_DASK_SCHEDULER_ADDRESS is not set. "
@@ -487,7 +517,9 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
         max_history=config.max_history,
         deep_research_job_submitter=deep_research_job_submitter,
         report_ask_fn=_answer_report_question,
-        report_edit_job_submitter=_submit_report_edit_job,
+        report_edit_job_submitter=report_edit_job_submitter,
+        report_edit_fn=_inline_report_edit,
+        report_seed_files_fn=_build_report_seed_files,
         checkpointer=checkpointer,
         validate_deep_research_tools_fn=validate_deep_research_tools,
     )

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -462,27 +462,15 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
                     from aiq_api.jobs.report_context import report_output_metadata
                     from aiq_api.jobs.report_context import to_initial_files
 
-                    # Parent-context seeding is an optional enrichment. If durable context
-                    # resolution fails (e.g. 409/503), still run the delta research rather
-                    # than aborting the whole job.
-                    try:
-                        report_context = await _resolve_report_context_for_state(state)
-                    except Exception as e:
-                        logger.warning(
-                            "Parent report context unavailable for %s (error_type=%s); "
-                            "continuing without seeded context",
-                            state.active_report_job_id,
-                            type(e).__name__,
-                        )
-                    else:
-                        initial_files = to_initial_files(report_context)
-                        output_metadata = report_output_metadata(report_context.parent_job_id, "research")
-                        input_text = (
-                            f"{input_text}\n\n"
-                            "Use the seeded parent report context in /shared/original_report.md and "
-                            "/shared/source_summary.md. Reuse the parent report where sufficient and perform "
-                            "new research only for the requested delta."
-                        )
+                    report_context = await _resolve_report_context_for_state(state)
+                    initial_files = to_initial_files(report_context)
+                    output_metadata = report_output_metadata(report_context.parent_job_id, "research")
+                    input_text = (
+                        f"{input_text}\n\n"
+                        "Use the seeded parent report context in /shared/original_report.md and "
+                        "/shared/source_summary.md. Reuse the parent report where sufficient and perform "
+                        "new research only for the requested delta."
+                    )
 
                 return await submit_agent_job(
                     agent_type="deep_researcher",

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -347,16 +347,19 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
 
     async def _resolve_report_context_for_state(state: ChatResearcherState):
         from aiq_api.jobs.access import require_verified_principal
+        from aiq_api.jobs.report_context import report_context_from_markdown
         from aiq_api.jobs.report_context import resolve_authorized_report_context
 
-        if not state.active_report_job_id:
-            raise RuntimeError("Report follow-up requires active_report_job_id")
-        # Use the same auth contract as the HTTP report endpoints: this returns a
-        # synthesized no-auth principal when REQUIRE_AUTH=false (the public default)
-        # and a verified principal otherwise. Using get_current_principal() directly
-        # would raise for anonymous callers and break report follow-up over chat.
-        principal = require_verified_principal()
-        return await resolve_authorized_report_context(state.active_report_job_id, principal)
+        # Precedence: an explicit job id (UI/server) wins; otherwise use the report produced
+        # inline in this session (synchronous CLI), which needs no job store / scheduler.
+        if state.active_report_job_id:
+            # Same auth contract as the HTTP report endpoints: synthesizes a no-auth principal
+            # when REQUIRE_AUTH=false (the public default), a verified principal otherwise.
+            principal = require_verified_principal()
+            return await resolve_authorized_report_context(state.active_report_job_id, principal)
+        if state.last_report_markdown:
+            return report_context_from_markdown(state.last_report_markdown)
+        raise RuntimeError("Report follow-up requires an active report")
 
     async def _answer_report_question(state: ChatResearcherState) -> str:
         from aiq_agent.common import get_latest_user_query

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -303,14 +303,16 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
     deep_research_job_submitter = None
 
     async def _resolve_report_context_for_state(state: ChatResearcherState):
-        from aiq_agent.auth import get_current_principal
+        from aiq_api.jobs.access import require_verified_principal
         from aiq_api.jobs.report_context import resolve_authorized_report_context
 
         if not state.active_report_job_id:
             raise RuntimeError("Report follow-up requires active_report_job_id")
-        principal = get_current_principal()
-        if principal is None:
-            raise RuntimeError("Report follow-up requires an authenticated user")
+        # Use the same auth contract as the HTTP report endpoints: this returns a
+        # synthesized no-auth principal when REQUIRE_AUTH=false (the public default)
+        # and a verified principal otherwise. Using get_current_principal() directly
+        # would raise for anonymous callers and break report follow-up over chat.
+        principal = require_verified_principal()
         return await resolve_authorized_report_context(state.active_report_job_id, principal)
 
     async def _answer_report_question(state: ChatResearcherState) -> str:
@@ -327,17 +329,15 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
 
     async def _submit_report_edit_job(state: ChatResearcherState) -> str:
         from aiq_agent.auth import get_auth_token
-        from aiq_agent.auth import get_current_principal
         from aiq_agent.common import get_latest_user_query
+        from aiq_api.jobs.access import require_verified_principal
         from aiq_api.jobs.report_context import report_output_metadata
         from aiq_api.jobs.report_context import to_initial_files
         from aiq_api.jobs.submit import submit_agent_job
 
         report_context = await _resolve_report_context_for_state(state)
         instruction = get_latest_user_query(state.messages)
-        principal = get_current_principal()
-        if principal is None:
-            raise RuntimeError("Report edit requires an authenticated user")
+        principal = require_verified_principal()
         return await submit_agent_job(
             agent_type="report_rewriter",
             input_text=instruction,
@@ -347,6 +347,7 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
             auth_token=get_auth_token(),
             initial_files=to_initial_files(report_context, instruction=instruction),
             output_metadata=report_output_metadata(report_context.parent_job_id, "edit"),
+            allow_internal=True,
         )
 
     if config.use_async_deep_research:

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -52,6 +52,24 @@ logger = logging.getLogger(__name__)
 _ensure_otel_redaction_registered()
 
 
+def _build_report_ask_prompt(
+    *,
+    question: str,
+    report_markdown: str,
+    source_summary_markdown: str,
+) -> str:
+    """Build a bounded QA prompt for questions against an existing report."""
+
+    return (
+        "Answer using only the parent report and source summary below. "
+        "If the answer is not supported by the parent report, say that the report does not contain enough "
+        "information to answer. Keep the answer concise and preserve citations when referencing report claims.\n\n"
+        f"Question:\n{question}\n\n"
+        f"Parent source summary:\n{source_summary_markdown}\n\n"
+        f"Parent report:\n{report_markdown}"
+    )
+
+
 ########################################################
 # Intent Classifier
 ########################################################
@@ -249,12 +267,75 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
     callbacks = [VerboseTraceCallback()] if verbose else []
 
     deep_research_job_submitter = None
+
+    async def _resolve_report_context_for_state(state: ChatResearcherState):
+        from aiq_agent.auth import get_current_principal
+        from aiq_api.jobs.report_context import resolve_authorized_report_context
+
+        if not state.active_report_job_id:
+            raise RuntimeError("Report follow-up requires active_report_job_id")
+        principal = get_current_principal()
+        if principal is None:
+            raise RuntimeError("Report follow-up requires an authenticated user")
+        return await resolve_authorized_report_context(state.active_report_job_id, principal)
+
+    async def _answer_report_question(state: ChatResearcherState) -> str:
+        from aiq_agent.agents.shallow_researcher.models import ShallowResearchAgentState
+        from aiq_agent.common import get_latest_user_query
+
+        report_context = await _resolve_report_context_for_state(state)
+        question = get_latest_user_query(state.messages)
+        prompt = _build_report_ask_prompt(
+            question=question,
+            report_markdown=report_context.report_markdown,
+            source_summary_markdown=report_context.source_summary_markdown,
+        )
+        result = await shallow_research_fn.ainvoke(
+            ShallowResearchAgentState(
+                messages=[HumanMessage(content=prompt)],
+                data_sources=state.data_sources,
+                available_documents=state.available_documents,
+            )
+        )
+        if not result.messages:
+            raise RuntimeError("Report QA produced no response")
+        content = result.messages[-1].content
+        return content if isinstance(content, str) else str(content)
+
+    async def _submit_report_edit_job(state: ChatResearcherState) -> str:
+        from aiq_agent.auth import get_auth_token
+        from aiq_agent.auth import get_current_principal
+        from aiq_agent.common import get_latest_user_query
+        from aiq_api.jobs.report_context import to_initial_files
+        from aiq_api.jobs.submit import submit_agent_job
+
+        report_context = await _resolve_report_context_for_state(state)
+        instruction = get_latest_user_query(state.messages)
+        principal = get_current_principal()
+        if principal is None:
+            raise RuntimeError("Report edit requires an authenticated user")
+        return await submit_agent_job(
+            agent_type="report_rewriter",
+            input_text=instruction,
+            owner=principal.email or principal.sub,
+            principal=principal,
+            data_sources=[],
+            auth_token=get_auth_token(),
+            initial_files=to_initial_files(report_context, instruction=instruction),
+            output_metadata={
+                "parent_job_id": report_context.parent_job_id,
+                "interaction_action": "edit",
+                "result_kind": "report",
+            },
+        )
+
     if config.use_async_deep_research:
         import os
 
         # Check if Dask scheduler is available
         scheduler_address = os.environ.get("NAT_DASK_SCHEDULER_ADDRESS")
         if scheduler_address:
+            from aiq_agent.auth import get_auth_token
             from aiq_agent.auth import get_current_principal
             from aiq_api.jobs.submit import submit_agent_job
 
@@ -279,12 +360,39 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
                         len(available_docs),
                     )
 
+                initial_files = None
+                output_metadata = None
+                if (
+                    state.active_report_job_id
+                    and state.user_intent
+                    and state.user_intent.use_parent_report_context
+                ):
+                    from aiq_api.jobs.report_context import to_initial_files
+
+                    report_context = await _resolve_report_context_for_state(state)
+                    initial_files = to_initial_files(report_context)
+                    output_metadata = {
+                        "parent_job_id": report_context.parent_job_id,
+                        "interaction_action": "research",
+                        "result_kind": "report",
+                    }
+                    input_text = (
+                        f"{input_text}\n\n"
+                        "Use the seeded parent report context in /shared/original_report.md and "
+                        "/shared/source_summary.md. Reuse the parent report where sufficient and perform "
+                        "new research only for the requested delta."
+                    )
+
                 return await submit_agent_job(
                     agent_type="deep_researcher",
                     input_text=input_text,
                     owner=owner,
+                    principal=principal,
                     available_documents=available_docs,
                     data_sources=state.data_sources,
+                    auth_token=get_auth_token(),
+                    initial_files=initial_files,
+                    output_metadata=output_metadata,
                 )
 
             deep_research_job_submitter = _submit_deep_job
@@ -306,6 +414,8 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
         callbacks=callbacks,
         max_history=config.max_history,
         deep_research_job_submitter=deep_research_job_submitter,
+        report_ask_fn=_answer_report_question,
+        report_edit_job_submitter=_submit_report_edit_job,
         checkpointer=checkpointer,
         validate_deep_research_tools_fn=validate_deep_research_tools,
     )

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -15,6 +15,7 @@
 
 """NAT register function for chat researcher agent."""
 
+import asyncio
 import logging
 from typing import Any
 
@@ -48,6 +49,10 @@ from .models import ChatResearcherState
 from .utils import _extract_query_context
 
 logger = logging.getLogger(__name__)
+
+# Upper bound on the single bounded report-ask LLM call so a stalled provider
+# degrades to a graceful message instead of blocking the whole chat turn.
+_REPORT_ASK_TIMEOUT_S = 120
 
 _ensure_otel_redaction_registered()
 
@@ -88,7 +93,11 @@ async def _answer_from_report_context(
         report_markdown=report_markdown,
         source_summary_markdown=source_summary_markdown,
     )
-    response = await llm.ainvoke([HumanMessage(content=prompt)])
+    try:
+        response = await asyncio.wait_for(llm.ainvoke([HumanMessage(content=prompt)]), timeout=_REPORT_ASK_TIMEOUT_S)
+    except TimeoutError:
+        logger.warning("Report ask LLM call timed out after %ss", _REPORT_ASK_TIMEOUT_S)
+        return "The report service took too long to respond. Please try again."
     content = response.content if hasattr(response, "content") else response
     answer = content if isinstance(content, str) else str(content)
     if not answer.strip():
@@ -387,15 +396,27 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
                     from aiq_api.jobs.report_context import report_output_metadata
                     from aiq_api.jobs.report_context import to_initial_files
 
-                    report_context = await _resolve_report_context_for_state(state)
-                    initial_files = to_initial_files(report_context)
-                    output_metadata = report_output_metadata(report_context.parent_job_id, "research")
-                    input_text = (
-                        f"{input_text}\n\n"
-                        "Use the seeded parent report context in /shared/original_report.md and "
-                        "/shared/source_summary.md. Reuse the parent report where sufficient and perform "
-                        "new research only for the requested delta."
-                    )
+                    # Parent-context seeding is an optional enrichment. If durable context
+                    # resolution fails (e.g. 409/503), still run the delta research rather
+                    # than aborting the whole job.
+                    try:
+                        report_context = await _resolve_report_context_for_state(state)
+                    except Exception as e:
+                        logger.warning(
+                            "Parent report context unavailable for %s (error_type=%s); "
+                            "continuing without seeded context",
+                            state.active_report_job_id,
+                            type(e).__name__,
+                        )
+                    else:
+                        initial_files = to_initial_files(report_context)
+                        output_metadata = report_output_metadata(report_context.parent_job_id, "research")
+                        input_text = (
+                            f"{input_text}\n\n"
+                            "Use the seeded parent report context in /shared/original_report.md and "
+                            "/shared/source_summary.md. Reuse the parent report where sufficient and perform "
+                            "new research only for the requested delta."
+                        )
 
                 return await submit_agent_job(
                     agent_type="deep_researcher",

--- a/src/aiq_agent/agents/chat_researcher/register.py
+++ b/src/aiq_agent/agents/chat_researcher/register.py
@@ -465,12 +465,6 @@ async def chat_deepresearcher_agent(config: ChatDeepResearcherConfig, builder: B
                     report_context = await _resolve_report_context_for_state(state)
                     initial_files = to_initial_files(report_context)
                     output_metadata = report_output_metadata(report_context.parent_job_id, "research")
-                    input_text = (
-                        f"{input_text}\n\n"
-                        "Use the seeded parent report context in /shared/original_report.md and "
-                        "/shared/source_summary.md. Reuse the parent report where sufficient and perform "
-                        "new research only for the requested delta."
-                    )
 
                 return await submit_agent_job(
                     agent_type="deep_researcher",

--- a/src/aiq_agent/agents/chat_researcher/utils.py
+++ b/src/aiq_agent/agents/chat_researcher/utils.py
@@ -105,16 +105,6 @@ def _extract_text_from_message(message: Any) -> str | None:
     return None
 
 
-def _extract_query_from_text(text: str) -> tuple[str, list[str] | None]:
-    """Extract query text and data sources from a text payload.
-
-    Thin wrapper over :func:`_extract_context_from_text` (single source of truth) for
-    consumers that only need the (query, data_sources) pair. Currently exercised by tests.
-    """
-    context = _extract_context_from_text(text)
-    return (context.query_text, context.data_sources)
-
-
 def _clean_optional_string(value: Any) -> str | None:
     return value.strip() if isinstance(value, str) and value.strip() else None
 

--- a/src/aiq_agent/agents/chat_researcher/utils.py
+++ b/src/aiq_agent/agents/chat_researcher/utils.py
@@ -106,20 +106,13 @@ def _extract_text_from_message(message: Any) -> str | None:
 
 
 def _extract_query_from_text(text: str) -> tuple[str, list[str] | None]:
-    if not text:
-        return ("", None)
-    trimmed = text.strip()
-    if trimmed.startswith("{") and trimmed.endswith("}"):
-        try:
-            payload = json.loads(trimmed)
-        except json.JSONDecodeError:
-            return (text, None)
-        if isinstance(payload, dict):
-            data_sources = parse_data_sources(payload.get("data_sources"))
-            query_text = payload.get("query") or payload.get("text")
-            if isinstance(query_text, str) and query_text.strip():
-                return (query_text.strip(), data_sources)
-    return (text, None)
+    """Extract query text and data sources from a text payload.
+
+    Thin wrapper over :func:`_extract_context_from_text` (single source of truth) for
+    consumers that only need the (query, data_sources) pair. Currently exercised by tests.
+    """
+    context = _extract_context_from_text(text)
+    return (context.query_text, context.data_sources)
 
 
 def _clean_optional_string(value: Any) -> str | None:

--- a/src/aiq_agent/agents/chat_researcher/utils.py
+++ b/src/aiq_agent/agents/chat_researcher/utils.py
@@ -18,8 +18,17 @@ from typing import Any
 
 from langchain_core.messages import BaseMessage
 from langchain_core.messages import trim_messages
+from pydantic import BaseModel
 
 from aiq_agent.common import parse_data_sources
+
+
+class ChatRequestContext(BaseModel):
+    """Normalized chat request context extracted from NAT/OpenAI-style payloads."""
+
+    query_text: str
+    data_sources: list[str] | None = None
+    active_report_job_id: str | None = None
 
 
 def trim_message_history(messages: list[BaseMessage], max_tokens: int) -> list[BaseMessage]:
@@ -113,18 +122,46 @@ def _extract_query_from_text(text: str) -> tuple[str, list[str] | None]:
     return (text, None)
 
 
-def _extract_query_and_sources(payload: Any) -> tuple[str, list[str] | None]:
-    """Extract query text and data sources from various payload formats.
+def _clean_optional_string(value: Any) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _extract_context_from_text(text: str) -> ChatRequestContext:
+    if not text:
+        return ChatRequestContext(query_text="")
+    trimmed = text.strip()
+    if trimmed.startswith("{") and trimmed.endswith("}"):
+        try:
+            payload = json.loads(trimmed)
+        except json.JSONDecodeError:
+            return ChatRequestContext(query_text=text)
+        if isinstance(payload, dict):
+            query_text = payload.get("query") or payload.get("text")
+            if isinstance(query_text, str) and query_text.strip():
+                return ChatRequestContext(
+                    query_text=query_text.strip(),
+                    data_sources=parse_data_sources(payload.get("data_sources")),
+                    active_report_job_id=_clean_optional_string(payload.get("active_report_job_id")),
+                )
+    return ChatRequestContext(query_text=text)
+
+
+def _extract_query_context(payload: Any) -> ChatRequestContext:
+    """Extract query text, data sources, and active report context from payloads.
 
     Returns:
-        Tuple of (query_text, data_sources).
+        ChatRequestContext.
         - data_sources is None if not specified, meaning use all configured tools
         - data_sources is a list if explicitly specified (use only those)
+        - active_report_job_id is optional report context for router decisions
     """
     if isinstance(payload, dict):
         content = payload.get("content", {}) if isinstance(payload.get("content"), dict) else {}
         data_sources = parse_data_sources(payload.get("data_sources")) or parse_data_sources(
             content.get("data_sources")
+        )
+        active_report_job_id = _clean_optional_string(payload.get("active_report_job_id")) or _clean_optional_string(
+            content.get("active_report_job_id")
         )
         messages = content.get("messages", [])
         query_text = None
@@ -141,14 +178,20 @@ def _extract_query_and_sources(payload: Any) -> tuple[str, list[str] | None]:
                 payload.get("text")
             )
         if query_text:
-            inline_query, inline_sources = _extract_query_from_text(query_text)
-            query_text = inline_query
-            data_sources = data_sources or inline_sources
-        return (query_text or "", data_sources)
+            inline_context = _extract_context_from_text(query_text)
+            query_text = inline_context.query_text
+            data_sources = data_sources or inline_context.data_sources
+            active_report_job_id = active_report_job_id or inline_context.active_report_job_id
+        return ChatRequestContext(
+            query_text=query_text or "",
+            data_sources=data_sources,
+            active_report_job_id=active_report_job_id,
+        )
 
     messages = getattr(payload, "messages", None)
     if isinstance(messages, list):
         data_sources = parse_data_sources(getattr(payload, "data_sources", None))
+        active_report_job_id = _clean_optional_string(getattr(payload, "active_report_job_id", None))
         query_text = None
         for msg in reversed(messages):
             if _is_user_role(getattr(msg, "role", None)):
@@ -158,11 +201,21 @@ def _extract_query_and_sources(payload: Any) -> tuple[str, list[str] | None]:
         if not query_text and messages:
             query_text = _extract_text_from_message(messages[-1])
         if query_text:
-            inline_query, inline_sources = _extract_query_from_text(query_text)
-            query_text = inline_query
-            data_sources = data_sources or inline_sources
-        return (query_text or "", data_sources)
+            inline_context = _extract_context_from_text(query_text)
+            query_text = inline_context.query_text
+            data_sources = data_sources or inline_context.data_sources
+            active_report_job_id = active_report_job_id or inline_context.active_report_job_id
+        return ChatRequestContext(
+            query_text=query_text or "",
+            data_sources=data_sources,
+            active_report_job_id=active_report_job_id,
+        )
 
-    query_text = str(payload)
-    inline_query, inline_sources = _extract_query_from_text(query_text)
-    return (inline_query, inline_sources)
+    return _extract_context_from_text(str(payload))
+
+
+def _extract_query_and_sources(payload: Any) -> tuple[str, list[str] | None]:
+    """Compatibility wrapper returning only query text and data sources."""
+
+    context = _extract_query_context(payload)
+    return (context.query_text, context.data_sources)

--- a/src/aiq_agent/agents/chat_researcher/utils.py
+++ b/src/aiq_agent/agents/chat_researcher/utils.py
@@ -150,9 +150,11 @@ def _extract_query_context(payload: Any) -> ChatRequestContext:
     """
     if isinstance(payload, dict):
         content = payload.get("content", {}) if isinstance(payload.get("content"), dict) else {}
-        data_sources = parse_data_sources(payload.get("data_sources")) or parse_data_sources(
-            content.get("data_sources")
-        )
+        # Use `is None` (not `or`): an explicit empty list means "no data-source tools"
+        # and must be preserved rather than falling through to the nested/inline value.
+        data_sources = parse_data_sources(payload.get("data_sources"))
+        if data_sources is None:
+            data_sources = parse_data_sources(content.get("data_sources"))
         active_report_job_id = _clean_optional_string(payload.get("active_report_job_id")) or _clean_optional_string(
             content.get("active_report_job_id")
         )
@@ -173,7 +175,8 @@ def _extract_query_context(payload: Any) -> ChatRequestContext:
         if query_text:
             inline_context = _extract_context_from_text(query_text)
             query_text = inline_context.query_text
-            data_sources = data_sources or inline_context.data_sources
+            if data_sources is None:
+                data_sources = inline_context.data_sources
             active_report_job_id = active_report_job_id or inline_context.active_report_job_id
         return ChatRequestContext(
             query_text=query_text or "",
@@ -196,7 +199,8 @@ def _extract_query_context(payload: Any) -> ChatRequestContext:
         if query_text:
             inline_context = _extract_context_from_text(query_text)
             query_text = inline_context.query_text
-            data_sources = data_sources or inline_context.data_sources
+            if data_sources is None:
+                data_sources = inline_context.data_sources
             active_report_job_id = active_report_job_id or inline_context.active_report_job_id
         return ChatRequestContext(
             query_text=query_text or "",

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -232,6 +232,9 @@ class DeepResearcherAgent:
         """
         Execute deep research with multi-phase workflow.
         """
+        prepared_files = self.deepagents_runtime.prepare_state_files(dict(state.files))
+        if prepared_files != state.files:
+            state = state.model_copy(update={"files": prepared_files})
         agent = self._build_orchestrator_agent(state)
 
         messages = state.messages

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import re
 from collections.abc import Callable
@@ -31,6 +32,7 @@ from langchain_core.tools import BaseTool
 from aiq_agent.common import LLMProvider
 from aiq_agent.common import load_prompt
 from aiq_agent.common.citation_verification import EmptySourceRegistryError
+from aiq_agent.common.citation_verification import SourceEntry
 from aiq_agent.common.citation_verification import sanitize_report
 from aiq_agent.common.citation_verification import verify_citations
 
@@ -48,6 +50,7 @@ from .tools.source_tool_batching import DEFAULT_MAX_SOURCE_TOOL_BATCH_SIZE
 logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_RESEARCH_CONCURRENCY = 6
+PARENT_REPORT_CONTEXT_PATH = "/shared/parent_report_context.json"
 
 # Path to this agent's directory (for loading prompts)
 AGENT_DIR = Path(__file__).parent
@@ -217,6 +220,55 @@ class DeepResearcherAgent:
         return stripped
 
     @staticmethod
+    def _read_seed_file_text(files: dict[str, Any], path: str) -> str | None:
+        entry = files.get(path)
+        if isinstance(entry, dict):
+            entry = entry.get("content")
+        if isinstance(entry, bytes):
+            entry = entry.decode("utf-8")
+        return entry if isinstance(entry, str) and entry.strip() else None
+
+    def _seed_parent_sources(self, files: dict[str, Any]) -> None:
+        """Register parent report sources so preserved citations verify in delta reports."""
+        context_text = self._read_seed_file_text(files, PARENT_REPORT_CONTEXT_PATH)
+        if not context_text:
+            return
+        try:
+            context = json.loads(context_text)
+        except json.JSONDecodeError:
+            logger.warning("Could not parse %s for parent source seeding", PARENT_REPORT_CONTEXT_PATH)
+            return
+
+        sources = context.get("sources")
+        if not isinstance(sources, list):
+            return
+
+        parent_sources: list[SourceEntry] = []
+        for source in sources:
+            if not isinstance(source, dict):
+                continue
+            url = source.get("url")
+            citation_key = source.get("citation_key")
+            if not isinstance(url, str):
+                url = None
+            if not isinstance(citation_key, str):
+                citation_key = None
+            if not url and not citation_key:
+                continue
+            title = source.get("title")
+            entry = SourceEntry(
+                url=url,
+                citation_key=citation_key,
+                title=title if isinstance(title, str) else None,
+                source_type=str(source.get("source_type") or "parent_report"),
+                tool_name=str(source.get("tool_name") or "parent_report"),
+            )
+            parent_sources.append(entry)
+        seeded = self.source_registry_middleware.register_compact_sources(parent_sources)
+        if seeded:
+            logger.info("Seeded %d parent report source(s) into citation registry", seeded)
+
+    @staticmethod
     def _replace_last_message_content(result: dict | Any, content: str) -> None:
         """Overwrite the final message content in-place with post-processed Markdown."""
         messages = result.get("messages") if isinstance(result, dict) else getattr(result, "messages", None)
@@ -235,6 +287,7 @@ class DeepResearcherAgent:
         prepared_files = self.deepagents_runtime.prepare_state_files(dict(state.files))
         if prepared_files != state.files:
             state = state.model_copy(update={"files": prepared_files})
+        self._seed_parent_sources(state.files)
         agent = self._build_orchestrator_agent(state)
 
         messages = state.messages

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import re
 from collections.abc import Callable
@@ -32,8 +31,8 @@ from langchain_core.tools import BaseTool
 from aiq_agent.common import LLMProvider
 from aiq_agent.common import load_prompt
 from aiq_agent.common.citation_verification import EmptySourceRegistryError
-from aiq_agent.common.citation_verification import SourceEntry
 from aiq_agent.common.citation_verification import sanitize_report
+from aiq_agent.common.citation_verification import source_entries_from_parent_context
 from aiq_agent.common.citation_verification import verify_citations
 
 from .custom_middleware import SourceRegistryMiddleware
@@ -233,37 +232,7 @@ class DeepResearcherAgent:
         context_text = self._read_seed_file_text(files, PARENT_REPORT_CONTEXT_PATH)
         if not context_text:
             return
-        try:
-            context = json.loads(context_text)
-        except json.JSONDecodeError:
-            logger.warning("Could not parse %s for parent source seeding", PARENT_REPORT_CONTEXT_PATH)
-            return
-
-        sources = context.get("sources")
-        if not isinstance(sources, list):
-            return
-
-        parent_sources: list[SourceEntry] = []
-        for source in sources:
-            if not isinstance(source, dict):
-                continue
-            url = source.get("url")
-            citation_key = source.get("citation_key")
-            if not isinstance(url, str):
-                url = None
-            if not isinstance(citation_key, str):
-                citation_key = None
-            if not url and not citation_key:
-                continue
-            title = source.get("title")
-            entry = SourceEntry(
-                url=url,
-                citation_key=citation_key,
-                title=title if isinstance(title, str) else None,
-                source_type=str(source.get("source_type") or "parent_report"),
-                tool_name=str(source.get("tool_name") or "parent_report"),
-            )
-            parent_sources.append(entry)
+        parent_sources = source_entries_from_parent_context(context_text)
         seeded = self.source_registry_middleware.register_compact_sources(parent_sources)
         if seeded:
             logger.info("Seeded %d parent report source(s) into citation registry", seeded)

--- a/src/aiq_agent/agents/deep_researcher/custom_middleware.py
+++ b/src/aiq_agent/agents/deep_researcher/custom_middleware.py
@@ -352,6 +352,19 @@ class SourceRegistryMiddleware(AgentMiddleware):
                 if isinstance(locator, str) and locator.strip():
                     self._compact_source_keys.add(self._locator_key(locator))
 
+    def register_compact_sources(self, sources: list[SourceEntry]) -> int:
+        """Register seeded sources and expose them in the compact citation source list."""
+        registry = self.active_registry()
+        registered = 0
+        for source in sources:
+            key = self._entry_key(source)
+            if not key:
+                continue
+            registry.add(source)
+            self._compact_source_keys.add(key)
+            registered += 1
+        return registered
+
     async def awrap_tool_call(self, request, handler):
         """Capture sources from tool results after execution.
 

--- a/src/aiq_agent/agents/deep_researcher/deepagents_runtime.py
+++ b/src/aiq_agent/agents/deep_researcher/deepagents_runtime.py
@@ -28,6 +28,7 @@ from uuid import uuid4
 from deepagents.backends import CompositeBackend
 from deepagents.backends import FilesystemBackend
 from deepagents.backends import StateBackend
+from deepagents.backends.state import create_file_data
 from pydantic import ConfigDict
 from pydantic import Field
 from pydantic import field_validator
@@ -228,6 +229,10 @@ class DeepAgentsRuntime:
         if provider is not None and hasattr(provider, "terminate"):
             provider.terminate()
 
+    def prepare_state_files(self, files: dict[str, Any]) -> dict[str, Any]:
+        """Normalize seeded virtual filesystem files for the configured backend."""
+        return _normalize_state_files(files, strip_shared_route=self._sandbox is not None)
+
 
 def _build_backend(
     *,
@@ -283,6 +288,33 @@ def _maybe_build_artifact_manager(
 def _skills_backend() -> FilesystemBackend:
     """Return the filesystem-backed built-in skills route."""
     return FilesystemBackend(root_dir=BUILTIN_SKILLS_DIR.resolve(), virtual_mode=True)
+
+
+def _normalize_state_files(files: dict[str, Any], *, strip_shared_route: bool) -> dict[str, Any]:
+    """Return files in the shape expected by DeepAgents StateBackend.
+
+    CompositeBackend strips a matched route before delegating to the route backend.
+    When /shared/ is backed by StateBackend, seeded files must therefore be stored
+    at the route-local path so reads for /shared/foo.md find /foo.md internally.
+    """
+    normalized: dict[str, Any] = {}
+    for file_path, file_data in files.items():
+        normalized_path = file_path
+        if strip_shared_route and file_path == SHARED_ROUTE.rstrip("/"):
+            normalized_path = "/"
+        elif strip_shared_route and file_path.startswith(SHARED_ROUTE):
+            normalized_path = f"/{file_path.removeprefix(SHARED_ROUTE)}"
+        normalized[normalized_path] = _normalize_file_data(file_data)
+    return normalized
+
+
+def _normalize_file_data(file_data: Any) -> Any:
+    """Return a DeepAgents file-data dict for raw seeded content."""
+    if isinstance(file_data, dict):
+        return file_data
+    if isinstance(file_data, bytes):
+        file_data = file_data.decode("utf-8")
+    return create_file_data(str(file_data))
 
 
 def discover_skill_collections(root: Path = BUILTIN_SKILLS_DIR) -> dict[str, str]:

--- a/src/aiq_agent/agents/deep_researcher/factory.py
+++ b/src/aiq_agent/agents/deep_researcher/factory.py
@@ -74,6 +74,12 @@ PLANNER_AGENT = "planner-agent"
 RESEARCHER_AGENT = "researcher-agent"
 SOURCE_ROUTER_AGENT = "source-router-agent"
 WRITER_AGENT = "writer-agent"
+PARENT_REPORT_CONTEXT_FILES = frozenset(
+    {
+        "/shared/original_report.md",
+        "/shared/parent_report_context.json",
+    }
+)
 
 
 @tool
@@ -127,6 +133,10 @@ class DeepResearchGraphContext:
     def available_documents(self) -> list[dict[str, Any]]:
         """Return the user-uploaded documents for this run as serialized dicts."""
         return [doc.model_dump() for doc in (self.state.available_documents or [])]
+
+    @property
+    def parent_report_context_available(self) -> bool:
+        return any(path in self.state.files for path in PARENT_REPORT_CONTEXT_FILES)
 
     def render_prompt(self, prompt_name: str, **values: Any) -> str:
         """Render a named prompt template with shared context plus any overrides."""
@@ -412,6 +422,7 @@ def build_deep_research_subagents(context: DeepResearchGraphContext) -> list[dic
             role=LLMRole.REPORT_WRITER,
             tools=context.tool_set.writer_tools,
             middleware=context.middleware_set.writer,
+            prompt_values={"parent_report_context_available": context.parent_report_context_available},
             skills=context.skill_sources(WRITER_AGENT),
         ),
     )
@@ -483,6 +494,7 @@ def build_deep_research_graph(
             enable_source_router=context.enable_source_router,
             max_research_concurrency=context.max_research_concurrency,
             execution_enabled=context.runtime.execution_enabled,
+            parent_report_context_available=context.parent_report_context_available,
         ),
         subagents=build_deep_research_subagents(context),
         store=InMemoryStore(),

--- a/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
@@ -20,6 +20,19 @@ Research is handled through the `run_research_batch` tool.
 {% endif %}
 - `write_file` cannot overwrite an existing file. To revise, use `edit_file` or write to a new path.
 
+{% if parent_report_context_available %}
+## Parent Report Delta Mode
+
+Parent report context is mounted in `/shared/`:
+- `/shared/original_report.md` contains the parent report.
+- `/shared/source_summary.md` contains the parent report's source summary when available.
+- `/shared/parent_report_context.json` contains parent source metadata when available.
+
+Treat the user request as a delta rewrite of the parent report. Research only what is needed for the requested delta, then have writer-agent merge the new evidence with the reusable parent report material.
+
+The final answer must be a complete standalone revised report. Do not return a research plan, insertion plan, patch, diff, commentary, or explanation of how to rewrite the report.
+{% endif %}
+
 ## Sequential Handoffs
 
 Dependent workflow steps must be serialized.
@@ -89,6 +102,10 @@ When calling task() for planner-agent, use this format:
 Create a research plan for the following user request:
 <paste user's complete request here verbatim>
 
+{% if parent_report_context_available %}
+This is a parent-report delta run. Plan only the requested delta research needed to revise `/shared/original_report.md`; do not plan a fresh report from scratch unless the user explicitly asks for one.
+{% endif %}
+
 {% if enable_source_router %}
 Read /shared/source_routing.json if it exists and use it as advisory source guidance.
 {% endif %}
@@ -112,6 +129,10 @@ When calling task() for writer-agent, use this format:
 Synthesize the final answer for the user request using the files already written to /shared/.
 
 Read /shared/plan.json, all research note files under /shared/, and the verified sources.
+{% if parent_report_context_available %}
+Also read /shared/original_report.md and /shared/source_summary.md. Preserve supported parent-report material where it still applies, incorporate the requested delta evidence, and write a complete standalone revised report.
+Do not produce an insertion plan, patch, or explanation of the rewrite.
+{% endif %}
 Before writing, inspect Available Skills. If an applicable writer skill exists, read its SKILL.md first and use it as the controlling synthesis protocol.
 Do not draft the final answer until that skill has been read. Synthesize a final response from the detailed research context.
 For broad reports, produce a cross-synthesized narrative with developed paragraphs; do not compress the answer into a checklist of short component summaries unless the user asked for that format.

--- a/src/aiq_agent/agents/deep_researcher/prompts/writer.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/writer.j2
@@ -30,8 +30,20 @@ Read these inputs before writing:
 - `/shared/plan.json`
 - Every `ResearchNotes` JSON file under `/shared/`, excluding `/shared/plan.json`, `/shared/source_routing.json`, and `/shared/output.md`
 - The compact result of `get_verified_sources`
+{% if parent_report_context_available %}
+- `/shared/original_report.md`
+- `/shared/source_summary.md` when available
+{% endif %}
 
 If an expected research note is missing, name that as a gap in the final answer when it affects the answer.
+
+{% if parent_report_context_available %}
+## Parent Report Delta Mode
+
+Use the parent report as the base document. Preserve supported parent-report material where it still applies, merge in the new delta evidence, and produce a complete standalone revised report.
+
+Do not return a research plan, insertion plan, patch, diff, commentary, or explanation of how to rewrite the report.
+{% endif %}
 
 ## Synthesis Contract
 - Follow `answer_strategy.answer_type`, `answer_strategy.title`, `answer_strategy.required_components`, and `constraints`.

--- a/src/aiq_agent/agents/report_rewriter/__init__.py
+++ b/src/aiq_agent/agents/report_rewriter/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal report rewriter agent used by report follow-up jobs."""
+
+from .agent import ReportRewriterAgent
+from .models import ReportRewriterAgentState
+
+__all__ = ["ReportRewriterAgent", "ReportRewriterAgentState"]

--- a/src/aiq_agent/agents/report_rewriter/agent.py
+++ b/src/aiq_agent/agents/report_rewriter/agent.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import Sequence
 from pathlib import Path
@@ -19,6 +20,10 @@ from aiq_agent.common import LLMProvider
 from aiq_agent.common import LLMRole
 from aiq_agent.common import load_prompt
 from aiq_agent.common import render_prompt_template
+from aiq_agent.common.citation_verification import SourceEntry
+from aiq_agent.common.citation_verification import SourceRegistry
+from aiq_agent.common.citation_verification import sanitize_report
+from aiq_agent.common.citation_verification import verify_citations
 
 from .models import ReportRewriterAgentState
 
@@ -32,6 +37,60 @@ EDIT_INSTRUCTION_PATH = "/shared/edit_instruction.txt"
 OUTPUT_REPORT_PATH = "/shared/output.md"
 
 _DEFAULT_SOURCE_SUMMARY = "No durable source metadata was found for the parent report."
+
+
+def _source_text(value: Any) -> str | None:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return None
+
+
+def _source_entries_from_parent_context(parent_context: str) -> list[SourceEntry]:
+    try:
+        payload = json.loads(parent_context)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(payload, dict):
+        return []
+    raw_sources = payload.get("sources")
+    if not isinstance(raw_sources, list):
+        return []
+
+    entries: list[SourceEntry] = []
+    for raw_source in raw_sources:
+        if not isinstance(raw_source, dict):
+            continue
+        url = _source_text(raw_source.get("url"))
+        citation_key = _source_text(raw_source.get("citation_key"))
+        if not (url or citation_key):
+            continue
+        entries.append(
+            SourceEntry(
+                url=url,
+                citation_key=citation_key,
+                title=_source_text(raw_source.get("title")),
+                source_type=_source_text(raw_source.get("source_type")) or "parent_report",
+                tool_name=_source_text(raw_source.get("tool_name")) or "parent_report",
+            )
+        )
+    return entries
+
+
+def _post_process_revised_report(revised_report: str, parent_sources: Sequence[SourceEntry]) -> str:
+    if parent_sources:
+        registry = SourceRegistry()
+        for source in parent_sources:
+            registry.add(source)
+        verification = verify_citations(revised_report, registry, reference_sources=parent_sources)
+        if verification.removed_citations:
+            logger.info(
+                "Report rewrite citation verification removed %d invalid citation(s)",
+                len(verification.removed_citations),
+            )
+        revised_report = verification.verified_report
+
+    return sanitize_report(revised_report).sanitized_report
 
 
 async def rewrite_report(
@@ -71,7 +130,10 @@ async def rewrite_report(
     revised_report = revised_report.strip()
     if not revised_report:
         raise ValueError("Report writer returned an empty revised report")
-    return revised_report
+    return _post_process_revised_report(
+        revised_report,
+        parent_sources=_source_entries_from_parent_context(parent_context),
+    )
 
 
 class ReportRewriterAgent:

--- a/src/aiq_agent/agents/report_rewriter/agent.py
+++ b/src/aiq_agent/agents/report_rewriter/agent.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal report rewriter agent."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from langchain_core.messages import AIMessage
+from langchain_core.messages import HumanMessage
+from langchain_core.messages import SystemMessage
+from langchain_core.tools import BaseTool
+
+from aiq_agent.common import LLMProvider
+from aiq_agent.common import LLMRole
+from aiq_agent.common import load_prompt
+from aiq_agent.common import render_prompt_template
+
+from .models import ReportRewriterAgentState
+
+logger = logging.getLogger(__name__)
+
+AGENT_DIR = Path(__file__).parent
+ORIGINAL_REPORT_PATH = "/shared/original_report.md"
+SOURCE_SUMMARY_PATH = "/shared/source_summary.md"
+PARENT_CONTEXT_PATH = "/shared/parent_report_context.json"
+EDIT_INSTRUCTION_PATH = "/shared/edit_instruction.txt"
+OUTPUT_REPORT_PATH = "/shared/output.md"
+
+
+class ReportRewriterAgent:
+    """Rewrite a completed parent report into a full revised child report."""
+
+    def __init__(
+        self,
+        llm_provider: LLMProvider,
+        tools: Sequence[BaseTool] | None = None,
+        *,
+        verbose: bool = False,
+        callbacks: list[Any] | None = None,
+        config: Any | None = None,
+        job_id: str | None = None,
+    ) -> None:
+        self.llm_provider = llm_provider
+        self.tools = list(tools or [])
+        self.verbose = verbose
+        self.callbacks = callbacks or []
+        self.config = config
+        self.job_id = job_id
+        self.system_prompt = load_prompt(AGENT_DIR / "prompts", "edit")
+
+    @staticmethod
+    def _read_text_file(files: dict[str, Any], path: str) -> str | None:
+        value = files.get(path)
+        if isinstance(value, dict):
+            value = value.get("content")
+        if isinstance(value, bytes):
+            value = value.decode("utf-8")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        return None
+
+    @staticmethod
+    def _latest_user_message(state: ReportRewriterAgentState) -> str:
+        for message in reversed(state.messages):
+            if isinstance(message, HumanMessage):
+                content = message.content
+                return content if isinstance(content, str) else str(content)
+        return ""
+
+    async def run(self, state: ReportRewriterAgentState) -> ReportRewriterAgentState:
+        original_report = self._read_text_file(state.files, ORIGINAL_REPORT_PATH)
+        if original_report is None:
+            raise ValueError(f"Report rewrite requires {ORIGINAL_REPORT_PATH}")
+
+        instruction = self._read_text_file(state.files, EDIT_INSTRUCTION_PATH) or self._latest_user_message(state)
+        if not instruction.strip():
+            raise ValueError("Report rewrite requires a non-empty edit instruction")
+
+        source_summary = self._read_text_file(state.files, SOURCE_SUMMARY_PATH) or (
+            "No durable source metadata was found for the parent report."
+        )
+        parent_context = self._read_text_file(state.files, PARENT_CONTEXT_PATH) or "{}"
+
+        rendered_prompt = render_prompt_template(
+            self.system_prompt,
+            original_report=original_report,
+            source_summary=source_summary,
+            parent_context=parent_context,
+            edit_instruction=instruction.strip(),
+        )
+
+        response = await self.llm_provider.get(LLMRole.REPORT_WRITER).ainvoke(
+            [
+                SystemMessage(content=rendered_prompt),
+                HumanMessage(content=instruction.strip()),
+            ]
+        )
+        revised_report = response.content if hasattr(response, "content") else str(response)
+        revised_report = revised_report if isinstance(revised_report, str) else str(revised_report)
+        revised_report = revised_report.strip()
+        if not revised_report:
+            raise ValueError("Report writer returned an empty revised report")
+
+        for callback in self.callbacks:
+            if hasattr(callback, "emit_final_report"):
+                callback.emit_final_report(revised_report)
+                break
+
+        files = dict(state.files)
+        files[OUTPUT_REPORT_PATH] = revised_report
+        logger.info("Report rewrite complete (job_id=%s, chars=%d)", self.job_id, len(revised_report))
+        return ReportRewriterAgentState(
+            messages=[*state.messages, AIMessage(content=revised_report)],
+            files=files,
+        )

--- a/src/aiq_agent/agents/report_rewriter/agent.py
+++ b/src/aiq_agent/agents/report_rewriter/agent.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from collections.abc import Sequence
 from pathlib import Path
@@ -14,7 +13,6 @@ from typing import Any
 from langchain_core.messages import AIMessage
 from langchain_core.messages import HumanMessage
 from langchain_core.messages import SystemMessage
-from langchain_core.tools import BaseTool
 
 from aiq_agent.common import LLMProvider
 from aiq_agent.common import LLMRole
@@ -25,6 +23,7 @@ from aiq_agent.common.citation_verification import SourceRegistry
 from aiq_agent.common.citation_verification import extract_source_entries_from_report
 from aiq_agent.common.citation_verification import report_has_citations
 from aiq_agent.common.citation_verification import sanitize_report
+from aiq_agent.common.citation_verification import source_entries_from_parent_context
 from aiq_agent.common.citation_verification import verify_citations
 
 from .models import ReportRewriterAgentState
@@ -41,48 +40,10 @@ OUTPUT_REPORT_PATH = "/shared/output.md"
 _DEFAULT_SOURCE_SUMMARY = "No durable source metadata was found for the parent report."
 
 
-def _source_text(value: Any) -> str | None:
-    if isinstance(value, str):
-        stripped = value.strip()
-        return stripped or None
-    return None
-
-
-def _source_entries_from_parent_context(parent_context: str) -> list[SourceEntry]:
-    try:
-        payload = json.loads(parent_context)
-    except json.JSONDecodeError:
-        return []
-    if not isinstance(payload, dict):
-        return []
-    raw_sources = payload.get("sources")
-    if not isinstance(raw_sources, list):
-        return []
-
-    entries: list[SourceEntry] = []
-    for raw_source in raw_sources:
-        if not isinstance(raw_source, dict):
-            continue
-        url = _source_text(raw_source.get("url"))
-        citation_key = _source_text(raw_source.get("citation_key"))
-        if not (url or citation_key):
-            continue
-        entries.append(
-            SourceEntry(
-                url=url,
-                citation_key=citation_key,
-                title=_source_text(raw_source.get("title")),
-                source_type=_source_text(raw_source.get("source_type")) or "parent_report",
-                tool_name=_source_text(raw_source.get("tool_name")) or "parent_report",
-            )
-        )
-    return entries
-
-
 def _effective_parent_sources(original_report: str, parent_context: str) -> list[SourceEntry]:
     """Build the rewrite allowlist from the canonical report and durable context."""
     report_sources = extract_source_entries_from_report(original_report)
-    context_sources = _source_entries_from_parent_context(parent_context)
+    context_sources = source_entries_from_parent_context(parent_context)
     if report_has_citations(original_report) and not (report_sources or context_sources):
         raise ValueError("Cannot rewrite a cited parent report because it cannot reconstruct its source registry")
 
@@ -159,14 +120,13 @@ class ReportRewriterAgent:
     def __init__(
         self,
         llm_provider: LLMProvider,
-        tools: Sequence[BaseTool] | None = None,
+        tools: Sequence[Any] | None = None,
         *,
         verbose: bool = False,
         callbacks: list[Any] | None = None,
         job_id: str | None = None,
     ) -> None:
         self.llm_provider = llm_provider
-        self.tools = list(tools or [])
         self.verbose = verbose
         self.callbacks = callbacks or []
         self.job_id = job_id

--- a/src/aiq_agent/agents/report_rewriter/agent.py
+++ b/src/aiq_agent/agents/report_rewriter/agent.py
@@ -22,6 +22,8 @@ from aiq_agent.common import load_prompt
 from aiq_agent.common import render_prompt_template
 from aiq_agent.common.citation_verification import SourceEntry
 from aiq_agent.common.citation_verification import SourceRegistry
+from aiq_agent.common.citation_verification import extract_source_entries_from_report
+from aiq_agent.common.citation_verification import report_has_citations
 from aiq_agent.common.citation_verification import sanitize_report
 from aiq_agent.common.citation_verification import verify_citations
 
@@ -77,6 +79,19 @@ def _source_entries_from_parent_context(parent_context: str) -> list[SourceEntry
     return entries
 
 
+def _effective_parent_sources(original_report: str, parent_context: str) -> list[SourceEntry]:
+    """Build the rewrite allowlist from the canonical report and durable context."""
+    report_sources = extract_source_entries_from_report(original_report)
+    context_sources = _source_entries_from_parent_context(parent_context)
+    if report_has_citations(original_report) and not (report_sources or context_sources):
+        raise ValueError("Cannot rewrite a cited parent report because it cannot reconstruct its source registry")
+
+    registry = SourceRegistry()
+    for source in [*report_sources, *context_sources]:
+        registry.add(source)
+    return registry.all_sources()
+
+
 def _post_process_revised_report(revised_report: str, parent_sources: Sequence[SourceEntry]) -> str:
     if parent_sources:
         registry = SourceRegistry()
@@ -89,6 +104,8 @@ def _post_process_revised_report(revised_report: str, parent_sources: Sequence[S
                 len(verification.removed_citations),
             )
         revised_report = verification.verified_report
+    elif report_has_citations(revised_report):
+        raise ValueError("Cannot publish a rewritten report with citations without a verified parent source registry")
 
     return sanitize_report(revised_report).sanitized_report
 
@@ -132,7 +149,7 @@ async def rewrite_report(
         raise ValueError("Report writer returned an empty revised report")
     return _post_process_revised_report(
         revised_report,
-        parent_sources=_source_entries_from_parent_context(parent_context),
+        parent_sources=_effective_parent_sources(original_report, parent_context),
     )
 
 

--- a/src/aiq_agent/agents/report_rewriter/agent.py
+++ b/src/aiq_agent/agents/report_rewriter/agent.py
@@ -31,6 +31,48 @@ PARENT_CONTEXT_PATH = "/shared/parent_report_context.json"
 EDIT_INSTRUCTION_PATH = "/shared/edit_instruction.txt"
 OUTPUT_REPORT_PATH = "/shared/output.md"
 
+_DEFAULT_SOURCE_SUMMARY = "No durable source metadata was found for the parent report."
+
+
+async def rewrite_report(
+    *,
+    llm: Any,
+    original_report: str,
+    edit_instruction: str,
+    source_summary: str = _DEFAULT_SOURCE_SUMMARY,
+    parent_context: str = "{}",
+    system_prompt: str | None = None,
+) -> str:
+    """Rewrite a report per an edit instruction with one bounded LLM call.
+
+    Shared by the async ``report_rewriter`` job and the synchronous in-session CLI edit path so
+    both produce identical revisions. Needs no filesystem, job store, or scheduler.
+    """
+    instruction = (edit_instruction or "").strip()
+    if not instruction:
+        raise ValueError("Report rewrite requires a non-empty edit instruction")
+    if system_prompt is None:
+        system_prompt = load_prompt(AGENT_DIR / "prompts", "edit")
+    rendered_prompt = render_prompt_template(
+        system_prompt,
+        original_report=original_report,
+        source_summary=source_summary,
+        parent_context=parent_context,
+        edit_instruction=instruction,
+    )
+    response = await llm.ainvoke(
+        [
+            SystemMessage(content=rendered_prompt),
+            HumanMessage(content=instruction),
+        ]
+    )
+    revised_report = response.content if hasattr(response, "content") else str(response)
+    revised_report = revised_report if isinstance(revised_report, str) else str(revised_report)
+    revised_report = revised_report.strip()
+    if not revised_report:
+        raise ValueError("Report writer returned an empty revised report")
+    return revised_report
+
 
 class ReportRewriterAgent:
     """Rewrite a completed parent report into a full revised child report."""
@@ -80,33 +122,18 @@ class ReportRewriterAgent:
         instruction = (
             self._read_text_file(state.files, EDIT_INSTRUCTION_PATH) or self._latest_user_message(state)
         ).strip()
-        if not instruction:
-            raise ValueError("Report rewrite requires a non-empty edit instruction")
 
-        source_summary = self._read_text_file(state.files, SOURCE_SUMMARY_PATH) or (
-            "No durable source metadata was found for the parent report."
-        )
+        source_summary = self._read_text_file(state.files, SOURCE_SUMMARY_PATH) or _DEFAULT_SOURCE_SUMMARY
         parent_context = self._read_text_file(state.files, PARENT_CONTEXT_PATH) or "{}"
 
-        rendered_prompt = render_prompt_template(
-            self.system_prompt,
+        revised_report = await rewrite_report(
+            llm=self.llm_provider.get(LLMRole.REPORT_WRITER),
             original_report=original_report,
+            edit_instruction=instruction,
             source_summary=source_summary,
             parent_context=parent_context,
-            edit_instruction=instruction,
+            system_prompt=self.system_prompt,
         )
-
-        response = await self.llm_provider.get(LLMRole.REPORT_WRITER).ainvoke(
-            [
-                SystemMessage(content=rendered_prompt),
-                HumanMessage(content=instruction),
-            ]
-        )
-        revised_report = response.content if hasattr(response, "content") else str(response)
-        revised_report = revised_report if isinstance(revised_report, str) else str(revised_report)
-        revised_report = revised_report.strip()
-        if not revised_report:
-            raise ValueError("Report writer returned an empty revised report")
 
         for callback in self.callbacks:
             if hasattr(callback, "emit_final_report"):

--- a/src/aiq_agent/agents/report_rewriter/agent.py
+++ b/src/aiq_agent/agents/report_rewriter/agent.py
@@ -84,14 +84,12 @@ class ReportRewriterAgent:
         *,
         verbose: bool = False,
         callbacks: list[Any] | None = None,
-        config: Any | None = None,
         job_id: str | None = None,
     ) -> None:
         self.llm_provider = llm_provider
         self.tools = list(tools or [])
         self.verbose = verbose
         self.callbacks = callbacks or []
-        self.config = config
         self.job_id = job_id
         self.system_prompt = load_prompt(AGENT_DIR / "prompts", "edit")
 

--- a/src/aiq_agent/agents/report_rewriter/agent.py
+++ b/src/aiq_agent/agents/report_rewriter/agent.py
@@ -77,8 +77,10 @@ class ReportRewriterAgent:
         if original_report is None:
             raise ValueError(f"Report rewrite requires {ORIGINAL_REPORT_PATH}")
 
-        instruction = self._read_text_file(state.files, EDIT_INSTRUCTION_PATH) or self._latest_user_message(state)
-        if not instruction.strip():
+        instruction = (
+            self._read_text_file(state.files, EDIT_INSTRUCTION_PATH) or self._latest_user_message(state)
+        ).strip()
+        if not instruction:
             raise ValueError("Report rewrite requires a non-empty edit instruction")
 
         source_summary = self._read_text_file(state.files, SOURCE_SUMMARY_PATH) or (
@@ -91,13 +93,13 @@ class ReportRewriterAgent:
             original_report=original_report,
             source_summary=source_summary,
             parent_context=parent_context,
-            edit_instruction=instruction.strip(),
+            edit_instruction=instruction,
         )
 
         response = await self.llm_provider.get(LLMRole.REPORT_WRITER).ainvoke(
             [
                 SystemMessage(content=rendered_prompt),
-                HumanMessage(content=instruction.strip()),
+                HumanMessage(content=instruction),
             ]
         )
         revised_report = response.content if hasattr(response, "content") else str(response)

--- a/src/aiq_agent/agents/report_rewriter/agent.py
+++ b/src/aiq_agent/agents/report_rewriter/agent.py
@@ -111,7 +111,6 @@ class ReportRewriterAgent:
         for callback in self.callbacks:
             if hasattr(callback, "emit_final_report"):
                 callback.emit_final_report(revised_report)
-                break
 
         files = dict(state.files)
         files[OUTPUT_REPORT_PATH] = revised_report

--- a/src/aiq_agent/agents/report_rewriter/models.py
+++ b/src/aiq_agent/agents/report_rewriter/models.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""State models for the internal report rewriter agent."""
+
+from __future__ import annotations
+
+from typing import Annotated
+from typing import Any
+
+from langchain_core.messages import AnyMessage
+from langgraph.graph.message import add_messages
+from pydantic import BaseModel
+from pydantic import Field
+
+
+def _merge_dict_state(left: dict[str, Any] | None, right: dict[str, Any] | None) -> dict[str, Any]:
+    if not left:
+        return right or {}
+    if not right:
+        return left
+    merged = dict(left)
+    merged.update(right)
+    return merged
+
+
+class ReportRewriterAgentState(BaseModel):
+    """State for report rewrite child jobs."""
+
+    messages: Annotated[list[AnyMessage], add_messages]
+    files: Annotated[dict[str, Any], _merge_dict_state] = Field(default_factory=dict)

--- a/src/aiq_agent/agents/report_rewriter/prompts/edit.j2
+++ b/src/aiq_agent/agents/report_rewriter/prompts/edit.j2
@@ -1,0 +1,23 @@
+You are the report editor for AIQ report follow-up.
+
+Rewrite the parent report according to the requested edit. Return a complete standalone Markdown report, not a patch, diff, commentary, or explanation.
+
+Hard requirements:
+- Preserve the parent report's factual grounding.
+- Preserve valid citations and references when the underlying claim is retained.
+- Do not invent new factual claims or sources.
+- If the requested edit cannot be supported from the parent report and source summary, keep the original claim or state the bounded limitation in the revised report.
+- Apply localized edits when practical, but a full rewrite is allowed when that is simpler or clearer.
+- Do not mention these instructions in the output.
+
+Edit instruction:
+{{ edit_instruction }}
+
+Parent source summary:
+{{ source_summary }}
+
+Parent report context:
+{{ parent_context }}
+
+Parent report:
+{{ original_report }}

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -31,6 +31,7 @@ Usage:
 from __future__ import annotations
 
 import contextvars
+import json
 import logging
 import re
 import threading
@@ -61,6 +62,38 @@ class SourceEntry:
     citation_key: str | None = None
     source_type: str = ""
     tool_name: str = ""
+
+
+def source_entries_from_parent_context(parent_context: str) -> list[SourceEntry]:
+    """Parse durable parent-report source metadata into verification entries."""
+    try:
+        payload = json.loads(parent_context)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(payload, dict) or not isinstance(payload.get("sources"), list):
+        return []
+
+    entries: list[SourceEntry] = []
+    for source in payload["sources"]:
+        if not isinstance(source, dict):
+            continue
+        url = source.get("url")
+        citation_key = source.get("citation_key")
+        url = url.strip() if isinstance(url, str) and url.strip() else None
+        citation_key = citation_key.strip() if isinstance(citation_key, str) and citation_key.strip() else None
+        if not (url or citation_key):
+            continue
+        title = source.get("title")
+        entries.append(
+            SourceEntry(
+                url=url,
+                citation_key=citation_key,
+                title=title.strip() if isinstance(title, str) and title.strip() else None,
+                source_type=str(source.get("source_type") or "parent_report"),
+                tool_name=str(source.get("tool_name") or "parent_report"),
+            )
+        )
+    return entries
 
 
 @dataclass

--- a/src/aiq_agent/common/citation_verification.py
+++ b/src/aiq_agent/common/citation_verification.py
@@ -821,6 +821,50 @@ def _normalize_source_section_layout(ref_section: str) -> str:
     return "\n".join(_split_collapsed_source_line(line) for line in ref_section.split("\n"))
 
 
+def extract_source_entries_from_report(report_text: str) -> list[SourceEntry]:
+    """Extract verifiable source identities from a report's source section.
+
+    A report source can anchor verification only when it has a URL or a
+    recognizable knowledge-layer citation key.
+    """
+    report_text = _normalize_citation_syntax(report_text)
+    ref_match = _REFERENCE_SECTION_RE.search(report_text)
+    if ref_match is None:
+        return []
+
+    entries: list[SourceEntry] = []
+    ref_section = _normalize_source_section_layout(report_text[ref_match.start() :])
+    for line_match in _CITATION_LINE_RE.finditer(ref_section):
+        ref_text = line_match.group(2).strip()
+        url_match = _URL_IN_LINE_RE.search(ref_text)
+        if url_match:
+            entries.append(
+                SourceEntry(
+                    url=url_match.group(0).rstrip(_URL_TRIM_CHARS),
+                    source_type="parent_report",
+                    tool_name="parent_report",
+                )
+            )
+            continue
+
+        is_knowledge, citation_key = _is_knowledge_citation(ref_text)
+        if is_knowledge and citation_key:
+            entries.append(
+                SourceEntry(
+                    citation_key=citation_key,
+                    source_type="parent_report",
+                    tool_name="parent_report",
+                )
+            )
+    return entries
+
+
+def report_has_citations(report_text: str) -> bool:
+    """Return whether a report claims to contain numbered citations."""
+    report_text = _normalize_citation_syntax(report_text)
+    return bool(_REFERENCE_SECTION_RE.search(report_text) or _INLINE_CITATION_RE.search(report_text))
+
+
 def _inline_citation_numbers(text: str) -> set[int]:
     """Return numeric inline citation labels present in text."""
     return {int(match.group(1)) for match in _INLINE_CITATION_RE.finditer(text)}
@@ -828,10 +872,11 @@ def _inline_citation_numbers(text: str) -> set[int]:
 
 def _strip_inline_citations_not_in(text: str, valid_numbers: set[int]) -> str:
     """Remove inline citations whose labels are not in valid_numbers."""
-    return _INLINE_CITATION_RE.sub(
+    stripped = _INLINE_CITATION_RE.sub(
         lambda match: match.group(0) if int(match.group(1)) in valid_numbers else "",
         text,
     )
+    return re.sub(r"[ \t]+(?=[,.;:!?])", "", stripped)
 
 
 def _renumber_citations(body: str, ref_section: str) -> tuple[str, str, dict[int, int]]:

--- a/tests/aiq_agent/agents/chat_researcher/models/test_intent.py
+++ b/tests/aiq_agent/agents/chat_researcher/models/test_intent.py
@@ -34,7 +34,28 @@ class TestIntentResult:
         """Test creating IntentResult with research intent."""
         result = IntentResult(intent="research")
         assert result.intent == "research"
+        assert result.target == "new_research"
+        assert result.report_action is None
+        assert result.use_parent_report_context is False
         assert result.raw is None
+
+    def test_intent_result_report_route(self):
+        """Test creating IntentResult with report-aware route fields."""
+        result = IntentResult(
+            intent="research",
+            target="report",
+            report_action="edit",
+            use_parent_report_context=False,
+        )
+
+        assert result.target == "report"
+        assert result.report_action == "edit"
+        assert result.use_parent_report_context is False
+
+    def test_intent_result_invalid_report_action(self):
+        """Test invalid report actions are rejected."""
+        with pytest.raises(ValidationError):
+            IntentResult(intent="research", report_action="delete")
 
     def test_intent_result_with_raw_data(self):
         """Test creating IntentResult with raw classification data."""

--- a/tests/aiq_agent/agents/chat_researcher/models/test_state.py
+++ b/tests/aiq_agent/agents/chat_researcher/models/test_state.py
@@ -135,6 +135,31 @@ class TestChatResearcherState:
 
         assert state.active_report_job_id == "job-1"
 
+    def test_state_with_last_report_markdown(self):
+        """State can carry the in-session report markdown for jobless follow-up."""
+        state = ChatResearcherState(
+            messages=[HumanMessage(content="Test")],
+            last_report_markdown="# Report\n\nFindings.",
+        )
+        assert state.last_report_markdown == "# Report\n\nFindings."
+        assert ChatResearcherState(messages=[]).last_report_markdown is None
+
+
+class TestKeepIfSetReducer:
+    """last_report_markdown must survive a fresh per-turn state (keep-if-set, not clobber)."""
+
+    def test_keep_prior_when_new_is_empty(self):
+        from aiq_agent.agents.chat_researcher.models.state import _keep_if_set
+
+        assert _keep_if_set("# prior report", None) == "# prior report"
+        assert _keep_if_set("# prior report", "") == "# prior report"
+
+    def test_overwrite_when_new_is_set(self):
+        from aiq_agent.agents.chat_researcher.models.state import _keep_if_set
+
+        assert _keep_if_set("# prior report", "# revised report") == "# revised report"
+        assert _keep_if_set(None, "# first report") == "# first report"
+
     def test_state_with_empty_data_sources(self):
         """Test state with empty data sources list."""
         state = ChatResearcherState(

--- a/tests/aiq_agent/agents/chat_researcher/models/test_state.py
+++ b/tests/aiq_agent/agents/chat_researcher/models/test_state.py
@@ -106,6 +106,7 @@ class TestChatResearcherState:
         assert state.final_report is None
         assert state.shallow_result is None
         assert state.data_sources is None
+        assert state.active_report_job_id is None
 
     def test_state_with_data_sources(self):
         """Test state with data_sources."""
@@ -124,6 +125,15 @@ class TestChatResearcherState:
         )
 
         assert state.data_sources == ["sharepoint"]
+
+    def test_state_with_active_report_job_id(self):
+        """Test state can carry an active report job id."""
+        state = ChatResearcherState(
+            messages=[HumanMessage(content="What are the risks in this report?")],
+            active_report_job_id="job-1",
+        )
+
+        assert state.active_report_job_id == "job-1"
 
     def test_state_with_empty_data_sources(self):
         """Test state with empty data sources list."""

--- a/tests/aiq_agent/agents/chat_researcher/nodes/test_intent_classifier.py
+++ b/tests/aiq_agent/agents/chat_researcher/nodes/test_intent_classifier.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 import pytest
 from langchain_core.messages import AIMessage
 from langchain_core.messages import HumanMessage
+from langchain_core.messages import SystemMessage
 
 from aiq_agent.agents.chat_researcher.models import ChatResearcherState
 from aiq_agent.agents.chat_researcher.nodes.intent_classifier import IntentClassifier
@@ -219,6 +220,7 @@ class TestIntentClassifier:
         assert route_schema in rendered_prompt
         assert delta_example in rendered_prompt
         assert '"make this shorter" -> route = "report_cosmetic_edit"' in rendered_prompt
+        assert 'Explicit report-generation requests ("write/create/generate a report")' in rendered_prompt
 
     @pytest.mark.asyncio
     async def test_run_maps_delta_research_route_to_parent_context_deep_research(self, mock_llm):
@@ -377,6 +379,35 @@ class TestIntentClassifier:
         assert config.get("callbacks") == [mock_callback]
 
     @pytest.mark.asyncio
+    async def test_run_does_not_pass_prior_report_content_to_classifier_llm(self, mock_llm):
+        """The router should classify the latest query, not continue the prior report conversation."""
+        mock_response = MagicMock()
+        mock_response.content = (
+            '{"intent":"research","route":"report_delta_research","target":"new_research","report_action":null,'
+            '"meta_response":null,"research_depth":"deep","use_parent_report_context":true,'
+            '"route_reasoning":"Needs more evidence for the active report."}'
+        )
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+
+        classifier = IntentClassifier(llm=mock_llm)
+        state = ChatResearcherState(
+            messages=[
+                HumanMessage(content="Write a report on reinforcement learning for AI agents"),
+                AIMessage(content="Previous report body with benchmark sections and citations"),
+                HumanMessage(content="can you rewrite the report to add more information on benchmarks"),
+            ],
+            active_report_job_id="job-1",
+        )
+
+        await classifier.run(state)
+
+        classifier_messages = mock_llm.ainvoke.call_args.args[0]
+        assert classifier_messages == [classifier_messages[0]]
+        assert isinstance(classifier_messages[0], SystemMessage)
+        assert "can you rewrite the report to add more information on benchmarks" in classifier_messages[0].content
+        assert "Previous report body with benchmark sections and citations" not in classifier_messages[0].content
+
+    @pytest.mark.asyncio
     async def test_run_meta_in_longer_response(self, mock_llm):
         """Test run() parses meta from JSON in response."""
         mock_response = MagicMock()
@@ -413,7 +444,7 @@ class TestIntentClassifier:
 
     @pytest.mark.asyncio
     async def test_run_invalid_json_fallback(self, mock_llm):
-        """Test run() on unparseable JSON returns fallback research + shallow depth_decision."""
+        """Test run() on unparseable JSON returns fallback research + deep depth_decision."""
         mock_response = MagicMock()
         mock_response.content = "not valid json at all"
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
@@ -424,7 +455,38 @@ class TestIntentClassifier:
         result = await classifier.run(state)
 
         assert result["user_intent"].intent == "research"
-        assert result["depth_decision"].decision == "shallow"
+        assert result["depth_decision"].decision == "deep"
+
+    @pytest.mark.asyncio
+    async def test_run_repairs_invalid_json_classifier_output(self, mock_llm):
+        """Invalid classifier prose gets one JSON-only repair attempt before fallback."""
+        bad_response = MagicMock()
+        bad_response.content = "I should rewrite the report instead of returning JSON."
+        repaired_response = MagicMock()
+        repaired_response.content = (
+            '{"intent":"research","route":"report_delta_research","target":"new_research","report_action":null,'
+            '"meta_response":null,"research_depth":"deep","use_parent_report_context":true,'
+            '"route_reasoning":"Rewrite asks for more benchmark evidence."}'
+        )
+        mock_llm.ainvoke = AsyncMock(side_effect=[bad_response, repaired_response])
+
+        classifier = IntentClassifier(llm=mock_llm)
+        state = ChatResearcherState(
+            messages=[HumanMessage(content="can you rewrite the report to add more information on benchmarks")],
+            active_report_job_id="job-1",
+        )
+
+        result = await classifier.run(state)
+
+        assert mock_llm.ainvoke.call_count == 2
+        repair_messages = mock_llm.ainvoke.call_args_list[1].args[0]
+        assert len(repair_messages) == 1
+        assert isinstance(repair_messages[0], SystemMessage)
+        assert "Return only one valid JSON object" in repair_messages[0].content
+        assert "I should rewrite the report instead of returning JSON." in repair_messages[0].content
+        assert result["user_intent"].target == "new_research"
+        assert result["user_intent"].use_parent_report_context is True
+        assert result["depth_decision"].decision == "deep"
 
     def test_load_default_prompt_fallback(self, mock_llm):
         """Test _load_default_prompt returns fallback when not found."""

--- a/tests/aiq_agent/agents/chat_researcher/nodes/test_intent_classifier.py
+++ b/tests/aiq_agent/agents/chat_researcher/nodes/test_intent_classifier.py
@@ -105,6 +105,73 @@ class TestIntentClassifier:
         assert result["depth_decision"].raw_reasoning == "Simple query"
 
     @pytest.mark.asyncio
+    async def test_run_parses_report_ask_route_with_active_report(self, mock_llm):
+        """Test report ask routing is preserved when an active report is present."""
+        mock_response = MagicMock()
+        mock_response.content = (
+            '{"intent":"research","target":"report","report_action":"ask",'
+            '"meta_response":null,"research_depth":null,"use_parent_report_context":false,'
+            '"depth_reasoning":"Question refers to the active report."}'
+        )
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+
+        classifier = IntentClassifier(llm=mock_llm)
+        state = ChatResearcherState(
+            messages=[HumanMessage(content="What are the risks in this report?")],
+            active_report_job_id="job-1",
+        )
+
+        result = await classifier.run(state)
+
+        assert result["user_intent"].intent == "research"
+        assert result["user_intent"].target == "report"
+        assert result["user_intent"].report_action == "ask"
+        assert "depth_decision" not in result
+
+    @pytest.mark.asyncio
+    async def test_run_downgrades_report_route_without_active_report(self, mock_llm):
+        """Test report routing is ignored when no active report id exists."""
+        mock_response = MagicMock()
+        mock_response.content = (
+            '{"intent":"research","target":"report","report_action":"edit",'
+            '"meta_response":null,"research_depth":"shallow","use_parent_report_context":false,'
+            '"depth_reasoning":"Asked to edit a report."}'
+        )
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+
+        classifier = IntentClassifier(llm=mock_llm)
+        state = ChatResearcherState(messages=[HumanMessage(content="Make this shorter")])
+
+        result = await classifier.run(state)
+
+        assert result["user_intent"].target == "new_research"
+        assert result["user_intent"].report_action is None
+        assert result["depth_decision"].decision == "shallow"
+
+    @pytest.mark.asyncio
+    async def test_run_parses_parent_context_deep_research_route(self, mock_llm):
+        """Test latest/update requests can route to deep research with parent report context."""
+        mock_response = MagicMock()
+        mock_response.content = (
+            '{"intent":"research","target":"new_research","report_action":null,'
+            '"meta_response":null,"research_depth":"deep","use_parent_report_context":true,'
+            '"depth_reasoning":"Requires fresh evidence against active report."}'
+        )
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+
+        classifier = IntentClassifier(llm=mock_llm)
+        state = ChatResearcherState(
+            messages=[HumanMessage(content="Update this with latest data")],
+            active_report_job_id="job-1",
+        )
+
+        result = await classifier.run(state)
+
+        assert result["user_intent"].target == "new_research"
+        assert result["user_intent"].use_parent_report_context is True
+        assert result["depth_decision"].decision == "deep"
+
+    @pytest.mark.asyncio
     async def test_run_defaults_to_research_on_ambiguous(self, mock_llm):
         """Test run() defaults to research when LLM returns intent that is not meta or research."""
         mock_response = MagicMock()

--- a/tests/aiq_agent/agents/chat_researcher/nodes/test_intent_classifier.py
+++ b/tests/aiq_agent/agents/chat_researcher/nodes/test_intent_classifier.py
@@ -172,6 +172,50 @@ class TestIntentClassifier:
         assert result["depth_decision"].decision == "deep"
 
     @pytest.mark.asyncio
+    async def test_run_infers_edit_action_for_edit_phrasing_when_action_missing(self, mock_llm):
+        """When the LLM omits report_action, an edit-phrased query routes to edit (not ask)."""
+        mock_response = MagicMock()
+        mock_response.content = (
+            '{"intent":"research","target":"report","report_action":null,'
+            '"meta_response":null,"research_depth":null,"use_parent_report_context":false,'
+            '"depth_reasoning":"Refers to the active report."}'
+        )
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+
+        classifier = IntentClassifier(llm=mock_llm)
+        state = ChatResearcherState(
+            messages=[HumanMessage(content="Remove the methodology section")],
+            active_report_job_id="job-1",
+        )
+
+        result = await classifier.run(state)
+
+        assert result["user_intent"].target == "report"
+        assert result["user_intent"].report_action == "edit"
+
+    @pytest.mark.asyncio
+    async def test_run_infers_ask_action_for_ask_phrasing_when_action_missing(self, mock_llm):
+        """When the LLM omits report_action, an ask-phrased query still routes to ask."""
+        mock_response = MagicMock()
+        mock_response.content = (
+            '{"intent":"research","target":"report","report_action":null,'
+            '"meta_response":null,"research_depth":null,"use_parent_report_context":false,'
+            '"depth_reasoning":"Refers to the active report."}'
+        )
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+
+        classifier = IntentClassifier(llm=mock_llm)
+        state = ChatResearcherState(
+            messages=[HumanMessage(content="Summarize this report")],
+            active_report_job_id="job-1",
+        )
+
+        result = await classifier.run(state)
+
+        assert result["user_intent"].target == "report"
+        assert result["user_intent"].report_action == "ask"
+
+    @pytest.mark.asyncio
     async def test_run_defaults_to_research_on_ambiguous(self, mock_llm):
         """Test run() defaults to research when LLM returns intent that is not meta or research."""
         mock_response = MagicMock()

--- a/tests/aiq_agent/agents/chat_researcher/nodes/test_intent_classifier.py
+++ b/tests/aiq_agent/agents/chat_researcher/nodes/test_intent_classifier.py
@@ -130,9 +130,9 @@ class TestIntentClassifier:
         """Test report ask routing is preserved when an active report is present."""
         mock_response = MagicMock()
         mock_response.content = (
-            '{"intent":"research","target":"report","report_action":"ask",'
+            '{"intent":"research","route":"report_ask","target":"report","report_action":"ask",'
             '"meta_response":null,"research_depth":null,"use_parent_report_context":false,'
-            '"depth_reasoning":"Question refers to the active report."}'
+            '"route_reasoning":"Question refers to the active report."}'
         )
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
 
@@ -154,9 +154,9 @@ class TestIntentClassifier:
         """Test report routing is ignored when no active report id exists."""
         mock_response = MagicMock()
         mock_response.content = (
-            '{"intent":"research","target":"report","report_action":"edit",'
+            '{"intent":"research","route":"report_cosmetic_edit","target":"report","report_action":"edit",'
             '"meta_response":null,"research_depth":"shallow","use_parent_report_context":false,'
-            '"depth_reasoning":"Asked to edit a report."}'
+            '"route_reasoning":"Asked to edit a report."}'
         )
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
 
@@ -174,9 +174,9 @@ class TestIntentClassifier:
         """Test latest/update requests can route to deep research with parent report context."""
         mock_response = MagicMock()
         mock_response.content = (
-            '{"intent":"research","target":"new_research","report_action":null,'
+            '{"intent":"research","route":"report_delta_research","target":"new_research","report_action":null,'
             '"meta_response":null,"research_depth":"deep","use_parent_report_context":true,'
-            '"depth_reasoning":"Requires fresh evidence against active report."}'
+            '"route_reasoning":"Requires fresh evidence against active report."}'
         )
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
 
@@ -193,8 +193,81 @@ class TestIntentClassifier:
         assert result["depth_decision"].decision == "deep"
 
     @pytest.mark.asyncio
-    async def test_run_infers_edit_action_for_edit_phrasing_when_action_missing(self, mock_llm):
-        """When the LLM omits report_action, an edit-phrased query routes to edit (not ask)."""
+    async def test_prompt_exposes_semantic_route_enum_for_report_followups(self, mock_llm):
+        """The LLM should judge report follow-up semantics via route, not keyword fallbacks."""
+        mock_response = MagicMock()
+        mock_response.content = (
+            '{"intent":"research","route":"report_delta_research","target":"new_research","report_action":null,'
+            '"meta_response":null,"research_depth":"deep","use_parent_report_context":true,'
+            '"route_reasoning":"Requires fresh evidence against active report."}'
+        )
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+
+        classifier = IntentClassifier(llm=mock_llm)
+        state = ChatResearcherState(
+            messages=[HumanMessage(content="Can we write a report on this from a player performance POV?")],
+            active_report_job_id="job-1",
+        )
+
+        await classifier.run(state)
+
+        rendered_prompt = mock_llm.ainvoke.call_args.args[0][0].content
+        route_schema = (
+            '"route": "report_ask" | "report_cosmetic_edit" | "report_delta_research" | "standalone_research" | "meta"'
+        )
+        delta_example = '"rewrite this report from a player-performance POV" -> route = "report_delta_research"'
+        assert route_schema in rendered_prompt
+        assert delta_example in rendered_prompt
+        assert '"make this shorter" -> route = "report_cosmetic_edit"' in rendered_prompt
+
+    @pytest.mark.asyncio
+    async def test_run_maps_delta_research_route_to_parent_context_deep_research(self, mock_llm):
+        """Evidence-bearing POV rewrites should run delta research against the parent report."""
+        mock_response = MagicMock()
+        mock_response.content = (
+            '{"intent":"research","route":"report_delta_research",'
+            '"meta_response":null,"research_depth":null,"route_reasoning":"New analytical POV."}'
+        )
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+
+        classifier = IntentClassifier(llm=mock_llm)
+        state = ChatResearcherState(
+            messages=[HumanMessage(content="Rewrite this report from a player performance POV")],
+            active_report_job_id="job-1",
+        )
+
+        result = await classifier.run(state)
+
+        assert result["user_intent"].target == "new_research"
+        assert result["user_intent"].report_action is None
+        assert result["user_intent"].use_parent_report_context is True
+        assert result["depth_decision"].decision == "deep"
+
+    @pytest.mark.asyncio
+    async def test_run_maps_cosmetic_edit_route_to_report_edit(self, mock_llm):
+        """Cosmetic edits should use the bounded report rewriter."""
+        mock_response = MagicMock()
+        mock_response.content = (
+            '{"intent":"research","route":"report_cosmetic_edit",'
+            '"meta_response":null,"research_depth":null,"route_reasoning":"Style-only edit."}'
+        )
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+
+        classifier = IntentClassifier(llm=mock_llm)
+        state = ChatResearcherState(
+            messages=[HumanMessage(content="Make this shorter")],
+            active_report_job_id="job-1",
+        )
+
+        result = await classifier.run(state)
+
+        assert result["user_intent"].target == "report"
+        assert result["user_intent"].report_action == "edit"
+        assert "depth_decision" not in result
+
+    @pytest.mark.asyncio
+    async def test_run_legacy_report_route_without_action_falls_back_to_research(self, mock_llm):
+        """Legacy target=report payloads without report_action are not keyword-classified in code."""
         mock_response = MagicMock()
         mock_response.content = (
             '{"intent":"research","target":"report","report_action":null,'
@@ -211,17 +284,17 @@ class TestIntentClassifier:
 
         result = await classifier.run(state)
 
-        assert result["user_intent"].target == "report"
-        assert result["user_intent"].report_action == "edit"
+        assert result["user_intent"].target == "new_research"
+        assert result["user_intent"].report_action is None
+        assert result["depth_decision"].decision == "shallow"
 
     @pytest.mark.asyncio
-    async def test_run_infers_ask_action_for_ask_phrasing_when_action_missing(self, mock_llm):
-        """When the LLM omits report_action, an ask-phrased query still routes to ask."""
+    async def test_run_maps_report_ask_route_to_report_ask(self, mock_llm):
+        """The LLM-owned report_ask route maps to bounded report QA."""
         mock_response = MagicMock()
         mock_response.content = (
-            '{"intent":"research","target":"report","report_action":null,'
-            '"meta_response":null,"research_depth":null,"use_parent_report_context":false,'
-            '"depth_reasoning":"Refers to the active report."}'
+            '{"intent":"research","route":"report_ask",'
+            '"meta_response":null,"research_depth":null,"route_reasoning":"Question about active report."}'
         )
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
 

--- a/tests/aiq_agent/agents/chat_researcher/nodes/test_intent_classifier.py
+++ b/tests/aiq_agent/agents/chat_researcher/nodes/test_intent_classifier.py
@@ -25,6 +25,27 @@ from langchain_core.messages import HumanMessage
 
 from aiq_agent.agents.chat_researcher.models import ChatResearcherState
 from aiq_agent.agents.chat_researcher.nodes.intent_classifier import IntentClassifier
+from aiq_agent.agents.chat_researcher.nodes.intent_classifier import _normalize_bool
+
+
+class TestNormalizeBool:
+    """LLM output can contain string booleans; bool('false') would wrongly be True."""
+
+    def test_string_false_is_false(self):
+        assert _normalize_bool("false") is False
+        assert _normalize_bool("False") is False
+        assert _normalize_bool("no") is False
+        assert _normalize_bool("") is False
+
+    def test_string_true_is_true(self):
+        assert _normalize_bool("true") is True
+        assert _normalize_bool("True") is True
+        assert _normalize_bool("yes") is True
+
+    def test_real_bools_and_none(self):
+        assert _normalize_bool(True) is True
+        assert _normalize_bool(False) is False
+        assert _normalize_bool(None) is False
 
 
 class TestIntentClassifier:

--- a/tests/aiq_agent/agents/chat_researcher/nodes/test_intent_classifier.py
+++ b/tests/aiq_agent/agents/chat_researcher/nodes/test_intent_classifier.py
@@ -26,27 +26,6 @@ from langchain_core.messages import SystemMessage
 
 from aiq_agent.agents.chat_researcher.models import ChatResearcherState
 from aiq_agent.agents.chat_researcher.nodes.intent_classifier import IntentClassifier
-from aiq_agent.agents.chat_researcher.nodes.intent_classifier import _normalize_bool
-
-
-class TestNormalizeBool:
-    """LLM output can contain string booleans; bool('false') would wrongly be True."""
-
-    def test_string_false_is_false(self):
-        assert _normalize_bool("false") is False
-        assert _normalize_bool("False") is False
-        assert _normalize_bool("no") is False
-        assert _normalize_bool("") is False
-
-    def test_string_true_is_true(self):
-        assert _normalize_bool("true") is True
-        assert _normalize_bool("True") is True
-        assert _normalize_bool("yes") is True
-
-    def test_real_bools_and_none(self):
-        assert _normalize_bool(True) is True
-        assert _normalize_bool(False) is False
-        assert _normalize_bool(None) is False
 
 
 class TestIntentClassifier:
@@ -131,8 +110,7 @@ class TestIntentClassifier:
         """Test report ask routing is preserved when an active report is present."""
         mock_response = MagicMock()
         mock_response.content = (
-            '{"intent":"research","route":"report_ask","target":"report","report_action":"ask",'
-            '"meta_response":null,"research_depth":null,"use_parent_report_context":false,'
+            '{"intent":"research","route":"report_ask","meta_response":null,"research_depth":null,'
             '"route_reasoning":"Question refers to the active report."}'
         )
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
@@ -155,8 +133,7 @@ class TestIntentClassifier:
         """Test report routing is ignored when no active report id exists."""
         mock_response = MagicMock()
         mock_response.content = (
-            '{"intent":"research","route":"report_cosmetic_edit","target":"report","report_action":"edit",'
-            '"meta_response":null,"research_depth":"shallow","use_parent_report_context":false,'
+            '{"intent":"research","route":"report_cosmetic_edit","meta_response":null,"research_depth":"shallow",'
             '"route_reasoning":"Asked to edit a report."}'
         )
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
@@ -175,8 +152,7 @@ class TestIntentClassifier:
         """Test latest/update requests can route to deep research with parent report context."""
         mock_response = MagicMock()
         mock_response.content = (
-            '{"intent":"research","route":"report_delta_research","target":"new_research","report_action":null,'
-            '"meta_response":null,"research_depth":"deep","use_parent_report_context":true,'
+            '{"intent":"research","route":"report_delta_research","meta_response":null,"research_depth":"deep",'
             '"route_reasoning":"Requires fresh evidence against active report."}'
         )
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
@@ -194,12 +170,11 @@ class TestIntentClassifier:
         assert result["depth_decision"].decision == "deep"
 
     @pytest.mark.asyncio
-    async def test_prompt_exposes_semantic_route_enum_for_report_followups(self, mock_llm):
-        """The LLM should judge report follow-up semantics via route, not keyword fallbacks."""
+    async def test_prompt_exposes_only_semantic_route_not_derived_workflow_fields(self, mock_llm):
+        """The LLM should judge route; Python derives target/report_action/context fields."""
         mock_response = MagicMock()
         mock_response.content = (
-            '{"intent":"research","route":"report_delta_research","target":"new_research","report_action":null,'
-            '"meta_response":null,"research_depth":"deep","use_parent_report_context":true,'
+            '{"intent":"research","route":"report_delta_research","meta_response":null,"research_depth":"deep",'
             '"route_reasoning":"Requires fresh evidence against active report."}'
         )
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
@@ -221,6 +196,30 @@ class TestIntentClassifier:
         assert delta_example in rendered_prompt
         assert '"make this shorter" -> route = "report_cosmetic_edit"' in rendered_prompt
         assert 'Explicit report-generation requests ("write/create/generate a report")' in rendered_prompt
+        assert "Compatibility fields:" not in rendered_prompt
+        assert '"target":' not in rendered_prompt
+        assert '"report_action":' not in rendered_prompt
+        assert '"use_parent_report_context":' not in rendered_prompt
+
+    @pytest.mark.asyncio
+    async def test_run_treats_meta_route_as_meta_even_when_intent_contradicts_it(self, mock_llm):
+        """route=meta must not produce target=meta plus a research depth decision."""
+        mock_response = MagicMock()
+        mock_response.content = (
+            '{"intent":"research","route":"meta","meta_response":"I can help with research reports.",'
+            '"research_depth":"shallow","route_reasoning":"Asked about system capabilities."}'
+        )
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+
+        classifier = IntentClassifier(llm=mock_llm)
+        state = ChatResearcherState(messages=[HumanMessage(content="What can you do?")])
+
+        result = await classifier.run(state)
+
+        assert result["user_intent"].intent == "meta"
+        assert result["user_intent"].target == "meta"
+        assert result["messages"][0].content == "I can help with research reports."
+        assert "depth_decision" not in result
 
     @pytest.mark.asyncio
     async def test_run_maps_delta_research_route_to_parent_context_deep_research(self, mock_llm):
@@ -383,8 +382,7 @@ class TestIntentClassifier:
         """The router should classify the latest query, not continue the prior report conversation."""
         mock_response = MagicMock()
         mock_response.content = (
-            '{"intent":"research","route":"report_delta_research","target":"new_research","report_action":null,'
-            '"meta_response":null,"research_depth":"deep","use_parent_report_context":true,'
+            '{"intent":"research","route":"report_delta_research","meta_response":null,"research_depth":"deep",'
             '"route_reasoning":"Needs more evidence for the active report."}'
         )
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
@@ -464,8 +462,7 @@ class TestIntentClassifier:
         bad_response.content = "I should rewrite the report instead of returning JSON."
         repaired_response = MagicMock()
         repaired_response.content = (
-            '{"intent":"research","route":"report_delta_research","target":"new_research","report_action":null,'
-            '"meta_response":null,"research_depth":"deep","use_parent_report_context":true,'
+            '{"intent":"research","route":"report_delta_research","meta_response":null,"research_depth":"deep",'
             '"route_reasoning":"Rewrite asks for more benchmark evidence."}'
         )
         mock_llm.ainvoke = AsyncMock(side_effect=[bad_response, repaired_response])

--- a/tests/aiq_agent/agents/chat_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_agent.py
@@ -479,6 +479,82 @@ class TestChatResearcherAgent:
         assert result["last_report_markdown"] == "# Updated Report\n\nWith delta."
 
     @pytest.mark.asyncio
+    async def test_inline_deep_research_sends_clean_query_not_report_history(
+        self,
+        mock_shallow_research,
+        mock_clarifier,
+    ):
+        """Inline deep research sends only the query (like the async job), not the prior report-laden
+        history, so a large prior report cannot bloat/break the writer."""
+        captured = {}
+
+        async def deep_orchestration(state):
+            return {
+                "user_intent": IntentResult(intent="research", target="new_research", raw=None),
+                "depth_decision": DepthDecision(decision="deep", raw_reasoning="x"),
+            }
+
+        async def deep(state):
+            captured["messages"] = list(state.messages)
+            result = MagicMock()
+            result.messages = list(state.messages) + [AIMessage(content="# Report")]
+            return result
+
+        agent = ChatResearcherAgent(
+            intent_classifier_fn=deep_orchestration,
+            shallow_research_fn=mock_shallow_research,
+            deep_research_fn=deep,
+            clarifier_fn=mock_clarifier,
+            enable_clarifier=False,
+        )
+
+        huge_prior_report = "# Old Report\n\n" + ("x" * 5000)
+        state = ChatResearcherState(
+            messages=[
+                HumanMessage(content="old question"),
+                AIMessage(content=huge_prior_report),
+                HumanMessage(content="now compare 2026 and 2022 world cups"),
+            ],
+        )
+        await agent.run(state, thread_id="test-clean-msgs")
+
+        assert len(captured["messages"]) == 1
+        assert "Old Report" not in captured["messages"][0].content
+        assert "compare 2026 and 2022" in captured["messages"][0].content
+
+    @pytest.mark.asyncio
+    async def test_inline_deep_research_degrades_gracefully_on_failure(
+        self,
+        mock_shallow_research,
+        mock_clarifier,
+    ):
+        """A deep-research failure in the synchronous CLI degrades to a chat message, not a hard crash."""
+
+        async def deep_orchestration(state):
+            return {
+                "user_intent": IntentResult(intent="research", target="new_research", raw=None),
+                "depth_decision": DepthDecision(decision="deep", raw_reasoning="x"),
+            }
+
+        async def deep_boom(state):
+            raise ValueError("writer-agent did not produce a final Markdown answer")
+
+        agent = ChatResearcherAgent(
+            intent_classifier_fn=deep_orchestration,
+            shallow_research_fn=mock_shallow_research,
+            deep_research_fn=deep_boom,
+            clarifier_fn=mock_clarifier,
+            enable_clarifier=False,
+        )
+
+        state = ChatResearcherState(messages=[HumanMessage(content="compare 2026 and 2022 world cups")])
+        result = await agent.run(state, thread_id="test-deep-fail")
+
+        content = result["messages"][-1].content
+        assert content
+        assert "try again" in content.lower()
+
+    @pytest.mark.asyncio
     async def test_report_ask_degrades_gracefully_when_hook_raises(
         self,
         mock_shallow_research,

--- a/tests/aiq_agent/agents/chat_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_agent.py
@@ -346,6 +346,50 @@ class TestChatResearcherAgent:
         }
 
     @pytest.mark.asyncio
+    async def test_run_report_edit_runs_inline_when_no_submitter(
+        self,
+        mock_shallow_research,
+        mock_deep_research,
+        mock_clarifier,
+    ):
+        """With no async submitter (CLI), report edit runs inline over the in-session report."""
+
+        async def report_orchestration(state):
+            return {
+                "user_intent": IntentResult(
+                    intent="research",
+                    target="report",
+                    report_action="edit",
+                    raw=None,
+                )
+            }
+
+        revised_report = "# FIFA World Cup 2026\n\n_Messi and Ronaldo walk into a bar..._\n\nBody."
+
+        async def inline_edit(state):
+            return revised_report
+
+        async def fail_if_called(_state):
+            raise AssertionError("research path should not run for report edit")
+
+        agent = ChatResearcherAgent(
+            intent_classifier_fn=report_orchestration,
+            shallow_research_fn=fail_if_called,
+            deep_research_fn=fail_if_called,
+            clarifier_fn=mock_clarifier,
+            report_edit_fn=inline_edit,
+        )
+
+        state = ChatResearcherState(
+            messages=[HumanMessage(content="add a messi-ronaldo joke under the title")],
+            last_report_markdown="# FIFA World Cup 2026\n\nBody.",
+        )
+        result = await agent.run(state, thread_id="test-inline-edit")
+
+        assert result["messages"][-1].content == revised_report
+        assert result["last_report_markdown"] == revised_report
+
+    @pytest.mark.asyncio
     async def test_run_deep_research_submitter_emits_structured_escalation(
         self,
         mock_shallow_research,
@@ -384,6 +428,55 @@ class TestChatResearcherAgent:
             "kind": "deep_research",
             "job_id": "deep-job-1",
         }
+
+    @pytest.mark.asyncio
+    async def test_deep_research_seeds_parent_report_for_inline_delta(
+        self,
+        mock_shallow_research,
+        mock_clarifier,
+    ):
+        """An inline delta (use_parent_report_context + in-session report) seeds the report into the deep agent FS."""
+        captured = {}
+
+        async def deep_orchestration(state):
+            return {
+                "user_intent": IntentResult(
+                    intent="research", target="new_research", use_parent_report_context=True, raw=None
+                ),
+                "depth_decision": DepthDecision(decision="deep", raw_reasoning="delta"),
+            }
+
+        async def deep(state):
+            captured["files"] = dict(state.files)
+            captured["query"] = state.messages[-1].content
+            result = MagicMock()
+            result.messages = list(state.messages) + [AIMessage(content="# Updated Report\n\nWith delta.")]
+            return result
+
+        async def seed_files(state):
+            return {
+                "/shared/original_report.md": state.last_report_markdown,
+                "/shared/source_summary.md": "- src",
+            }
+
+        agent = ChatResearcherAgent(
+            intent_classifier_fn=deep_orchestration,
+            shallow_research_fn=mock_shallow_research,
+            deep_research_fn=deep,
+            clarifier_fn=mock_clarifier,
+            enable_clarifier=False,
+            report_seed_files_fn=seed_files,
+        )
+
+        state = ChatResearcherState(
+            messages=[HumanMessage(content="expand the economic impact section with new 2025 data")],
+            last_report_markdown="# FIFA World Cup 2026\n\nBody.",
+        )
+        result = await agent.run(state, thread_id="test-delta-seed")
+
+        assert captured["files"].get("/shared/original_report.md") == "# FIFA World Cup 2026\n\nBody."
+        assert "/shared/original_report.md" in captured["query"]
+        assert result["last_report_markdown"] == "# Updated Report\n\nWith delta."
 
     @pytest.mark.asyncio
     async def test_report_ask_degrades_gracefully_when_hook_raises(

--- a/tests/aiq_agent/agents/chat_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_agent.py
@@ -333,10 +333,56 @@ class TestChatResearcherAgent:
         )
         result = await agent.run(state, thread_id="test-thread")
 
-        assert result["messages"][-1].content == "Report edit job submitted. Job ID: child-job-1"
+        import json
+
+        assert json.loads(result["messages"][-1].content) == {
+            "type": "job_escalation",
+            "kind": "report_edit",
+            "job_id": "child-job-1",
+        }
         assert captured_state == {
             "active_report_job_id": "job-1",
             "query": "Remove the appendix",
+        }
+
+    @pytest.mark.asyncio
+    async def test_run_deep_research_submitter_emits_structured_escalation(
+        self,
+        mock_shallow_research,
+        mock_deep_research,
+        mock_clarifier,
+    ):
+        """A submitted deep-research job yields a structured escalation payload, not a prose sentence."""
+        import json
+
+        async def deep_orchestration(state):
+            return {
+                "user_intent": IntentResult(intent="research", raw=None),
+                "depth_decision": DepthDecision(decision="deep", raw_reasoning="Complex"),
+            }
+
+        async def submit_deep(state):
+            return "deep-job-1"
+
+        async def fail_if_called(_state):
+            raise AssertionError("inline deep research should not run when a submitter is set")
+
+        agent = ChatResearcherAgent(
+            intent_classifier_fn=deep_orchestration,
+            shallow_research_fn=mock_shallow_research,
+            deep_research_fn=fail_if_called,
+            clarifier_fn=mock_clarifier,
+            enable_clarifier=False,
+            deep_research_job_submitter=submit_deep,
+        )
+
+        state = ChatResearcherState(messages=[HumanMessage(content="Compare CUDA vs OpenCL")])
+        result = await agent.run(state, thread_id="test-thread-deep-escalation")
+
+        assert json.loads(result["messages"][-1].content) == {
+            "type": "job_escalation",
+            "kind": "deep_research",
+            "job_id": "deep-job-1",
         }
 
     @pytest.mark.asyncio

--- a/tests/aiq_agent/agents/chat_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_agent.py
@@ -340,6 +340,86 @@ class TestChatResearcherAgent:
         }
 
     @pytest.mark.asyncio
+    async def test_report_ask_degrades_gracefully_when_hook_raises(
+        self,
+        mock_shallow_research,
+        mock_deep_research,
+        mock_clarifier,
+    ):
+        """A failing report-ask hook returns a user-facing message, not an unhandled error."""
+
+        async def report_orchestration(state):
+            return {
+                "user_intent": IntentResult(
+                    intent="research",
+                    target="report",
+                    report_action="ask",
+                    raw=None,
+                )
+            }
+
+        async def report_ask_raises(_state):
+            raise RuntimeError("Report follow-up requires an authenticated user")
+
+        agent = ChatResearcherAgent(
+            intent_classifier_fn=report_orchestration,
+            shallow_research_fn=mock_shallow_research,
+            deep_research_fn=mock_deep_research,
+            clarifier_fn=mock_clarifier,
+            report_ask_fn=report_ask_raises,
+        )
+
+        state = ChatResearcherState(
+            messages=[HumanMessage(content="Summarize this report")],
+            active_report_job_id="job-1",
+        )
+        result = await agent.run(state, thread_id="test-thread")
+
+        content = result["messages"][-1].content
+        assert isinstance(content, str) and content.strip()
+        assert "couldn't" in content.lower() or "could not" in content.lower()
+
+    @pytest.mark.asyncio
+    async def test_report_edit_degrades_gracefully_when_hook_raises(
+        self,
+        mock_shallow_research,
+        mock_deep_research,
+        mock_clarifier,
+    ):
+        """A failing report-edit hook returns a user-facing message, not an unhandled error."""
+
+        async def report_orchestration(state):
+            return {
+                "user_intent": IntentResult(
+                    intent="research",
+                    target="report",
+                    report_action="edit",
+                    raw=None,
+                )
+            }
+
+        async def report_edit_raises(_state):
+            raise RuntimeError("boom")
+
+        agent = ChatResearcherAgent(
+            intent_classifier_fn=report_orchestration,
+            shallow_research_fn=mock_shallow_research,
+            deep_research_fn=mock_deep_research,
+            clarifier_fn=mock_clarifier,
+            report_edit_job_submitter=report_edit_raises,
+        )
+
+        state = ChatResearcherState(
+            messages=[HumanMessage(content="Rewrite this report")],
+            active_report_job_id="job-1",
+        )
+        result = await agent.run(state, thread_id="test-thread")
+
+        content = result["messages"][-1].content
+        assert isinstance(content, str) and content.strip()
+        assert "couldn't" in content.lower() or "could not" in content.lower()
+
+    @pytest.mark.asyncio
     async def test_run_with_empty_messages(
         self,
         mock_intent_classifier,

--- a/tests/aiq_agent/agents/chat_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_agent.py
@@ -563,3 +563,70 @@ class TestChatResearcherAgent:
         await agent.run(state, thread_id="test-thread")
 
         assert captured_state["data_sources"] == []
+
+    @pytest.mark.asyncio
+    async def test_in_session_report_routes_ask_without_job_id(
+        self,
+        mock_shallow_research,
+        mock_deep_research,
+        mock_clarifier,
+    ):
+        """A report produced inline (no job id) still routes follow-up 'ask' to the report hook."""
+
+        async def report_orchestration(state):
+            return {"user_intent": IntentResult(intent="research", target="report", report_action="ask", raw=None)}
+
+        async def report_ask(state):
+            return "From the in-session report: the main risk is integration complexity."
+
+        async def fail_if_called(_state):
+            raise AssertionError("research path should not run for an in-session report ask")
+
+        agent = ChatResearcherAgent(
+            intent_classifier_fn=report_orchestration,
+            shallow_research_fn=fail_if_called,
+            deep_research_fn=fail_if_called,
+            clarifier_fn=mock_clarifier,
+            report_ask_fn=report_ask,
+        )
+
+        state = ChatResearcherState(
+            messages=[HumanMessage(content="What is the biggest risk in this report?")],
+            active_report_job_id=None,
+            last_report_markdown="# Report\n\nThe main risk is integration complexity.",
+        )
+        result = await agent.run(state, thread_id="test-thread-insession")
+
+        assert result["messages"][-1].content.startswith("From the in-session report")
+
+    @pytest.mark.asyncio
+    async def test_deep_research_captures_last_report_markdown(
+        self,
+        mock_shallow_research,
+        mock_clarifier,
+    ):
+        """A synchronous deep-research turn captures its report into last_report_markdown."""
+
+        async def deep_orchestration(state):
+            return {
+                "user_intent": IntentResult(intent="research", raw=None),
+                "depth_decision": DepthDecision(decision="deep", raw_reasoning="complex"),
+            }
+
+        async def deep(state):
+            result = MagicMock()
+            result.messages = list(state.messages) + [AIMessage(content="# Deep Report\n\nFindings.")]
+            return result
+
+        agent = ChatResearcherAgent(
+            intent_classifier_fn=deep_orchestration,
+            shallow_research_fn=mock_shallow_research,
+            deep_research_fn=deep,
+            clarifier_fn=mock_clarifier,
+            enable_clarifier=False,
+        )
+
+        state = ChatResearcherState(messages=[HumanMessage(content="Compare CUDA vs OpenCL")])
+        result = await agent.run(state, thread_id="test-thread-capture")
+
+        assert result["last_report_markdown"] == "# Deep Report\n\nFindings."

--- a/tests/aiq_agent/agents/chat_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_agent.py
@@ -475,7 +475,7 @@ class TestChatResearcherAgent:
         result = await agent.run(state, thread_id="test-delta-seed")
 
         assert captured["files"].get("/shared/original_report.md") == "# FIFA World Cup 2026\n\nBody."
-        assert "/shared/original_report.md" in captured["query"]
+        assert captured["query"] == "expand the economic impact section with new 2025 data"
         assert result["last_report_markdown"] == "# Updated Report\n\nWith delta."
 
     @pytest.mark.asyncio

--- a/tests/aiq_agent/agents/chat_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_agent.py
@@ -244,6 +244,102 @@ class TestChatResearcherAgent:
         assert result is not None
 
     @pytest.mark.asyncio
+    async def test_run_report_ask_routes_to_inline_report_answer(
+        self,
+        mock_shallow_research,
+        mock_deep_research,
+        mock_clarifier,
+    ):
+        """Report ask turns use the report ask hook instead of shallow/deep research."""
+        captured_state = {}
+
+        async def report_orchestration(state):
+            return {
+                "user_intent": IntentResult(
+                    intent="research",
+                    target="report",
+                    report_action="ask",
+                    raw=None,
+                )
+            }
+
+        async def report_ask(state):
+            captured_state["active_report_job_id"] = state.active_report_job_id
+            captured_state["query"] = state.messages[-1].content
+            return "The report's main risk is integration complexity."
+
+        async def fail_if_called(_state):
+            raise AssertionError("research path should not run for report ask")
+
+        agent = ChatResearcherAgent(
+            intent_classifier_fn=report_orchestration,
+            shallow_research_fn=fail_if_called,
+            deep_research_fn=fail_if_called,
+            clarifier_fn=mock_clarifier,
+            report_ask_fn=report_ask,
+        )
+
+        state = ChatResearcherState(
+            messages=[HumanMessage(content="What is the biggest risk in this report?")],
+            active_report_job_id="job-1",
+        )
+        result = await agent.run(state, thread_id="test-thread")
+
+        assert result["messages"][-1].content == "The report's main risk is integration complexity."
+        assert captured_state == {
+            "active_report_job_id": "job-1",
+            "query": "What is the biggest risk in this report?",
+        }
+
+    @pytest.mark.asyncio
+    async def test_run_report_edit_routes_to_child_job_submitter(
+        self,
+        mock_shallow_research,
+        mock_deep_research,
+        mock_clarifier,
+    ):
+        """Report edit turns submit a child job instead of running shallow/deep research inline."""
+        captured_state = {}
+
+        async def report_orchestration(state):
+            return {
+                "user_intent": IntentResult(
+                    intent="research",
+                    target="report",
+                    report_action="edit",
+                    raw=None,
+                )
+            }
+
+        async def submit_report_edit(state):
+            captured_state["active_report_job_id"] = state.active_report_job_id
+            captured_state["query"] = state.messages[-1].content
+            return "child-job-1"
+
+        async def fail_if_called(_state):
+            raise AssertionError("research path should not run for report edit")
+
+        agent = ChatResearcherAgent(
+            intent_classifier_fn=report_orchestration,
+            shallow_research_fn=fail_if_called,
+            deep_research_fn=fail_if_called,
+            clarifier_fn=mock_clarifier,
+            report_edit_job_submitter=submit_report_edit,
+        )
+
+        state = ChatResearcherState(
+            messages=[HumanMessage(content="Remove the appendix")],
+            active_report_job_id="job-1",
+        )
+        result = await agent.run(state, thread_id="test-thread")
+
+        assert result["messages"][-1].content == "Report edit job submitted. Job ID: child-job-1"
+        assert captured_state == {
+            "active_report_job_id": "job-1",
+            "query": "Remove the appendix",
+        }
+
+    @pytest.mark.asyncio
     async def test_run_with_empty_messages(
         self,
         mock_intent_classifier,

--- a/tests/aiq_agent/agents/chat_researcher/test_register_helpers.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_register_helpers.py
@@ -17,6 +17,7 @@
 
 from unittest.mock import MagicMock
 
+import pytest
 from langchain_core.messages import AIMessage
 from langchain_core.messages import HumanMessage
 
@@ -42,6 +43,54 @@ class TestReportFollowUpHelpers:
         assert "Risk is rollout complexity." in prompt
         assert "- [1] https://example.com" in prompt
         assert "Answer using only the parent report" in prompt
+
+    @pytest.mark.asyncio
+    async def test_answer_from_report_context_uses_single_bounded_llm_call(self):
+        """Report Q&A answers with one direct LLM call over the bounded prompt.
+
+        It must NOT route through the shallow/deep research agents or any tools —
+        report ask is bounded to parent report context and never triggers live research.
+        """
+        from aiq_agent.agents.chat_researcher.register import _answer_from_report_context
+
+        captured = {}
+
+        class FakeLLM:
+            async def ainvoke(self, messages):
+                captured["messages"] = messages
+                return AIMessage(content="Bounded answer from report.")
+
+        answer = await _answer_from_report_context(
+            FakeLLM(),
+            question="What is the main risk?",
+            report_markdown="# Report\n\nRisk is rollout complexity.",
+            source_summary_markdown="- [1] https://example.com",
+        )
+
+        assert answer == "Bounded answer from report."
+        sent = captured["messages"][0].content
+        assert "What is the main risk?" in sent
+        assert "Risk is rollout complexity." in sent
+        assert "Answer using only the parent report" in sent
+
+    @pytest.mark.asyncio
+    async def test_answer_from_report_context_falls_back_on_empty_response(self):
+        """An empty/whitespace LLM completion yields a bounded fallback, never a blank answer."""
+        from aiq_agent.agents.chat_researcher.register import _answer_from_report_context
+
+        class EmptyLLM:
+            async def ainvoke(self, messages):
+                return AIMessage(content="   ")
+
+        answer = await _answer_from_report_context(
+            EmptyLLM(),
+            question="What is the risk?",
+            report_markdown="# Report",
+            source_summary_markdown="",
+        )
+
+        assert answer.strip()
+        assert "does not contain enough information" in answer.lower()
 
 
 class TestExtractTextFromMessageString:

--- a/tests/aiq_agent/agents/chat_researcher/test_register_helpers.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_register_helpers.py
@@ -22,7 +22,6 @@ from langchain_core.messages import AIMessage
 from langchain_core.messages import HumanMessage
 
 from aiq_agent.agents.chat_researcher.utils import _extract_query_and_sources
-from aiq_agent.agents.chat_researcher.utils import _extract_query_from_text
 from aiq_agent.agents.chat_researcher.utils import _extract_text_from_message
 
 
@@ -200,64 +199,6 @@ class TestExtractTextFromMessageDict:
         message = {"content": "Content value", "text": "Text value"}
         result = _extract_text_from_message(message)
         assert result == "Content value"
-
-
-class TestExtractQueryFromText:
-    """Tests for _extract_query_from_text function."""
-
-    def test_extract_plain_text(self):
-        """Test that plain text is returned as-is."""
-        query, sources = _extract_query_from_text("What is CUDA?")
-        assert query == "What is CUDA?"
-        assert sources is None
-
-    def test_extract_empty_text(self):
-        """Test extracting from empty text."""
-        query, sources = _extract_query_from_text("")
-        assert query == ""
-        assert sources is None
-
-    def test_extract_json_payload_with_query(self):
-        """Test extracting from JSON payload with query key."""
-        text = '{"query": "What is CUDA?", "data_sources": ["web_search"]}'
-        query, sources = _extract_query_from_text(text)
-        assert query == "What is CUDA?"
-        assert sources == ["web_search"]
-
-    def test_extract_json_payload_with_text_key(self):
-        """Test extracting from JSON payload with text key."""
-        text = '{"text": "Hello world", "data_sources": "confluence"}'
-        query, sources = _extract_query_from_text(text)
-        assert query == "Hello world"
-        assert sources == ["confluence"]
-
-    def test_extract_json_payload_no_data_sources(self):
-        """Test extracting from JSON without data_sources."""
-        text = '{"query": "Simple query"}'
-        query, sources = _extract_query_from_text(text)
-        assert query == "Simple query"
-        assert sources is None
-
-    def test_extract_invalid_json_returns_original(self):
-        """Test that invalid JSON returns original text."""
-        text = '{"invalid json'
-        query, sources = _extract_query_from_text(text)
-        assert query == '{"invalid json'
-        assert sources is None
-
-    def test_extract_json_with_whitespace(self):
-        """Test extracting from JSON with surrounding whitespace."""
-        text = '  {"query": "Test"}  '
-        query, sources = _extract_query_from_text(text)
-        assert query == "Test"
-        assert sources is None
-
-    def test_extract_json_missing_query_returns_none_text(self):
-        """Test JSON without query or text returns None query."""
-        text = '{"data_sources": ["web_search"]}'
-        query, sources = _extract_query_from_text(text)
-        assert query == '{"data_sources": ["web_search"]}'
-        assert sources is None
 
 
 class TestExtractQueryAndSourcesDict:

--- a/tests/aiq_agent/agents/chat_researcher/test_register_helpers.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_register_helpers.py
@@ -25,6 +25,25 @@ from aiq_agent.agents.chat_researcher.utils import _extract_query_from_text
 from aiq_agent.agents.chat_researcher.utils import _extract_text_from_message
 
 
+class TestReportFollowUpHelpers:
+    """Tests for report follow-up helper prompt shaping."""
+
+    def test_build_report_ask_prompt_anchors_answer_to_parent_report(self):
+        from aiq_agent.agents.chat_researcher.register import _build_report_ask_prompt
+
+        prompt = _build_report_ask_prompt(
+            question="What is the main risk?",
+            report_markdown="# Report\n\nRisk is rollout complexity.",
+            source_summary_markdown="- [1] https://example.com",
+        )
+
+        assert "What is the main risk?" in prompt
+        assert "# Report" in prompt
+        assert "Risk is rollout complexity." in prompt
+        assert "- [1] https://example.com" in prompt
+        assert "Answer using only the parent report" in prompt
+
+
 class TestExtractTextFromMessageString:
     """Tests for _extract_text_from_message with string inputs."""
 

--- a/tests/aiq_agent/agents/chat_researcher/test_register_helpers.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_register_helpers.py
@@ -481,3 +481,58 @@ class TestExtractQueryAndSourcesEdgeCases:
         query, sources = _extract_query_and_sources(payload)
         assert query == "Query"
         assert sources == ["web_search", "confluence"]
+
+
+class TestResolveEffectiveReportJobId:
+    """Precedence + conversation-scoped fallback for the active report job."""
+
+    @pytest.mark.asyncio
+    async def test_client_supplied_id_wins_without_lookup(self, monkeypatch):
+        from aiq_agent.agents.chat_researcher.register import _resolve_effective_report_job_id
+        from aiq_api.jobs import access
+
+        lookup = MagicMock(return_value="from-db")
+        monkeypatch.setattr(access, "get_latest_report_job_for_conversation", lookup)
+
+        result = await _resolve_effective_report_job_id(
+            "client-id", conversation_id="conv-A", principal=None, is_input_mode=False
+        )
+        assert result == "client-id"
+        lookup.assert_not_called()  # precedence short-circuits the DB query
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_conversation_last_report(self, monkeypatch):
+        from aiq_agent.agents.chat_researcher.register import _resolve_effective_report_job_id
+        from aiq_api.jobs import access
+
+        monkeypatch.setattr(access, "get_latest_report_job_for_conversation", MagicMock(return_value="last-report"))
+
+        result = await _resolve_effective_report_job_id(
+            None, conversation_id="conv-A", principal=None, is_input_mode=False
+        )
+        assert result == "last-report"
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_for_input_mode_or_missing_conversation(self, monkeypatch):
+        from aiq_agent.agents.chat_researcher.register import _resolve_effective_report_job_id
+        from aiq_api.jobs import access
+
+        lookup = MagicMock(return_value="should-not-be-used")
+        monkeypatch.setattr(access, "get_latest_report_job_for_conversation", lookup)
+
+        # --input mode: deliberately discards continuity
+        assert await _resolve_effective_report_job_id(None, "conv-A", None, is_input_mode=True) is None
+        # no client conversation id (generated thread): no fallback
+        assert await _resolve_effective_report_job_id(None, None, None, is_input_mode=False) is None
+        lookup.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_lookup_error_degrades_to_none(self, monkeypatch):
+        from aiq_agent.agents.chat_researcher.register import _resolve_effective_report_job_id
+        from aiq_api.jobs import access
+
+        monkeypatch.setattr(
+            access, "get_latest_report_job_for_conversation", MagicMock(side_effect=RuntimeError("db down"))
+        )
+        result = await _resolve_effective_report_job_id(None, "conv-A", None, is_input_mode=False)
+        assert result is None

--- a/tests/aiq_agent/agents/chat_researcher/test_utils.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_utils.py
@@ -235,3 +235,22 @@ class TestExtractQueryContext:
 
         assert context.query_text == "Update this with latest data"
         assert context.active_report_job_id == "job-3"
+
+    def test_explicit_empty_data_sources_preserved_dict_payload(self):
+        """An explicit empty data_sources list ('no data-source tools') must survive."""
+        payload = {
+            "data_sources": [],
+            "content": {"messages": [{"role": "user", "content": "hello"}]},
+        }
+        context = _extract_query_context(payload)
+        assert context.data_sources == []
+
+    def test_explicit_empty_data_sources_preserved_object_payload(self):
+        from types import SimpleNamespace
+
+        payload = SimpleNamespace(
+            data_sources=[],
+            messages=[SimpleNamespace(role="user", content="hello")],
+        )
+        context = _extract_query_context(payload)
+        assert context.data_sources == []

--- a/tests/aiq_agent/agents/chat_researcher/test_utils.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_utils.py
@@ -23,7 +23,6 @@ from langchain_core.messages import SystemMessage
 
 from aiq_agent.agents.chat_researcher.utils import _extract_query_and_sources
 from aiq_agent.agents.chat_researcher.utils import _extract_query_context
-from aiq_agent.agents.chat_researcher.utils import _extract_query_from_text
 from aiq_agent.agents.chat_researcher.utils import _extract_text_from_message
 from aiq_agent.agents.chat_researcher.utils import trim_message_history
 
@@ -133,36 +132,6 @@ class TestExtractTextFromMessage:
         """Test extracting text from dict message."""
         message = {"content": [{"type": "text", "text": "Hello"}]}
         assert _extract_text_from_message(message) == "Hello"
-
-
-class TestExtractQueryFromText:
-    """Tests for _extract_query_from_text."""
-
-    def test_extract_simple_text(self):
-        """Test extracting from plain text."""
-        query, sources = _extract_query_from_text("What is CUDA?")
-        assert query == "What is CUDA?"
-        assert sources is None
-
-    def test_extract_empty_text(self):
-        """Test extracting from empty string."""
-        query, sources = _extract_query_from_text("")
-        assert query == ""
-        assert sources is None
-
-    def test_extract_json_payload(self):
-        """Test extracting from JSON payload."""
-        text = '{"query": "Test query", "data_sources": ["web_search"]}'
-        query, sources = _extract_query_from_text(text)
-        assert query == "Test query"
-        assert sources == ["web_search"]
-
-    def test_extract_invalid_json(self):
-        """Test invalid JSON returns original text."""
-        text = '{"invalid json'
-        query, sources = _extract_query_from_text(text)
-        assert query == text
-        assert sources is None
 
 
 class TestExtractQueryAndSources:

--- a/tests/aiq_agent/agents/chat_researcher/test_utils.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_utils.py
@@ -231,9 +231,7 @@ class TestExtractQueryContext:
         assert context.active_report_job_id == "job-2"
 
     def test_extract_active_report_job_id_from_json_string(self):
-        context = _extract_query_context(
-            '{"query": "Update this with latest data", "active_report_job_id": "job-3"}'
-        )
+        context = _extract_query_context('{"query": "Update this with latest data", "active_report_job_id": "job-3"}')
 
         assert context.query_text == "Update this with latest data"
         assert context.active_report_job_id == "job-3"

--- a/tests/aiq_agent/agents/chat_researcher/test_utils.py
+++ b/tests/aiq_agent/agents/chat_researcher/test_utils.py
@@ -22,6 +22,7 @@ from langchain_core.messages import HumanMessage
 from langchain_core.messages import SystemMessage
 
 from aiq_agent.agents.chat_researcher.utils import _extract_query_and_sources
+from aiq_agent.agents.chat_researcher.utils import _extract_query_context
 from aiq_agent.agents.chat_researcher.utils import _extract_query_from_text
 from aiq_agent.agents.chat_researcher.utils import _extract_text_from_message
 from aiq_agent.agents.chat_researcher.utils import trim_message_history
@@ -196,3 +197,43 @@ class TestExtractQueryAndSources:
         query, sources = _extract_query_and_sources("Plain query string")
         assert query == "Plain query string"
         assert sources is None
+
+
+class TestExtractQueryContext:
+    """Tests for report-aware chat request context extraction."""
+
+    def test_extract_active_report_job_id_from_top_level_payload(self):
+        payload = {
+            "active_report_job_id": "job-1",
+            "content": {
+                "messages": [{"role": "user", "content": "What are the risks?"}],
+                "data_sources": ["web_search"],
+            },
+        }
+
+        context = _extract_query_context(payload)
+
+        assert context.query_text == "What are the risks?"
+        assert context.data_sources == ["web_search"]
+        assert context.active_report_job_id == "job-1"
+
+    def test_extract_active_report_job_id_from_nested_content(self):
+        payload = {
+            "content": {
+                "active_report_job_id": "job-2",
+                "messages": [{"role": "user", "content": "Summarize this report"}],
+            }
+        }
+
+        context = _extract_query_context(payload)
+
+        assert context.query_text == "Summarize this report"
+        assert context.active_report_job_id == "job-2"
+
+    def test_extract_active_report_job_id_from_json_string(self):
+        context = _extract_query_context(
+            '{"query": "Update this with latest data", "active_report_job_id": "job-3"}'
+        )
+
+        assert context.query_text == "Update this with latest data"
+        assert context.active_report_job_id == "job-3"

--- a/tests/aiq_agent/agents/deep_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_agent.py
@@ -570,6 +570,51 @@ class TestDeepResearcherAgent:
                 not in (create.call_args.kwargs["system_prompt"])
             )
 
+    def test_build_orchestrator_uses_parent_report_delta_prompt_when_seeded(
+        self,
+        mock_llm_provider,
+        real_tool,
+        mock_create_deep_agent,
+    ):
+        """Parent-report delta runs are governed by deep researcher synthesis prompts, not chat query rewriting."""
+        with (
+            patch(
+                "aiq_agent.agents.deep_researcher.factory.create_deep_agent",
+                return_value=mock_create_deep_agent,
+            ) as create,
+            patch(
+                "aiq_agent.agents.deep_researcher.factory.create_agent",
+                return_value=mock_create_deep_agent,
+            ),
+        ):
+            from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+
+            agent = DeepResearcherAgent(llm_provider=mock_llm_provider, tools=[real_tool])
+            state = DeepResearchAgentState(
+                messages=[HumanMessage(content="Add a Codex vs Claude Code comparison")],
+                files={
+                    "/shared/original_report.md": "# Parent report",
+                    "/shared/source_summary.md": "- source",
+                },
+            )
+
+            agent._build_orchestrator_agent(state)
+
+            kwargs = create.call_args.kwargs
+            orchestrator_prompt = kwargs["system_prompt"]
+            subagents = {subagent["name"]: subagent for subagent in kwargs["subagents"]}
+            writer_prompt = subagents["writer-agent"]["system_prompt"]
+
+            assert "Parent Report Delta Mode" in orchestrator_prompt
+            assert "/shared/original_report.md" in orchestrator_prompt
+            assert "/shared/source_summary.md" in orchestrator_prompt
+            assert "complete standalone revised report" in orchestrator_prompt
+            assert "Do not return a research plan" in orchestrator_prompt
+            assert "Parent Report Delta Mode" in writer_prompt
+            assert "/shared/original_report.md" in writer_prompt
+            assert "complete standalone revised report" in writer_prompt
+            assert "Do not return a research plan" in writer_prompt
+
     def test_build_orchestrator_can_disable_source_router(
         self,
         mock_llm_provider,

--- a/tests/aiq_agent/agents/deep_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_agent.py
@@ -1356,6 +1356,59 @@ class TestFinalMarkdownExtraction:
 
             assert "# CapEx Report" in result.messages[-1].content
 
+    @pytest.mark.asyncio
+    async def test_run_seeds_parent_sources_for_delta_citation_verification(
+        self,
+        mock_llm_provider,
+        real_tool,
+    ):
+        """Delta reports may preserve parent citations that must be valid in the child registry."""
+        parent_url = "https://parent.example/source"
+        report = f"Preserved parent claim [1].\n\n## Sources\n[1] Parent: {parent_url}"
+        parent_context = {
+            "parent_job_id": "parent-job-1",
+            "source_summary_markdown": f"- [1] Parent: {parent_url}",
+            "sources": [
+                {
+                    "url": parent_url,
+                    "title": "Parent",
+                    "source_type": "parent_report",
+                    "tool_name": "parent_report",
+                }
+            ],
+        }
+        mock_agent = MagicMock()
+        mock_agent.with_config = MagicMock(return_value=mock_agent)
+        mock_agent.ainvoke = AsyncMock(
+            return_value={
+                "messages": [AIMessage(content="Wrote /shared/output.md")],
+                "files": {
+                    **output_markdown_file(report),
+                    "/shared/parent_report_context.json": {"content": json.dumps(parent_context)},
+                },
+            }
+        )
+
+        with patch(
+            "aiq_agent.agents.deep_researcher.factory.create_deep_agent",
+            return_value=mock_agent,
+        ):
+            from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+
+            agent = DeepResearcherAgent(llm_provider=mock_llm_provider, tools=[real_tool])
+            state = DeepResearchAgentState(
+                messages=[HumanMessage(content="Add OpenShell")],
+                files={
+                    "/shared/parent_report_context.json": json.dumps(parent_context),
+                },
+            )
+
+            result = await agent.run(state)
+
+            assert "[1] Parent: https://parent.example/source" in result.messages[-1].content
+            assert agent.source_registry_middleware.active_registry().has_url(parent_url)
+            assert agent.source_registry_middleware.get_source_entries(mode="compact")[0].url == parent_url
+
 
 class TestDeepResearcherCitationVerification:
     """Tests for deep researcher citation post-processing."""

--- a/tests/aiq_agent/agents/deep_researcher/test_deepagents_runtime.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_deepagents_runtime.py
@@ -115,10 +115,12 @@ class TestDeepAgentsRuntimeRouting:
     def test_prepare_state_files_normalizes_shared_paths_for_route_backend(self) -> None:
         runtime = DeepAgentsRuntime(sandbox=DeepResearchSandboxConfig())
 
-        files = runtime.prepare_state_files({
-            "/shared/original_report.md": "# Parent",
-            "/shared/source_summary.md": b"- src",
-        })
+        files = runtime.prepare_state_files(
+            {
+                "/shared/original_report.md": "# Parent",
+                "/shared/source_summary.md": b"- src",
+            }
+        )
 
         assert "/original_report.md" in files
         assert "/source_summary.md" in files

--- a/tests/aiq_agent/agents/deep_researcher/test_deepagents_runtime.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_deepagents_runtime.py
@@ -103,6 +103,31 @@ class TestDeepAgentsRuntimeRouting:
         assert runtime.execution_enabled is True
         assert runtime.skills_enabled is False
 
+    def test_prepare_state_files_preserves_shared_paths_without_route(self) -> None:
+        runtime = DeepAgentsRuntime()
+
+        files = runtime.prepare_state_files({"/shared/original_report.md": "# Parent"})
+
+        assert "/shared/original_report.md" in files
+        assert files["/shared/original_report.md"]["content"] == "# Parent"
+        assert "modified_at" in files["/shared/original_report.md"]
+
+    def test_prepare_state_files_normalizes_shared_paths_for_route_backend(self) -> None:
+        runtime = DeepAgentsRuntime(sandbox=DeepResearchSandboxConfig())
+
+        files = runtime.prepare_state_files({
+            "/shared/original_report.md": "# Parent",
+            "/shared/source_summary.md": b"- src",
+        })
+
+        assert "/original_report.md" in files
+        assert "/source_summary.md" in files
+        assert "/shared/original_report.md" not in files
+        assert "/shared/source_summary.md" not in files
+        assert files["/original_report.md"]["content"] == "# Parent"
+        assert files["/source_summary.md"]["content"] == "- src"
+        assert "modified_at" in files["/original_report.md"]
+
     def test_sandbox_and_skills_add_shared_and_skills_routes(self) -> None:
         fake_sandbox = MagicMock()
         skills = DeepResearchSkillsConfig(agents={"researcher-agent": ("research",)})

--- a/tests/aiq_agent/agents/deep_researcher/test_deepagents_runtime.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_deepagents_runtime.py
@@ -113,7 +113,11 @@ class TestDeepAgentsRuntimeRouting:
         assert "modified_at" in files["/shared/original_report.md"]
 
     def test_prepare_state_files_normalizes_shared_paths_for_route_backend(self) -> None:
-        runtime = DeepAgentsRuntime(sandbox=DeepResearchSandboxConfig())
+        with patch(
+            "aiq_agent.agents.deep_researcher.deepagents_runtime._create_sandbox_backend",
+            return_value=MagicMock(),
+        ):
+            runtime = DeepAgentsRuntime(sandbox=DeepResearchSandboxConfig())
 
         files = runtime.prepare_state_files(
             {

--- a/tests/aiq_agent/agents/report_rewriter/test_agent.py
+++ b/tests/aiq_agent/agents/report_rewriter/test_agent.py
@@ -115,7 +115,83 @@ async def test_report_rewriter_verifies_and_sanitizes_revised_report_against_par
     assert "https://valid.example/source" in revised_report
     assert "https://fabricated.example/source" not in revised_report
     assert "[2]" not in revised_report
+    assert "Unsupported claim." in revised_report
     assert result.messages[-1].content == revised_report
+
+
+@pytest.mark.asyncio
+async def test_rewrite_report_reconstructs_registry_from_original_report_when_parent_context_is_malformed():
+    from aiq_agent.agents.report_rewriter.agent import rewrite_report
+
+    revised = await rewrite_report(
+        llm=FakeWriterLLM(
+            content=(
+                "# Revised Report\n\n"
+                "Supported claim [1]. Unsupported claim [2].\n\n"
+                "## Sources\n"
+                "[1] Valid Source: https://valid.example/source\n"
+                "[2] Fabricated Source: https://fabricated.example/source"
+            )
+        ),
+        original_report=(
+            "# Parent Report\n\nSupported claim [1].\n\n## Sources\n[1] Valid Source: https://valid.example/source"
+        ),
+        edit_instruction="Make it clearer.",
+        parent_context="{not valid JSON",
+    )
+
+    assert "https://valid.example/source" in revised
+    assert "https://fabricated.example/source" not in revised
+    assert "[2]" not in revised
+
+
+@pytest.mark.asyncio
+async def test_rewrite_report_preserves_sources_missing_from_parent_context():
+    from aiq_agent.agents.report_rewriter.agent import rewrite_report
+
+    revised = await rewrite_report(
+        llm=FakeWriterLLM(
+            content=(
+                "# Revised Report\n\n"
+                "First claim [1]. Second claim [2]. Unsupported claim [3].\n\n"
+                "## Sources\n"
+                "[1] First Source: https://first.example/source\n"
+                "[2] Second Source: https://second.example/source\n"
+                "[3] Fabricated Source: https://fabricated.example/source"
+            )
+        ),
+        original_report=(
+            "# Parent Report\n\nFirst claim [1]. Second claim [2].\n\n"
+            "## Sources\n"
+            "[1] First Source: https://first.example/source\n"
+            "[2] Second Source: https://second.example/source"
+        ),
+        edit_instruction="Make it clearer.",
+        parent_context=json.dumps(
+            {
+                "parent_job_id": "parent-job",
+                "sources": [{"url": "https://first.example/source"}],
+            }
+        ),
+    )
+
+    assert "https://first.example/source" in revised
+    assert "https://second.example/source" in revised
+    assert "https://fabricated.example/source" not in revised
+    assert "[3]" not in revised
+
+
+@pytest.mark.asyncio
+async def test_rewrite_report_rejects_cited_parent_without_reconstructable_sources():
+    from aiq_agent.agents.report_rewriter.agent import rewrite_report
+
+    with pytest.raises(ValueError, match="cannot reconstruct its source registry"):
+        await rewrite_report(
+            llm=FakeWriterLLM(content="# Revised Report\n\nUpdated body."),
+            original_report="# Parent Report\n\nSupported claim [1].\n\n## Sources\n[1] Missing locator",
+            edit_instruction="Make it clearer.",
+            parent_context="{}",
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/aiq_agent/agents/report_rewriter/test_agent.py
+++ b/tests/aiq_agent/agents/report_rewriter/test_agent.py
@@ -51,6 +51,33 @@ async def test_report_rewriter_uses_parent_report_context_and_emits_output_file(
 
 
 @pytest.mark.asyncio
+async def test_rewrite_report_core_returns_revised_markdown_and_renders_prompt():
+    """The extracted rewrite core (shared by the job and the inline CLI path) is a single LLM call."""
+    from aiq_agent.agents.report_rewriter.agent import rewrite_report
+
+    writer_llm = FakeWriterLLM(content="# Edited\n\nNew body.")
+    revised = await rewrite_report(
+        llm=writer_llm,
+        original_report="# Parent\n\nBody.",
+        edit_instruction="Add a Messi-Ronaldo joke under the title.",
+        source_summary="- [1] https://example.com",
+    )
+
+    assert revised == "# Edited\n\nNew body."
+    rendered_prompt = writer_llm.seen_messages[0].content
+    assert "# Parent" in rendered_prompt
+    assert "Add a Messi-Ronaldo joke under the title." in rendered_prompt
+
+
+@pytest.mark.asyncio
+async def test_rewrite_report_core_rejects_empty_instruction():
+    from aiq_agent.agents.report_rewriter.agent import rewrite_report
+
+    with pytest.raises(ValueError, match="non-empty edit instruction"):
+        await rewrite_report(llm=FakeWriterLLM(), original_report="# R", edit_instruction="   ")
+
+
+@pytest.mark.asyncio
 async def test_report_rewriter_requires_original_report_file():
     from aiq_agent.agents.report_rewriter.agent import ReportRewriterAgent
     from aiq_agent.agents.report_rewriter.models import ReportRewriterAgentState

--- a/tests/aiq_agent/agents/report_rewriter/test_agent.py
+++ b/tests/aiq_agent/agents/report_rewriter/test_agent.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import AIMessage
+from langchain_core.messages import HumanMessage
+
+from aiq_agent.common import LLMProvider
+from aiq_agent.common import LLMRole
+
+
+class FakeWriterLLM:
+    def __init__(self, content: str = "# Revised Report\n\nUpdated body.") -> None:
+        self.content = content
+        self.seen_messages = None
+
+    async def ainvoke(self, messages):
+        self.seen_messages = messages
+        return AIMessage(content=self.content)
+
+
+@pytest.mark.asyncio
+async def test_report_rewriter_uses_parent_report_context_and_emits_output_file():
+    from aiq_agent.agents.report_rewriter.agent import ReportRewriterAgent
+    from aiq_agent.agents.report_rewriter.models import ReportRewriterAgentState
+
+    writer_llm = FakeWriterLLM()
+    provider = LLMProvider()
+    provider.configure(LLMRole.REPORT_WRITER, writer_llm)
+    agent = ReportRewriterAgent(llm_provider=provider, tools=[])
+
+    state = ReportRewriterAgentState(
+        messages=[HumanMessage(content="Remove the appendix.")],
+        files={
+            "/shared/original_report.md": "# Parent Report\n\nBody.\n\n## Appendix\n\nRemove me.",
+            "/shared/source_summary.md": "- [1] Example: https://example.com",
+            "/shared/edit_instruction.txt": "Remove the appendix.",
+        },
+    )
+
+    result = await agent.run(state)
+
+    assert result.files["/shared/output.md"] == "# Revised Report\n\nUpdated body."
+    assert result.messages[-1].content == "# Revised Report\n\nUpdated body."
+    rendered_prompt = writer_llm.seen_messages[0].content
+    assert "# Parent Report" in rendered_prompt
+    assert "Remove the appendix." in rendered_prompt
+    assert "complete standalone Markdown report" in rendered_prompt
+
+
+@pytest.mark.asyncio
+async def test_report_rewriter_requires_original_report_file():
+    from aiq_agent.agents.report_rewriter.agent import ReportRewriterAgent
+    from aiq_agent.agents.report_rewriter.models import ReportRewriterAgentState
+
+    writer_llm = FakeWriterLLM()
+    provider = LLMProvider()
+    provider.configure(LLMRole.REPORT_WRITER, writer_llm)
+    agent = ReportRewriterAgent(llm_provider=provider, tools=[])
+
+    with pytest.raises(ValueError, match="/shared/original_report.md"):
+        await agent.run(ReportRewriterAgentState(messages=[HumanMessage(content="Shorten it.")], files={}))

--- a/tests/aiq_agent/agents/report_rewriter/test_agent.py
+++ b/tests/aiq_agent/agents/report_rewriter/test_agent.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 from langchain_core.messages import AIMessage
 from langchain_core.messages import HumanMessage
@@ -67,6 +69,53 @@ async def test_rewrite_report_core_returns_revised_markdown_and_renders_prompt()
     rendered_prompt = writer_llm.seen_messages[0].content
     assert "# Parent" in rendered_prompt
     assert "Add a Messi-Ronaldo joke under the title." in rendered_prompt
+
+
+@pytest.mark.asyncio
+async def test_report_rewriter_verifies_and_sanitizes_revised_report_against_parent_sources():
+    from aiq_agent.agents.report_rewriter.agent import ReportRewriterAgent
+    from aiq_agent.agents.report_rewriter.models import ReportRewriterAgentState
+
+    writer_llm = FakeWriterLLM(
+        content=(
+            "# Revised Report\n\n"
+            "Supported claim [1]. Unsupported claim [2].\n\n"
+            "## Sources\n"
+            "[1] Valid Source: https://valid.example/source\n"
+            "[2] Fabricated Source: https://fabricated.example/source"
+        )
+    )
+    provider = LLMProvider()
+    provider.configure(LLMRole.REPORT_WRITER, writer_llm)
+    agent = ReportRewriterAgent(llm_provider=provider, tools=[])
+
+    parent_context = {
+        "parent_job_id": "parent-job",
+        "sources": [
+            {
+                "url": "https://valid.example/source",
+                "title": "Valid Source",
+                "source_type": "parent_report",
+                "tool_name": "parent_report",
+            }
+        ],
+    }
+    state = ReportRewriterAgentState(
+        messages=[HumanMessage(content="Make it clearer.")],
+        files={
+            "/shared/original_report.md": "# Parent\n\nSupported claim [1].\n\n## Sources\n[1] Valid Source: https://valid.example/source",
+            "/shared/source_summary.md": "- [1] Valid Source: https://valid.example/source",
+            "/shared/parent_report_context.json": json.dumps(parent_context),
+        },
+    )
+
+    result = await agent.run(state)
+
+    revised_report = result.files["/shared/output.md"]
+    assert "https://valid.example/source" in revised_report
+    assert "https://fabricated.example/source" not in revised_report
+    assert "[2]" not in revised_report
+    assert result.messages[-1].content == revised_report
 
 
 @pytest.mark.asyncio

--- a/tests/aiq_agent/common/test_citation_verification.py
+++ b/tests/aiq_agent/common/test_citation_verification.py
@@ -577,7 +577,7 @@ class TestVerifyCitations:
         report = "Finding one [1]. Missing source [3]. Finding two [2]."
         result = verify_citations(report, registry, reference_sources=registry.all_sources()[:2])
 
-        assert "Missing source ." in result.verified_report
+        assert "Missing source." in result.verified_report
         assert "[3]" not in result.verified_report
         assert "[1] Article 1: https://valid.com/article1" in result.verified_report
         assert "[2] Article 2: https://valid.com/article2" in result.verified_report
@@ -735,7 +735,7 @@ class TestVerifyCitations:
         assert len(result.removed_citations) == 1
         assert result.removed_citations[0]["number"] == 2
         assert result.removed_citations[0]["reason"] == "url_not_in_registry"
-        assert "Good finding [1]. Bad finding ." in result.verified_report
+        assert "Good finding [1]. Bad finding." in result.verified_report
         assert "Fake Source" not in result.verified_report
 
     def test_ordered_list_parenthesis_references_are_normalized_and_verified(self, registry):
@@ -783,7 +783,7 @@ class TestVerifyCitations:
         report = "Good finding [1]. Missing reference [3].\n\n## Sources\n[1] Article 1: https://valid.com/article1"
         result = verify_citations(report, registry)
 
-        assert "Missing reference ." in result.verified_report
+        assert "Missing reference." in result.verified_report
         assert "[3]" not in result.verified_report
         assert len(result.valid_citations) == 1
         assert not result.removed_citations
@@ -797,8 +797,8 @@ class TestVerifyCitations:
         )
         result = verify_citations(report, registry)
 
-        assert "Bad finding ." in result.verified_report
-        assert "Missing reference ." in result.verified_report
+        assert "Bad finding." in result.verified_report
+        assert "Missing reference." in result.verified_report
         assert "[2]" not in result.verified_report
         assert "[3]" not in result.verified_report
         assert len(result.valid_citations) == 1

--- a/tests/aiq_agent/jobs/test_runner.py
+++ b/tests/aiq_agent/jobs/test_runner.py
@@ -1526,13 +1526,13 @@ class TestAsyncJobRunnerAgentFactory:
     @pytest.mark.asyncio
     async def test_run_agent_seeds_initial_files_when_state_supports_files(self):
         """Async runner seeds DeepAgents virtual filesystem files into stateful agents."""
+        from typing import Annotated
         from typing import Any
 
         from langchain_core.messages import AnyMessage
         from langgraph.graph.message import add_messages
         from pydantic import BaseModel
         from pydantic import Field
-        from typing_extensions import Annotated
 
         from aiq_api.jobs import runner
 

--- a/tests/aiq_agent/jobs/test_runner.py
+++ b/tests/aiq_agent/jobs/test_runner.py
@@ -1533,6 +1533,44 @@ class TestAsyncJobRunnerAgentFactory:
         assert agent.config is fn_config
         assert agent.job_id == "job-123"
 
+    def test_create_agent_instance_passes_job_id_to_agent_without_config_arg(self):
+        """Async workers should preserve job_id for non-deep agents that do not need config."""
+        from aiq_agent.agents.deep_researcher.register import DeepResearchAgentConfig
+        from aiq_api.jobs.runner import _create_agent_instance
+
+        class FakeReportRewriterAgent:
+            def __init__(
+                self,
+                llm_provider,
+                tools=None,
+                *,
+                verbose=False,
+                callbacks=None,
+                job_id=None,
+            ):
+                self.llm_provider = llm_provider
+                self.tools = tools
+                self.verbose = verbose
+                self.callbacks = callbacks
+                self.job_id = job_id
+
+        agent = _create_agent_instance(
+            agent_cls=FakeReportRewriterAgent,
+            llm_provider="provider",
+            llm="llm",
+            tools=["tool"],
+            fn_config=DeepResearchAgentConfig(orchestrator_llm="llm"),
+            verbose=True,
+            callbacks=["callback"],
+            job_id="job-123",
+        )
+
+        assert agent.llm_provider == "provider"
+        assert agent.tools == ["tool"]
+        assert agent.verbose is True
+        assert agent.callbacks == ["callback"]
+        assert agent.job_id == "job-123"
+
     def test_async_deep_researcher_constructor_applies_config_tuning(self):
         """Async construction preserves catalog and concurrency settings."""
         from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent

--- a/tests/aiq_agent/jobs/test_runner.py
+++ b/tests/aiq_agent/jobs/test_runner.py
@@ -1571,6 +1571,58 @@ class TestAsyncJobRunnerAgentFactory:
         assert result == {"report": "# Parent"}
         assert agent.seen_state.files == initial_files
 
+    @pytest.mark.asyncio
+    async def test_run_agent_skips_data_sources_when_state_lacks_field(self):
+        """Runner must not inject data_sources into states that don't declare the field.
+
+        report_rewriter's state omits data_sources; with Pydantic's default (extra
+        ignored) that is currently harmless, but the runner should not pass fields a
+        state does not model. This uses an extra=forbid state to prove the guard
+        actually prevents the injection (without it, state construction would raise).
+        """
+        from typing import Annotated
+
+        from langchain_core.messages import AnyMessage
+        from langgraph.graph.message import add_messages
+        from pydantic import BaseModel
+        from pydantic import ConfigDict
+
+        from aiq_api.jobs import runner
+
+        class StrictState(BaseModel):
+            model_config = ConfigDict(extra="forbid")
+            messages: Annotated[list[AnyMessage], add_messages]
+
+        class FakeAgent:
+            def __init__(self):
+                self.seen_state = None
+
+            async def run(self, state):
+                self.seen_state = state
+                return "ok"
+
+        class FakeMonitor:
+            is_cancelled = False
+
+            def start(self):
+                return None
+
+            def stop(self):
+                return None
+
+        agent = FakeAgent()
+
+        with patch("aiq_api.jobs.runner._get_agent_state_class", return_value=StrictState):
+            result = await runner._run_agent(
+                agent=agent,
+                input_text="revise",
+                monitor=FakeMonitor(),
+                data_sources=["web_search"],
+            )
+
+        assert result == "ok"
+        assert not hasattr(agent.seen_state, "data_sources")
+
     def test_async_deep_researcher_constructor_preserves_writer_skills(self):
         """Async job construction preserves writer-only skills and sandbox job scoping."""
         from langchain_core.messages import HumanMessage

--- a/tests/aiq_agent/jobs/test_runner.py
+++ b/tests/aiq_agent/jobs/test_runner.py
@@ -435,8 +435,41 @@ class TestSubmitDeepResearchJob:
         assert result == "test-job-id"
         mock_job_store.submit_job.assert_called_once()
         job_args = mock_job_store.submit_job.call_args.kwargs["job_args"]
-        # data_sources is second-to-last (auth_token is last)
-        assert job_args[-2] == ["web_search"]
+        assert ["web_search"] in job_args
+
+    @pytest.mark.asyncio
+    async def test_submit_agent_job_passes_initial_files_and_output_metadata(self):
+        """Test submit_agent_job forwards report context files and output metadata into worker args."""
+        from aiq_api.jobs.submit import submit_agent_job
+
+        mock_job_store = MagicMock()
+        mock_job_store.ensure_job_id.return_value = "test-job-id"
+        mock_job_store.submit_job = AsyncMock(return_value=None)
+        initial_files = {"/shared/original_report.md": "# Report"}
+        output_metadata = {"parent_job_id": "parent-job", "interaction_action": "edit"}
+
+        with patch.dict(
+            "os.environ",
+            {
+                "NAT_DASK_SCHEDULER_ADDRESS": "tcp://localhost:8786",
+                "NAT_JOB_STORE_DB_URL": "sqlite:///./test.db",
+            },
+        ):
+            with patch("nat.front_ends.fastapi.async_jobs.job_store.JobStore", return_value=mock_job_store):
+                with patch("aiq_api.jobs.submit.get_current_principal", return_value=self.principal):
+                    with patch("aiq_api.jobs.submit.create_job_access"):
+                        result = await submit_agent_job(
+                            agent_type="deep_researcher",
+                            input_text="test query",
+                            owner="test@example.com",
+                            initial_files=initial_files,
+                            output_metadata=output_metadata,
+                        )
+
+        assert result == "test-job-id"
+        job_args = mock_job_store.submit_job.call_args.kwargs["job_args"]
+        assert job_args[-2] == initial_files
+        assert job_args[-1] == output_metadata
 
     @pytest.mark.asyncio
     async def test_submit_with_custom_job_id(self):
@@ -1489,6 +1522,54 @@ class TestAsyncJobRunnerAgentFactory:
         assert agent.max_research_concurrency == 2
         assert agent.max_concurrent_source_tool_calls == 3
         assert agent.max_source_tool_batch_size == 4
+
+    @pytest.mark.asyncio
+    async def test_run_agent_seeds_initial_files_when_state_supports_files(self):
+        """Async runner seeds DeepAgents virtual filesystem files into stateful agents."""
+        from typing import Any
+
+        from langchain_core.messages import AnyMessage
+        from langgraph.graph.message import add_messages
+        from pydantic import BaseModel
+        from pydantic import Field
+        from typing_extensions import Annotated
+
+        from aiq_api.jobs import runner
+
+        class FakeState(BaseModel):
+            messages: Annotated[list[AnyMessage], add_messages]
+            files: dict[str, Any] = Field(default_factory=dict)
+
+        class FakeAgent:
+            def __init__(self):
+                self.seen_state = None
+
+            async def run(self, state):
+                self.seen_state = state
+                return {"report": state.files["/shared/original_report.md"]}
+
+        class FakeMonitor:
+            is_cancelled = False
+
+            def start(self):
+                return None
+
+            def stop(self):
+                return None
+
+        agent = FakeAgent()
+        initial_files = {"/shared/original_report.md": "# Parent"}
+
+        with patch("aiq_api.jobs.runner._get_agent_state_class", return_value=FakeState):
+            result = await runner._run_agent(
+                agent=agent,
+                input_text="revise",
+                monitor=FakeMonitor(),
+                initial_files=initial_files,
+            )
+
+        assert result == {"report": "# Parent"}
+        assert agent.seen_state.files == initial_files
 
     def test_async_deep_researcher_constructor_preserves_writer_skills(self):
         """Async job construction preserves writer-only skills and sandbox job scoping."""

--- a/tests/aiq_agent/jobs/test_runner.py
+++ b/tests/aiq_agent/jobs/test_runner.py
@@ -1485,6 +1485,54 @@ class TestAsyncJobRunnerAgentFactory:
         assert agent.max_concurrent_source_tool_calls == 3
         assert agent.max_source_tool_batch_size == 4
 
+    def test_create_agent_instance_allows_non_deep_agent_to_reuse_deep_config(self):
+        """Async workers should not treat shared DeepResearchAgentConfig as a constructor contract."""
+        from aiq_agent.agents.deep_researcher.register import DeepResearchAgentConfig
+        from aiq_api.jobs.runner import _create_agent_instance
+
+        class FakeReportRewriterAgent:
+            def __init__(
+                self,
+                llm_provider,
+                tools=None,
+                *,
+                verbose=False,
+                callbacks=None,
+                config=None,
+                job_id=None,
+            ):
+                self.llm_provider = llm_provider
+                self.tools = tools
+                self.verbose = verbose
+                self.callbacks = callbacks
+                self.config = config
+                self.job_id = job_id
+
+        fn_config = DeepResearchAgentConfig(
+            orchestrator_llm="llm",
+            domain_catalog_path="configs/domain_catalogs/deep_research_domain_catalog.yml",
+            enable_source_router=False,
+            enable_citation_verification=False,
+        )
+
+        agent = _create_agent_instance(
+            agent_cls=FakeReportRewriterAgent,
+            llm_provider="provider",
+            llm="llm",
+            tools=["tool"],
+            fn_config=fn_config,
+            verbose=True,
+            callbacks=["callback"],
+            job_id="job-123",
+        )
+
+        assert agent.llm_provider == "provider"
+        assert agent.tools == ["tool"]
+        assert agent.verbose is True
+        assert agent.callbacks == ["callback"]
+        assert agent.config is fn_config
+        assert agent.job_id == "job-123"
+
     def test_async_deep_researcher_constructor_applies_config_tuning(self):
         """Async construction preserves catalog and concurrency settings."""
         from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent


### PR DESCRIPTION
#### Overview

Adds **report-aware follow-up** to the deep-research blueprint. After a report job completes, a user can ask about it, make cosmetic edits, or start delta research that reuses the prior report — without forcing every follow-up through a dedicated "report mode." A chat **router** picks a semantic route from the message plus an optional `active_report_job_id`; the active report is treated as *context*, never as a command.

**Modes**
- **report ask** — inline, bounded LLM answer from the parent report only. No tools, no live research, no child artifact.
- **report cosmetic edit** — an internal `report_rewriter` async child job for mechanical/aesthetic edits that do not need new evidence. The parent report stays immutable.
- **report delta research** — the existing deep researcher, seeded with parent-report context, for fresh evidence, deeper analysis, or a new analytical perspective on the same report topic.
- **standalone research** — normal shallow/deep research when the request is unrelated to the active report or asks for a separate report.

**Intent routing examples**
- `what are the risks in this report?` → `report_ask`
- `make this shorter` → `report_cosmetic_edit`
- `format the key takeaways as bullets` → `report_cosmetic_edit`
- `rewrite this report from a player-performance POV` → `report_delta_research`
- `redo this with newer evidence on 2026 logistics` → `report_delta_research`
- `write a separate report on player performance trends across 2014, 2018, and 2022` → `standalone_research`

**Key pieces**
- One new internal agent — `report_rewriter` — registered with `public=False` (hidden from `GET /agents`; direct `/submit` of internal-only agents is rejected, and the gate is also enforced at the submission boundary).
- A durable parent-report **context resolver** that reconstructs the report + sources from job output/events, **authorizes the caller before any read**, and seeds `/shared/*` files into child runs.
- New endpoint `POST /v1/jobs/async/job/{job_id}/report/edit` (per-job ownership auth); `GET .../report` extended with `parent_job_id` / `interaction_action` / `result_kind`.
- Chat (`POST /chat` / WebSocket) accepts `active_report_job_id`; the UI forwards the latest completed report job id and renders the report-edit child job through the existing report-streaming path.
- DeepAgents runtime normalizes seeded `/shared/*` parent-context files so delta research can read `/shared/original_report.md` and `/shared/source_summary.md` reliably.

> Rebased onto `develop` (which now includes #267); this branch is a standalone PR. The most recent commits harden the feature for production: the chat path works under the default `REQUIRE_AUTH=false`, a caller-supplied `job_id` can no longer delete another job's state, submission failures roll back cleanly, the UI consumes the report-edit response, and report-delta research can reuse seeded parent context without creating `/shared/shared` or malformed file records.

#### Validation

All commands run from the repo root unless noted.

**Lint / format / unit tests (backend)**
```bash
uv run ruff check .
uv run ruff format --check .
uv run pytest                                  # full suite
# or the suites this PR touches:
uv run pytest frontends/aiq_api/tests/ \
              tests/aiq_agent/agents/chat_researcher/ \
              tests/aiq_agent/agents/report_rewriter/ \
              tests/aiq_agent/agents/deep_researcher/test_deepagents_runtime.py \
              tests/aiq_agent/jobs/test_runner.py
```

**UI**
```bash
cd frontends/ui
npm run lint && npm run type-check && npm run test:ci
# focused: npx vitest run src/features/chat/hooks/use-websocket-chat.spec.ts \
#                         src/adapters/api/websocket-client.spec.ts
```

**End-to-end (manual)** — report follow-up needs async jobs, so bring up the full stack (PostgreSQL job store + embedded Dask scheduler/worker + web), e.g. via `deploy/compose` or `scripts/start_server_in_debug_mode.sh` with `deploy/.env`, then exercise the surfaces below.

**What to test**
1. **Internal-agent gating** — `GET /v1/jobs/async/agents` does *not* list `report_rewriter`; `POST /v1/jobs/async/submit` with `agent_type=report_rewriter` returns `400 Agent type is internal-only: report_rewriter`.
2. **HTTP report edit** — `POST /v1/jobs/async/job/{id}/report/edit` on a completed report → a `report_rewriter` child job; `GET .../report` on the child returns a revised report plus `parent_job_id`, `interaction_action="edit"`, `result_kind="report"`. The parent report is unchanged.
3. **Chat routing with `active_report_job_id`** — verify each semantic route:
   - **report ask**: `What are the top three takeaways from this report?`; `Where does the report say the evidence is weak or incomplete?`
   - **report cosmetic edit**: `Make this report shorter while preserving the sources.`; `Format the key takeaways as bullets.`; `Remove the one-table comparison section and keep the rest unchanged.`
   - **report delta research**: `Rewrite this report from a player-performance POV.`; `Redo this report with newer evidence on 2026 logistics and host-city operations.`; `Add a section on fan travel emissions for 2026.`
   - **standalone research**: `Write a separate report on player performance trends across the 2014, 2018, and 2022 World Cups.`; `Research the economics of Olympic host cities since 2000.`
4. **Parent-context seeding for delta research** — delta research should read `/shared/original_report.md` and `/shared/source_summary.md` successfully, not see `/shared/shared/`, and not fail with `string indices must be integers` or `'str' object has no attribute 'get'` from filesystem tools.
5. **Authorization** — works for anonymous callers under `REQUIRE_AUTH=false`; under `REQUIRE_AUTH=true`, a non-owner is rejected with `404` before any report content is read.
6. **Robustness / edge cases** — a colliding caller-supplied `job_id` returns `409` and does **not** delete the existing job; whitespace-only `input` returns `422`; report ask/edit degrade to a chat message (not an opaque workflow error) if context resolution fails.

**Evidence** — backend suites (`frontends/aiq_api/tests` + `tests/aiq_agent/...`) and UI specs pass; `ruff` and `tsc` clean. Verified live against a Postgres + Dask stack with `deploy/.env`: internal agent hidden + `/submit` rejected (400); HTTP and chat report-edit produce a revised child report with correct lineage; chat report-ask answers from the report only; `job_id` collision → 409 with the victim preserved; blank input → 422; ownership-mismatch → 404 under `REQUIRE_AUTH=true`; report-delta routing kicks off deep research with seeded parent context.

- [x] I ran the relevant local checks or explained why they are not applicable.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-facing or contributor-facing changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.

#### Where should reviewers start?

Read in this order — security-sensitive paths first:

1. **`frontends/aiq_api/src/aiq_api/jobs/report_context.py`** — durable report/source reconstruction and `resolve_authorized_report_context()`, which **authorizes the caller before any read** and seeds `/shared/*` for child runs. The core security boundary.
2. **`frontends/aiq_api/src/aiq_api/routes/jobs.py`** — the `report/edit` endpoint, the `public` agent filter on `/agents` + `/submit`, the new `JobReportResponse` fields, and the request validators (blank-input → 422, `job_id` collision → 409).
3. **`frontends/aiq_api/src/aiq_api/jobs/submit.py`** — `submit_agent_job()` ownership recording, the `JobIdConflictError`/`InternalAgentError` gates, and the rollback that only deletes state this submission created.
4. **`src/aiq_agent/agents/chat_researcher/nodes/intent_classifier.py`** + **`agent.py`** + **`register.py`** — the semantic route classifier (`report_ask` / `report_cosmetic_edit` / `report_delta_research` / `standalone_research`), the bounded tool-free report-ask path, and how each entry point resolves the principal (same contract as the HTTP routes).
5. **`src/aiq_agent/agents/deep_researcher/deepagents_runtime.py`** — route-aware `/shared/*` file seeding for delta research.
6. **`src/aiq_agent/agents/report_rewriter/`** — the single new internal agent (a bounded, tool-less single-LLM rewrite).
7. **`frontends/ui/src/features/chat/hooks/use-websocket-chat.ts`** + `adapters/api/websocket-client.ts` — forwards `active_report_job_id` and routes the report-edit child job through the existing report-streaming path.

Tests mirror these: `test_report_context.py`, `test_report_edit.py`, `test_submit_collision.py`, `test_submit_internal_agent.py`, `test_job_access.py`, `test_agent_registry_visibility.py`, `test_intent_classifier.py`, `test_deepagents_runtime.py` (backend), and `use-websocket-chat.spec.ts` (UI).

#### Related Issues

- Relates to #267 (deep-researcher structured output / customization — merged into `develop`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Report editing and follow-up workflows to revise completed reports
  * Report Q&A capability to ask questions about existing reports
  * Conversation-scoped job tracking for multi-turn interactions
  * Agent visibility controls restricting certain agents from public submission

* **Improvements**
  * Enhanced input validation and error responses for job submissions
  * Expanded REST API documentation for report operations
  * Better job ID conflict detection and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
