### PR TITLE
docs(skills): correct data-source registry example and clean up maintainer skill artifacts

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -24,7 +24,7 @@ AI-Q has two distinct kinds of skill, separated by audience:
 | :-- | :-- | :-- |
 | **Audience** | Developers changing the AI-Q repo | Users calling a running AI-Q server |
 | **Location** | `.agents/skills/` (this directory) | top-level `skills/` |
-| **Examples** | `aiq-add-data-source`, `aiq-release-qa`, `aiq-prepare-pr` | `aiq-deploy`, `aiq-research` |
+| **Examples** | `aiq-add-data-source`, `aiq-add-tool`, `aiq-release-qa`, `aiq-prepare-pr` | `aiq-deploy`, `aiq-research` |
 | **Assumes** | A repo checkout and dev toolchain | A reachable AI-Q backend |
 
 Consumer skills under `skills/` are authored to be self-contained and exportable

--- a/.agents/skills/aiq-add-data-source/SKILL.md
+++ b/.agents/skills/aiq-add-data-source/SKILL.md
@@ -69,10 +69,11 @@ Run the narrowest commands first; broaden only if the change touches shared code
 uv pip install -e ./sources/my_data_source
 uv run pytest sources/my_data_source/tests
 uv run ruff check sources/my_data_source
+uv run ruff format --check sources/my_data_source
 ```
 
-Expected: the package installs, its tests pass, and Ruff reports no lint
-failures for the new source package.
+Expected: the package installs, its tests pass, and Ruff reports no lint or
+format failures for the new source package.
 
 ## Common Mistakes
 

--- a/.agents/skills/aiq-add-data-source/references/registry-and-ui.md
+++ b/.agents/skills/aiq-add-data-source/references/registry-and-ui.md
@@ -16,22 +16,25 @@ the **only** config change needed — agents inherit registry tools automaticall
 
 ```yaml
 functions:
-  data_source_registry:
+  data_sources:                  # function instance name; _type is the registry
     _type: data_source_registry
     sources:
       - id: my_data_source
-        name: My Data Source
-        category: web          # web | enterprise | storage | collaboration
+        name: "My Data Source"
+        description: "What this source retrieves."
         default_enabled: true
         tools:
-          - _type: my_data_source
+          - my_data_source_tool  # function instance name(s), as plain strings
 
-  my_data_source:
-    _type: my_data_source       # matches the config class name= / entry-point key
+  my_data_source_tool:
+    _type: my_data_source        # _type matches the config class name= / entry-point key
 ```
 
-Confirm the field names against the `DataSourceRegistryConfig` in
-`src/aiq_agent/common/data_source_registry.py`; do not guess the schema.
+Confirm the per-source field names against `DataSourceEntry` (and the parent
+`DataSourceRegistryConfig`) in `src/aiq_agent/common/data_source_registry.py`;
+do not guess the schema. A source entry takes `id`, `name`, `description`,
+`default_enabled`, `requires_auth`, and a `tools` list of plain function-instance
+names — there is no `category` field on the config model.
 
 ## How the registry surfaces the source
 
@@ -52,8 +55,8 @@ Confirm the field names against the `DataSourceRegistryConfig` in
 TypeScript interface (`id`, `name`, `description`, `category`, `defaultEnabled`,
 `requiresAuth`). Because sources are fetched dynamically from
 `GET /v1/data_sources`, adding a source does not require editing this file. Touch
-the UI only for a genuinely new presentation need — that is `aiq-ui-change`
-territory, not this skill.
+the UI only for a genuinely new presentation need — that is a separate frontend
+change under `frontends/ui/`, outside this skill's scope.
 
 ## Authenticated sources
 

--- a/.agents/skills/aiq-prepare-pr/SKILL.md
+++ b/.agents/skills/aiq-prepare-pr/SKILL.md
@@ -88,4 +88,3 @@ contains only files relevant to this change, and the working tree is clean.
 - `aiq-release-qa`
 - `aiq-add-tool`
 - `aiq-add-data-source`
-</content>

--- a/.agents/skills/aiq-prepare-pr/references/pr-checklist.md
+++ b/.agents/skills/aiq-prepare-pr/references/pr-checklist.md
@@ -72,4 +72,3 @@ branch directly:
 Address feedback until required checks pass and code-owner review is approved.
 Keep new commits signed; re-run the relevant `aiq-release-qa` checks after
 substantive changes and update the Validation section if results change.
-</content>

--- a/.agents/skills/aiq-release-qa/SKILL.md
+++ b/.agents/skills/aiq-release-qa/SKILL.md
@@ -95,8 +95,8 @@ matrix reference.
 - Hand-reformatting unrelated code; only the changed code should move.
 - Forgetting that `nat eval` needs `deploy/.env`; run evals via
   `dotenv -f deploy/.env run nat eval ...` (see the matrix reference).
-- Inventing npm scripts; only `lint`, `type-check`, `test:ci`, and `build`
-  exist in `frontends/ui/package.json`.
+- Inventing npm scripts; stick to the canonical checks `lint`, `type-check`,
+  `test:ci`, and `build` defined in `frontends/ui/package.json`.
 
 ## Related Skills
 

--- a/.agents/skills/aiq-release-qa/references/validation-matrix.md
+++ b/.agents/skills/aiq-release-qa/references/validation-matrix.md
@@ -57,8 +57,8 @@ npm run test:ci
 npm run build     # when the change could affect the production build
 ```
 
