### PR TITLE
feat(skills): complete maintainer skill set and extend aiq-research

### DIFF
--- a/.agents/skills/aiq-add-tool/SKILL.md
+++ b/.agents/skills/aiq-add-tool/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: aiq-add-tool
+description: Use when adding or changing a general-purpose AI-Q tool (a NeMo Agent Toolkit function) under sources/, defining its FunctionBaseConfig schema, registering it with @register_function, wiring it into an agent's tools list, or testing it.
+license: Apache-2.0
+compatibility: Claude Code, Codex, Cursor, OpenCode, and Agent Skills-compatible tools.
+metadata:
+  version: "0.1.0"
+  source-repo: "NVIDIA-AI-Blueprints/aiq"
+  tags: "aiq nemo-agent-toolkit tool function sources"
+allowed-tools: Read Bash Edit
+---
+
+# Add an AI-Q Tool
+
+Use this skill when a developer wants to add a general-purpose tool to AI-Q — a
+NeMo Agent Toolkit (NAT) function such as a web search, calculator, or code
+helper. The tool is a package under `sources/`, registered with
+`@register_function` and referenced directly in an agent's `tools` list.
+
+## Start Here
+
+- Confirm this is a **general utility tool**. If it is domain-specific retrieval
+  that should appear as a toggleable source in the UI, use `aiq-add-data-source`
+  instead — a data source is the same NAT function plus a `data_source_registry`
+  entry. This skill stops at wiring the tool into an agent.
+- Read the authoritative files below before editing.
+- Copy the closest existing tool package rather than inventing a new shape.
+- Never print or commit API keys; resolve secrets at runtime via `SecretStr`.
+
+## Authoritative References
+
+- `docs/source/extending/adding-a-tool.md`: canonical 8-step walkthrough; the
+  workflow below mirrors it.
+- `sources/tavily_web_search/`: minimal tool package.
+- `sources/google_scholar_paper_search/`: tool package with a separate client,
+  a graceful missing-secret stub, and tests.
+- `docs/source/extending/adding-a-data-source.md`: "Data Source vs. Tool" — a
+  data source is architecturally identical to a tool; only the registry wiring
+  differs.
+
+Existing tools to model on: `tavily_web_search`, `exa_web_search`,
+`paper_search` (Google Scholar), `knowledge_retrieval`.
+
+Longer procedures live in this bundle:
+
+- [references/nat-function-pattern.md](references/nat-function-pattern.md):
+  package layout, config class, registration, the missing-secret stub, the
+  `pyproject.toml` entry point, and wiring the tool into an agent in YAML.
+- [references/testing.md](references/testing.md): unit-test pattern and the
+  install/test/lint validation commands.
+
+## Workflow
+
+1. Pick the closest existing package under `sources/` and inspect its layout.
+2. Create `sources/<my_tool>/` with `src/register.py`, a client module,
+   `pyproject.toml`, and `tests/`.
+3. Define a `FunctionBaseConfig` subclass with a stable `name=` (this becomes the
+   YAML `_type`); resolve any API key via `SecretStr`.
+4. Register an async `@register_function` that yields a `FunctionInfo`; yield a
+   graceful stub when a required secret is missing.
+5. Add the `[project.entry-points."nat.plugins"]` entry and install the package
+   editable.
+6. Reference the tool in a config under `configs/` (under `functions:`, then in
+   an agent's `tools:` list).
+7. Add focused tests; run the validation commands below.
+8. Summarize changed files and paste the test/lint evidence.
+
+## Validation
+
+Run the narrowest commands first; broaden only if the change touches shared code.
+
+```bash
+uv pip install -e ./sources/my_tool
+uv run pytest sources/my_tool/tests
+uv run ruff check sources/my_tool
+uv run ruff format --check sources/my_tool
+```
+
+Expected: the package installs, its tests pass, and Ruff reports no lint or
+format failures for the new tool package.
+
+## Common Mistakes
+
+- Omitting the `[project.entry-points."nat.plugins"]` entry in `pyproject.toml`,
+  so NAT never discovers the registration at import time.
+- Crashing on a missing API key instead of yielding a stub that returns a clear
+  error string.
+- Raising exceptions from the tool function; tools must return error messages as
+  strings so they never crash the agent.
+- Weak docstrings: the LLM uses the function docstring as the tool description to
+  decide when to call it — state what it does, when to use it, and what it returns.
+- Printing API keys or embedding secrets in YAML instead of using environment
+  variables or `SecretStr`.
+
+## Related Skills
+
+- `aiq-add-data-source`
+- `aiq-release-qa`
+- `aiq-prepare-pr`

--- a/.agents/skills/aiq-add-tool/references/nat-function-pattern.md
+++ b/.agents/skills/aiq-add-tool/references/nat-function-pattern.md
@@ -1,0 +1,130 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# NAT function pattern
+
+Authoritative source: `docs/source/extending/adding-a-tool.md`. Model new tools
+on `sources/google_scholar_paper_search/` (has tests) or `sources/tavily_web_search/`
+(minimal).
+
+## Package layout
+
+```text
+sources/my_tool/
+  pyproject.toml
+  README.md
+  src/
+    __init__.py
+    register.py        # config class + NAT registration
+    my_client.py       # NAT-independent implementation
+  tests/
+    __init__.py
+    conftest.py
+    test_my_tool.py
+```
+
+Keep the client (`my_client.py`) free of NAT imports so it is unit-testable on
+its own; `register.py` adapts it into a NAT function.
+
+## Config class and registration
+
+In `src/register.py`, define a `FunctionBaseConfig` subclass with a stable
+`name=` (this is the YAML `_type`), resolve secrets via `SecretStr`, and yield a
+`FunctionInfo` from an async `@register_function`:
+
+```python
+import os
+
+from pydantic import Field, SecretStr
+from nat.builder.builder import Builder
+from nat.builder.function_info import FunctionInfo
+from nat.cli.register_workflow import register_function
+from nat.data_models.function import FunctionBaseConfig
+
+
+class MyToolConfig(FunctionBaseConfig, name="my_tool"):
+    """Config for the my_tool function."""
+
+    max_results: int = Field(default=10, description="Max results to return")
+    my_api_key: SecretStr | None = Field(default=None, description="API key")
+
+
+@register_function(config_type=MyToolConfig)
+async def my_tool(tool_config: MyToolConfig, builder: Builder):
+    api_key = os.environ.get("MY_API_KEY") or (
+        tool_config.my_api_key.get_secret_value() if tool_config.my_api_key else None
+    )
+    if not api_key:
+        async def _stub(query: str) -> str:
+            """Tool unavailable - missing MY_API_KEY."""
+            return "Error: my_tool is unavailable because MY_API_KEY is not set."
+
+        yield FunctionInfo.from_fn(_stub, description=_stub.__doc__)
+        return
+
+    async def _run(query: str) -> str:
+        """Describe WHAT the tool does, WHEN to use it, and WHAT it returns."""
+        ...  # call the client in my_client.py
+
+    yield FunctionInfo.from_fn(_run, description=_run.__doc__)
+```
+
+Notes:
+
+- The function docstring becomes the `description` the LLM sees — make it
+  specific so the agent calls the tool at the right time.
+- Tools must not raise; catch errors and return an error string.
+- For results with URLs, use the `<Document href="...">...</Document>` format so
+  the agent can cite sources.
+
+## pyproject.toml entry point
+
+```toml
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools >= 64", "setuptools-scm>=8"]
+
+[tool.setuptools]
+packages = ["my_tool"]
+package-dir = {"my_tool" = "src"}
+
+[project]
+name = "my-tool"
+version = "1.0.0"
+description = "NAT-based <what it does> tool"
+readme = "README.md"
+requires-python = ">=3.11,<3.14"
+license = {text = "Apache-2.0"}
+dependencies = [
+    "httpx>=0.24.0",
+    "pydantic>=2.0.0",
+]
+
+# REQUIRED so NAT discovers the registration at import time. The left-hand key
+# is the YAML `_type` name; the right-hand value points at the register module.
+[project.entry-points."nat.plugins"]
+my_tool = "my_tool.register"
+```
+
+## Wire the tool into an agent (YAML)
+
+Unlike a data source, a plain tool is referenced **directly** in an agent's
+`tools` list — there is no `data_source_registry` entry and no UI toggle:
+
+```yaml
+functions:
+  my_search:
+    _type: my_tool         # matches the config class name= / entry-point key
+    max_results: 10
+
+  shallow_research_agent:
+    _type: shallow_research_agent
+    llm: research_llm
+    tools:
+      - my_search
+```
+
+If you want the tool to appear as a toggleable UI source instead, stop here and
+use `aiq-add-data-source`, which adds the registry entry on top of this pattern.

--- a/.agents/skills/aiq-add-tool/references/testing.md
+++ b/.agents/skills/aiq-add-tool/references/testing.md
@@ -1,0 +1,79 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Testing a tool
+
+Authoritative source: `docs/source/extending/adding-a-tool.md` (Step 8). Model
+tests on `sources/google_scholar_paper_search/tests/test_paper_search.py`.
+
+## Unit tests
+
+Test the client (in `my_client.py`) directly with mocked I/O — no live network.
+Cover both the success path and graceful empty/error handling.
+
+```python
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from my_tool.my_client import MyClient
+
+
+@pytest.mark.asyncio
+async def test_returns_results():
+    client = MyClient(api_key="test-key", max_results=5)
+    with patch("httpx.AsyncClient.get") as mock_get:
+        mock_get.return_value = AsyncMock(
+            status_code=200,
+            json=lambda: {"results": [{"url": "https://example.com", "content": "Example"}]},
+            raise_for_status=lambda: None,
+        )
+        result = await client.run("test query")
+    assert "Example" in result
+
+
+@pytest.mark.asyncio
+async def test_handles_no_results():
+    client = MyClient(api_key="test-key")
+    with patch("httpx.AsyncClient.get") as mock_get:
+        mock_get.return_value = AsyncMock(
+            status_code=200,
+            json=lambda: {"results": []},
+            raise_for_status=lambda: None,
+        )
+        result = await client.run("nonexistent")
+    assert "No results found" in result
+```
+
+Also cover the missing-secret stub path: with no API key set, the registered
+function should yield the stub that returns a clear error string rather than
+raising.
+
+## Validation commands
+
+Run from the repo root:
+
+```bash
+uv pip install -e ./sources/my_tool
+uv run pytest sources/my_tool/tests
+uv run ruff check sources/my_tool
+uv run ruff format --check sources/my_tool
+```
+
+Expected: the package installs, tests pass, and Ruff reports no lint or format
+failures (line length 120, target 3.11).
+
+## Integration check (optional)
+
+With a real API key set, run the tool through a config that references it:
+
+```bash
+.venv/bin/nat run --config_file configs/my_config.yml --input "test query"
+```
+
+## Evidence to capture
+
+For the PR (see `aiq-prepare-pr`), record the created/changed files, the
+`pytest` transcript with pass counts, and the `ruff` results. Never print secret
+values in captured output.

--- a/.agents/skills/aiq-prepare-pr/SKILL.md
+++ b/.agents/skills/aiq-prepare-pr/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: aiq-prepare-pr
+description: Use when preparing, opening, or updating an AI-Q pull request — scoping the branch, signing commits with DCO, filling the PR template with real validation evidence, and following the copy-pr-bot CI and merge flow.
+license: Apache-2.0
+compatibility: Claude Code, Codex, Cursor, OpenCode, and Agent Skills-compatible tools.
+metadata:
+  version: "0.1.0"
+  source-repo: "NVIDIA-AI-Blueprints/aiq"
+  tags: "aiq pull-request dco contributing release-qa"
+allowed-tools: Read Bash Edit
+---
+
+# Prepare an AI-Q Pull Request
+
+Use this skill to take a finished AI-Q change from a working branch to a
+review-ready pull request: a focused branch off `develop`, DCO-signed commits,
+the PR template filled with real validation evidence, and the copy-pr-bot CI
+flow followed correctly.
+
+## Start Here
+
+- Confirm the change is scoped: no unrelated files, no generated artifacts, no
+  secrets, no environment-specific hostnames.
+- Confirm validation already ran. This skill does not invent test commands —
+  run `aiq-release-qa` first and reuse its exact output as evidence.
+- Confirm every commit is signed off (DCO). Commits without a `Signed-off-by`
+  trailer may be rejected.
+- Target the `develop` branch unless a maintainer asked for a release branch.
+
+## Authoritative References
+
+- [CONTRIBUTING.md](../../../CONTRIBUTING.md): the canonical PR workflow, Local
+  Validation, DCO text, and the copy-pr-bot / `/ok to test` / `/merge` flow.
+- [.github/pull_request_template.md](../../../.github/pull_request_template.md):
+  the exact sections and checklist your PR description must fill.
+- [AGENTS.md](../../../AGENTS.md): "Git and PR hygiene" and the validation
+  commands `aiq-release-qa` runs.
+
+For the step-by-step checklist and the bot command reference:
+
+- [references/pr-checklist.md](references/pr-checklist.md)
+
+## Workflow
+
+1. Verify the branch is focused and based on `develop`; rebase or reset scope if
+   unrelated files crept in.
+2. Ensure every commit is signed: `git commit -s` (and `git commit --amend -s`
+   or `git rebase --signoff` to fix unsigned commits already made).
+3. Run the relevant checks via `aiq-release-qa` and keep the exact output.
+4. Push the branch and open the PR into `develop`.
+5. Fill the PR template: Overview, Validation (paste the commands and output),
+   reviewer starting point, related issues, and tick every checklist box you
+   can honestly tick.
+6. Drive CI: a maintainer or vetter comments `/ok to test`, copy-pr-bot mirrors
+   the PR to `pull-request/<number>`, and CI runs there.
+7. Address review feedback until required checks and code-owner review pass.
+
+## Validation
+
+This skill is about PR hygiene, not code execution; verify the contributor
+mechanics:
+
+```bash
+git log --pretty=full origin/develop..HEAD | grep -c "Signed-off-by:"  # every commit signed
+git diff --name-only origin/develop..HEAD                              # only intended files
+git status --porcelain                                                 # no stray artifacts
+```
+
+Expected: the sign-off count equals your commit count, the changed-file list
+contains only files relevant to this change, and the working tree is clean.
+
+## Common Mistakes
+
+- Unsigned commits. Use `git commit -s`; fix existing ones with
+  `git rebase --signoff origin/develop` before pushing.
+- A vague Validation section. Paste the real commands and their output from
+  `aiq-release-qa`; "ran tests" is not evidence.
+- Scope creep: unrelated refactors, formatting churn on untouched files, or
+  committed generated artifacts.
+- Committing secrets or `deploy/.env` values. Resolve secrets at runtime; never
+  paste them into the PR.
+- Expecting CI to run on push alone — it runs on the copy-pr-bot mirror after
+  `/ok to test`.
+- Skipping the docs update for user-facing or contributor-facing changes.
+
+## Related Skills
+
+- `aiq-release-qa`
+- `aiq-add-tool`
+- `aiq-add-data-source`
+</content>

--- a/.agents/skills/aiq-prepare-pr/references/pr-checklist.md
+++ b/.agents/skills/aiq-prepare-pr/references/pr-checklist.md
@@ -1,0 +1,75 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# AI-Q PR checklist and bot commands
+
+Step-by-step companion to `SKILL.md`. The source of truth is `CONTRIBUTING.md`
+and `.github/pull_request_template.md`; this file condenses them into an
+actionable checklist.
+
+## 1. Scope and branch
+
+- Branch is created from `develop` and named for the change.
+- The diff contains only files relevant to this change — no unrelated
+  refactors, no formatting churn on untouched files, no generated artifacts.
+- No secrets, credentials, private hostnames, internal-only logs, or customer
+  data are included.
+
+```bash
+git diff --name-only origin/develop..HEAD   # confirm the file set
+git status --porcelain                      # confirm a clean tree
+```
+
+## 2. DCO sign-off
+
+Every commit must carry a `Signed-off-by: Your Name <your@email.com>` trailer.
+
+```bash
+git commit -s -m "Concise, scoped change"   # sign as you commit
+git commit --amend -s --no-edit             # sign the latest commit
+git rebase --signoff origin/develop         # sign a range already committed
+```
+
+Verify the count matches your commits:
+
+```bash
+git log --pretty=full origin/develop..HEAD | grep -c "Signed-off-by:"
+```
+
+## 3. Validation evidence
+
+Run the checks with `aiq-release-qa` and keep the exact commands and output.
+Paste them into the PR's Validation section — do not summarize as "ran tests".
+
+## 4. Open the PR
+
+- Target branch is `develop`.
+- Fill every section of `.github/pull_request_template.md`:
+  - **Overview** — what changed and why.
+  - **Validation** — the exact commands, output, workflow links, or screenshots.
+  - **Where should reviewers start?** — the key file, test, or decision.
+  - **Related Issues** — `Closes`/`Fixes`/`Relates to #...`.
+- Tick each checklist item you can honestly tick (local checks, tests added,
+  docs updated, no secrets, DCO sign-off).
+
+## 5. CI and merge flow (copy-pr-bot)
+
+AI-Q uses push-triggered GitHub Actions on mirrored branches, not on the PR
+branch directly:
+
+- A maintainer or configured vetter comments `/ok to test`.
+- copy-pr-bot mirrors the PR to `pull-request/<PR number>` and CI runs there.
+- Owners, org members, and collaborators can request NVSkills validation with
+  `/nvskills-ci`.
+- Maintainers can request bot-driven merge with `/merge`, which requires the
+  RAPIDS ops-bot app plus satisfied repository rules: required checks,
+  code-owner review, resolved review threads, and branch policy.
+
+## 6. Review loop
+
+Address feedback until required checks pass and code-owner review is approved.
+Keep new commits signed; re-run the relevant `aiq-release-qa` checks after
+substantive changes and update the Validation section if results change.
+</content>

--- a/.agents/skills/aiq-release-qa/SKILL.md
+++ b/.agents/skills/aiq-release-qa/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: aiq-release-qa
+description: Use when validating an AI-Q change before opening or merging a PR — choosing and running the right Python, frontend, docs, or eval checks for the surfaces you touched instead of one fixed command list.
+license: Apache-2.0
+compatibility: Claude Code, Codex, Cursor, OpenCode, and Agent Skills-compatible tools.
+metadata:
+  version: "0.1.0"
+  source-repo: "NVIDIA-AI-Blueprints/aiq"
+  tags: "aiq nemo-agent-toolkit validation testing release-qa"
+allowed-tools: Read Bash
+---
+
+# AI-Q Release QA
+
+Use this skill to validate a change in the AI-Q repository before opening or
+merging a pull request. The goal is to run the **narrowest set of checks that
+covers what you touched**, then broaden only when a change crosses shared
+boundaries — not to run every command every time.
+
+## Start Here
+
+- Identify which surfaces the change touches: backend Python (`src/`,
+  `sources/`, `tests/`), web UI (`frontends/ui/`), docs (`docs/`), or evals
+  (`frontends/benchmarks/`).
+- Run the scoped checks for those surfaces first (see the matrix below).
+- Broaden to the full suite only when the change crosses shared boundaries
+  (for example editing `src/aiq_agent/common/` or a config many agents load).
+- Capture the exact commands and their output — `aiq-prepare-pr` requires this
+  as validation evidence.
+- Never paste secrets or `deploy/.env` values into command output you share.
+
+## Authoritative References
+
+- [AGENTS.md](../../../AGENTS.md): the "Build, test, and validation commands"
+  section is the source of truth for every command below.
+- [CONTRIBUTING.md](../../../CONTRIBUTING.md): "Local Validation" — the exact
+  commands to run and the requirement to include their output in the PR.
+- `pyproject.toml`: Ruff config (line length 120, rule sets `E,F,W,I,PL,UP`)
+  and the dev dependency group used by `uv sync --group dev`.
+- `frontends/ui/package.json`: the real `scripts` (`lint`, `type-check`,
+  `test:ci`, `build`) — use these names, do not invent npm scripts.
+
+For the full per-surface command list and expected results:
+
+- [references/validation-matrix.md](references/validation-matrix.md)
+
+## Workflow
+
+1. List the changed paths (`git status`, `git diff --name-only`) and map them to
+   surfaces.
+2. Run the scoped Python, UI, docs, or eval checks for those surfaces.
+3. If the change touches shared code or config, broaden to the full suite for
+   that surface.
+4. Re-run until lint, format, type, and tests all pass; fix failures rather than
+   skipping checks.
+5. Record the exact commands and their output for the PR description.
+
+## Validation
+
+Pick the block that matches the change. Run the narrowest first.
+
+Backend Python (run from the repo root; the project uses `uv`):
+
+```bash
+uv run ruff check <changed paths>          # lint
+uv run ruff format --check <changed paths> # format check
+uv run pytest <scoped test paths>          # tests
+```
+
+Broaden to the whole tree when the change crosses shared boundaries:
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pytest
+```
+
+Frontend (from `frontends/ui/`):
+
+```bash
+npm run lint
+npm run type-check
+npm run test:ci
+```
+
+Expected: Ruff reports no lint or format failures, tests pass, and the frontend
+lint/type-check/test commands exit cleanly. For docs and eval changes, see the
+matrix reference.
+
+## Common Mistakes
+
+- Running the entire `uv run pytest` suite for a one-package change instead of
+  scoping to the touched paths first — slow, and it buries the relevant signal.
+- Skipping `ruff format --check` and pushing unformatted code that fails CI.
+- Hand-reformatting unrelated code; only the changed code should move.
+- Forgetting that `nat eval` needs `deploy/.env`; run evals via
+  `dotenv -f deploy/.env run nat eval ...` (see the matrix reference).
+- Inventing npm scripts; only `lint`, `type-check`, `test:ci`, and `build`
+  exist in `frontends/ui/package.json`.
+
+## Related Skills
+
+- `aiq-prepare-pr`
+- `aiq-add-tool`
+- `aiq-add-data-source`

--- a/.agents/skills/aiq-release-qa/references/validation-matrix.md
+++ b/.agents/skills/aiq-release-qa/references/validation-matrix.md
@@ -1,0 +1,101 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# AI-Q validation matrix
+
+Map the change to a surface, run that surface's checks, and broaden only when
+the change crosses shared boundaries. All commands come from `AGENTS.md`
+("Build, test, and validation commands") and `CONTRIBUTING.md` ("Local
+Validation"); this file is a convenience index, not a new source of truth.
+
+## One-time environment setup
+
+```bash
+./scripts/setup.sh          # one-time environment setup
+uv sync --group dev         # ensure dev dependencies (ruff, pytest) are present
+```
+
+## Backend Python — `src/`, `sources/`, `tests/`
+
+Scoped first (replace the paths with what you changed):
+
+```bash
+uv run ruff check sources/my_package
+uv run ruff format --check sources/my_package
+uv run pytest sources/my_package/tests
+```
+
+A `sources/*` package usually needs an editable install before its tests run:
+
+```bash
+uv pip install -e ./sources/my_package
+```
+
+Broaden to the whole tree when the change touches shared code (for example
+`src/aiq_agent/common/`) or a config many agents load:
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pytest
+```
+
+Expected: Ruff reports no lint or format failures for the changed code, and the
+selected tests pass. Ruff config (line length 120; rule sets `E,F,W,I,PL,UP`)
+lives in `pyproject.toml`.
+
+## Web UI — `frontends/ui/`
+
+```bash
+cd frontends/ui
+npm ci            # only when dependencies changed or node_modules is stale
+npm run lint
+npm run type-check
+npm run test:ci
+npm run build     # when the change could affect the production build
+```
+
+Expected: each command exits cleanly. Only `lint`, `type-check`, `test`,
+`test:ci`, and `build` are defined in `package.json` — do not invent scripts.
+Include a screenshot for user-visible changes.
+
+## Docs — `docs/`
+
+```bash
+cd docs
+make html         # Sphinx build via the provided Makefile
+```
+
+Expected: the Sphinx build completes without errors. Update pages under
+`docs/source/` whenever behavior, configuration, or workflows change.
+
+## Evals — `frontends/benchmarks/`
+
+Evals use the NAT eval harness and need the deployment env file `deploy/.env`
+(created during deployment; never commit it):
+
+```bash
+dotenv -f deploy/.env run nat eval \
+  --config_file frontends/benchmarks/deepresearch_bench/configs/config_deep_research_bench.yml
+```
+
+Other harness configs:
+
+- `frontends/benchmarks/freshqa/configs/config_full_workflow.yml`
+- `frontends/benchmarks/freshqa/configs/config_shallow_research_only.yml`
+- `frontends/benchmarks/deepsearch_qa/configs/config_deepsearch_qa.yml`
+
+Expected: the eval run completes and writes its results. Evals call models and
+data sources, so they need the relevant API keys present in `deploy/.env`.
+
+## Running the backend for a manual check
+
+```bash
+./scripts/start_cli.sh        # CLI mode (configs/config_cli_default.yml)
+nat serve --config_file configs/config_cli_default.yml --port 8000
+```
+
+The backend API serves at `http://localhost:8000`.
+</content>

--- a/.claude/skills/aiq-add-tool
+++ b/.claude/skills/aiq-add-tool
@@ -1,0 +1,1 @@
+../../.agents/skills/aiq-add-tool

--- a/.claude/skills/aiq-prepare-pr
+++ b/.claude/skills/aiq-prepare-pr
@@ -1,0 +1,1 @@
+../../.agents/skills/aiq-prepare-pr

--- a/.claude/skills/aiq-release-qa
+++ b/.claude/skills/aiq-release-qa
@@ -1,0 +1,1 @@
+../../.agents/skills/aiq-release-qa

--- a/skills/aiq-research/SKILL.md
+++ b/skills/aiq-research/SKILL.md
@@ -74,6 +74,8 @@ The helper script has no third-party Python package dependencies; it uses Python
 5. Poll asynchronous deep research jobs when AI-Q returns a job ID.
 6. Present returned reports with citations and source URLs intact.
 7. Stop on failed jobs and show the returned error; do not retry automatically.
+8. After presenting a report, support follow-up: answer questions about it
+   (ask) or run a refined research pass (redo) using the same commands.
 
 ### Step 1 - Resolve the backend
 
@@ -154,6 +156,43 @@ the final output. Use `research_poll` to keep waiting for completion.
 When `research_poll` completes successfully, fetch and present the full report. Keep citations and source URLs intact.
 If the job status is `failed`, `failure`, or `cancelled`, show the error from the status response and ask whether the
 user wants to retry with a narrower query or different approach.
+
+### Step 6 - Follow up: ask about or redo a report
+
+After a report is presented, the user often wants to go deeper or adjust scope.
+Reuse the existing backend flow — the same auth boundary, polling, and report
+retrieval from Steps 1-5 apply; there is no separate follow-up endpoint.
+
+**Ask** — a follow-up question about a report already in hand:
+
+- For a question answerable from the report you already have, answer directly
+  from its content and citations; do not call the backend again.
+- For a question that needs new investigation, send a fresh request that carries
+  the needed context from the prior question and report into the new query
+  text, then present the new result:
+
+  ```bash
+  python3 $SKILL_DIR/scripts/aiq.py chat "<FOLLOW_UP_QUESTION> (context: <PRIOR_TOPIC>)"
+  ```
+
+  If this returns a `deep_research_running` job ID, poll it with `research_poll`
+  exactly as in Step 3.
+
+**Redo** — re-run research with adjusted scope (a narrower query, a corrected
+question, or a different depth):
+
+```bash
+python3 $SKILL_DIR/scripts/aiq.py research "<REFINED_QUERY>" [agent_type]
+```
+
+- Choose `agent_type` to match the desired depth (for example a deep agent for a
+  thorough pass, or `shallow_researcher` for a quick one); list options with
+  `agents` if unsure.
+- Treat a redo as a new job: state the target endpoint again before sending
+  (Step 2), then poll and present as in Steps 3-5.
+
+Do not send credentials or secret values in follow-up query text, and keep
+citations and source URLs intact in every follow-up answer.
 
 ## Version Compatibility
 
@@ -254,6 +293,20 @@ python3 $SKILL_DIR/scripts/aiq.py research_poll <JOB_ID>
 
 Replace `<JOB_ID>` with the UUID returned by AI-Q. Expected output: status JSON followed by the report JSON when the
 job completes. If the job failed, show the returned status and do not retry automatically.
+
+### Example 3: Ask a follow-up or redo with a refined query
+
+```bash
+# Ask: a follow-up that needs new investigation, carrying prior context.
+python3 $SKILL_DIR/scripts/aiq.py chat "How does that compare on cost? (context: local AIQ deep research vs web search)"
+
+# Redo: re-run research with a narrower query and explicit depth.
+python3 $SKILL_DIR/scripts/aiq.py research "AIQ deep research cost on a single workstation" shallow_researcher
+```
+
+Expected output: a routed chat response or a new `deep_research_running` job ID
+to poll with `research_poll`. Present the follow-up answer with citations and
+source URLs intact.
 
 ## References
 


### PR DESCRIPTION
#### Overview

Adds the remaining AI-Q maintainer Agent Skills and extends the `aiq-research`
consumer skill, completing the maintainer skill set started in #269.

- **`aiq-add-tool`**: maintainer skill for adding a general-purpose NAT-function
  tool under `sources/` — `FunctionBaseConfig` schema, `@register_function`,
  wiring into an agent's `tools` list, and tests.
- **`aiq-release-qa`**: maintainer skill for choosing and running the right
  validation (Python, frontend, docs, evals) for the surfaces a change touches,
  grounded in `AGENTS.md` and `CONTRIBUTING.md`.
- **`aiq-prepare-pr`**: maintainer skill for branch scoping, DCO sign-off,
  filling the PR template with real evidence, and the copy-pr-bot CI/merge flow.
  Reuses `aiq-release-qa` for validation rather than duplicating.
- **`aiq-research`**: adds report **ask/redo** follow-up usage to the consumer
  skill, reusing the existing auth, polling, and report-retrieval flow (no new
  helper-script commands).

Each maintainer skill is a real directory under `.agents/skills/` with a
`.claude/skills/` compatibility symlink. No deployed-product behavior changes —
these are guidance for coding agents working in the repo.

#### Validation

```text
$ uv run python scripts/validate_skills.py .agents/skills
Skill validation passed: 6 skill(s) OK.

$ uv run pytest tests/test_agent_skills.py -q
4 passed

$ uv run pre-commit run --files <changed skill files>
Detect secrets...........................................................Passed
Validate agent skills....................................................Passed
Markdown Link Check......................................................Passed
```

- [x] I ran the relevant local checks or explained why they are not applicable.
- [x] I added or updated tests for behavior changes. *(validator/pytest cover skill structure; skills are static markdown, no runtime code added)*
- [x] I updated documentation for user-facing or contributor-facing changes. *(the skills are the contributor-facing docs; canonical docs under `docs/source/` unchanged)*
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.

#### Related Issues

- Relates to #269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Documentation**
* Added end-to-end guides for creating AI-Q tools, including setup patterns, testing practices, and integration workflows
* New pull request preparation documentation with validation checklists and requirements
* Added release QA validation reference covering backend, frontend, documentation, and evaluation checks
* Enhanced research workflow with follow-up and refinement capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->