### PR TITLE
chore(skills): trigger NVSkills CI validation (no-op)

### DIFF
--- a/skills/aiq-deploy/SKILL.md
+++ b/skills/aiq-deploy/SKILL.md
@@ -349,3 +349,5 @@ Expected output: a successful health response. Then tell the user to keep `AIQ_S
 1. Prefer a normal restart from `references/shutdown.md`.
 2. Ask for explicit approval before running volume deletion.
 3. After cleanup, rerun deployment and validation from the selected route.
+
+<!-- nvskills: source touch to trigger an NVSkills validation refresh; safe to revert. -->

--- a/skills/aiq-research/SKILL.md
+++ b/skills/aiq-research/SKILL.md
@@ -407,3 +407,5 @@ source URLs intact.
    ```bash
    python3 $SKILL_DIR/scripts/aiq.py research_poll <JOB_ID>
    ```
+
+<!-- nvskills: source touch to trigger an NVSkills validation refresh; safe to revert. -->


### PR DESCRIPTION
No-op PR to trigger an NVSkills validation run on the consumer skills (`aiq-research`, `aiq-deploy`).

Appends a benign HTML comment to each skill's `BENCHMARK.md` so the PR carries a diff under `skills/`, which the `NVIDIA/skills` team-request workflow requires before dispatching the run. No skill behavior, signed artifacts (`skill.oms.sig`), or maintainer skills under `.agents/skills/` are affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added small “source touch” HTML comment markers to internal skill documentation to trigger a validation refresh in associated tooling.
  * Updated two skill documentation sections to include a safe-to-revert marker, without changing any instructional content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->