-Expected: each command exits cleanly. Only `lint`, `type-check`, `test`,
-`test:ci`, and `build` are defined in `package.json` — do not invent scripts.
+Expected: each command exits cleanly. Stick to the canonical checks `lint`,
+`type-check`, `test:ci`, and `build` from `package.json`; do not invent scripts.
 Include a screenshot for user-visible changes.
 
 ## Docs — `docs/`
@@ -98,4 +98,3 @@ nat serve --config_file configs/config_cli_default.yml --port 8000
 ```
 
 The backend API serves at `http://localhost:8000`.
-</content>

--- a/docs/source/integration/agent-skills.md
+++ b/docs/source/integration/agent-skills.md
@@ -17,7 +17,7 @@ the **API-consumer** skills. The maintainer skills are documented in their own
 | :-- | :-- | :-- |
 | **Audience** | Users calling a running AI-Q server | Developers changing the AI-Q repo |
 | **Location** | top-level `skills/` | `.agents/skills/` |
-| **Examples** | `aiq-deploy`, `aiq-research` | `aiq-add-data-source` |
+| **Examples** | `aiq-deploy`, `aiq-research` | `aiq-add-data-source`, `aiq-add-tool`, `aiq-release-qa`, `aiq-prepare-pr` |
 | **Assumes** | A reachable AI-Q backend | A repo checkout and dev toolchain |
 
 The API-consumer skills are:
@@ -108,6 +108,9 @@ skills point into `skills/`; the maintainer skills point into `.agents/skills/`:
 .claude/skills/aiq-deploy -> ../../skills/aiq-deploy
 .claude/skills/aiq-research -> ../../skills/aiq-research
 .claude/skills/aiq-add-data-source -> ../../.agents/skills/aiq-add-data-source
+.claude/skills/aiq-add-tool -> ../../.agents/skills/aiq-add-tool
+.claude/skills/aiq-release-qa -> ../../.agents/skills/aiq-release-qa
+.claude/skills/aiq-prepare-pr -> ../../.agents/skills/aiq-prepare-pr
 ```
 
 To recreate the consumer-skill repo-local install manually:


### PR DESCRIPTION
#### Overview

The maintainer skill set under `.agents/skills/` (landed in #269 and #277) carried
a few documentation defects, found while auditing the skills against the live
AI-Q config schema and the sibling NeMo-Relay skill set. This PR fixes them.
**Documentation-only — no skills are added or removed, and no product/runtime
code changes.**

What changed:

- **`aiq-add-data-source` registry example (highest-impact).** The YAML example in
  `references/registry-and-ui.md` did not match `DataSourceEntry` /
  `DataSourceRegistryConfig` or any working config: it used the `data_source_registry`
  instance name (real configs use `data_sources`), included a non-existent
  `category` field, and expressed `tools` as `_type:` mappings instead of the
  schema's `list[FunctionRef]` (plain function-instance-name strings). Corrected to
  match the schema and `configs/config_web_frag.yml`. Also added the missing
  `uv run ruff format --check` to the validation block (its own `references/validation.md`
  and the sibling `aiq-add-tool` already include it).
- **Dangling skill reference.** `registry-and-ui.md` routed UI work to a
  non-existent `aiq-ui-change` skill; replaced with a generic `frontends/ui/` note.
- **Stray `</content>` artifacts** removed from three files
  (`aiq-prepare-pr/SKILL.md`, `aiq-prepare-pr/references/pr-checklist.md`,
  `aiq-release-qa/references/validation-matrix.md`).
- **Inaccurate npm-scripts claim.** `aiq-release-qa` stated only a handful of npm
  scripts "exist" in `frontends/ui/package.json`, which defines ~16; reworded to
  recommend the canonical checks without asserting exhaustiveness.
- **Stale skill lists.** `docs/source/integration/agent-skills.md` and
  `.agents/skills/README.md` listed only `aiq-add-data-source` as a maintainer
  example; updated both to list all four maintainer skills and all four
  `.claude/skills` maintainer symlinks.

#### Validation

All commands run from the repo root; output below is verbatim.

```text
$ uv run python scripts/validate_skills.py .agents/skills
Skill validation passed: 6 skill(s) OK.

$ uv run pytest tests/test_agent_skills.py -q
4 passed in 0.06s

$ uv run pre-commit run --files $(git diff --name-only origin/develop..HEAD)
Detect secrets...........................................................Passed
Validate agent skills....................................................Passed
Markdown Link Check......................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed

$ grep -rn 'content>' .agents/skills
(no matches — stray tags removed)
```

- [x] I ran the relevant local checks or explained why they are not applicable.
- [ ] I added or updated tests for behavior changes. (N/A — documentation-only; no behavior change. The existing `scripts/validate_skills.py` + `tests/test_agent_skills.py` gates already cover these skill files and pass.)
- [x] I updated documentation for user-facing or contributor-facing changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.

#### Where should reviewers start?

`.agents/skills/aiq-add-data-source/references/registry-and-ui.md` — the registry
YAML example is the highest-impact fix; compare it against `DataSourceEntry` in
`src/aiq_agent/common/data_source_registry.py` and the `data_sources:` block in
`configs/config_web_frag.yml`. The rest are small, self-evident cleanups.

#### Related Issues

- Relates to #277, #269 (fixes documentation defects in the maintainer skill set those PRs introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated data source registration examples and validation procedures for clarity.
  * Clarified AI-Q skill guidance and development workflow documentation.
  * Refined validation checklists and frontend QA script specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->