### PR TITLE
feat(skills): add aiq-customize-prompts-models and aiq-maintain-ci

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -24,7 +24,7 @@ AI-Q has two distinct kinds of skill, separated by audience:
 | :-- | :-- | :-- |
 | **Audience** | Developers changing the AI-Q repo | Users calling a running AI-Q server |
 | **Location** | `.agents/skills/` (this directory) | top-level `skills/` |
-| **Examples** | `aiq-add-data-source`, `aiq-add-tool`, `aiq-release-qa`, `aiq-prepare-pr` | `aiq-deploy`, `aiq-research` |
+| **Examples** | `aiq-add-data-source`, `aiq-add-tool`, `aiq-release-qa`, `aiq-prepare-pr`, `aiq-customize-prompts-models`, `aiq-maintain-ci` | `aiq-deploy`, `aiq-research` |
 | **Assumes** | A repo checkout and dev toolchain | A reachable AI-Q backend |
 
 Consumer skills under `skills/` are authored to be self-contained and exportable

--- a/.agents/skills/aiq-customize-prompts-models/SKILL.md
+++ b/.agents/skills/aiq-customize-prompts-models/SKILL.md
@@ -14,8 +14,10 @@ allowed-tools: Read Bash Edit
 
 Use this skill when a developer wants to change *how* an AI-Q agent reasons or
 *which* model it uses — by editing a Jinja2 prompt template or by assigning a
-different LLM to an agent role — without changing agent code. AI-Q agent behavior
-is driven by prompts and config, so most tuning is a template or YAML change.
+different LLM to an agent role — usually without touching agent code. AI-Q agent
+behavior is driven by prompts and config, so most tuning is a template or YAML
+change. The one exception is adding a brand-new template, which needs a one-line
+`load_prompt` wiring in the agent (see the prompt-templates reference).
 
 ## Start Here
 
@@ -29,9 +31,12 @@ is driven by prompts and config, so most tuning is a template or YAML change.
 
 ## Authoritative References
 
-- `docs/source/customization/prompts.md`: canonical prompt guide — template
-  inventory, `load_prompt(path, name)`, `render_prompt_template(template, ...)`,
-  template variables, the STRICT citation rules, and how to edit or add a template.
+- `docs/source/customization/prompts.md`: prompt guide — template inventory,
+  `load_prompt(path, name)`, `render_prompt_template(template, ...)`, the
+  documented template variables, the STRICT citation rules, and "Creating a New
+  Template". Note it does not document every template's variables (e.g.
+  `source_router.j2`, `writer.j2`, `source_registry.j2`) — the `.j2` files are
+  authoritative for the variables they actually use.
 - `docs/source/customization/swapping-models.md`: choosing hosted vs. self-hosted
   NIMs and pointing config at them.
 - `docs/source/customization/configuration-reference.md`: the `llms` section and
@@ -39,10 +44,12 @@ is driven by prompts and config, so most tuning is a template or YAML change.
 - `src/aiq_agent/common/prompt_utils.py`: `load_prompt` and
   `render_prompt_template`.
 - `src/aiq_agent/common/llm_provider.py`: `LLMRole` and `LLMProvider.configure`,
-  which bind a resolved LLM to an agent role.
+  which bind a resolved LLM to an agent role (used by the deep research agent).
 - Templates to model on: `src/aiq_agent/agents/deep_researcher/prompts/*.j2`
   (orchestrator, planner, researcher, source_router, writer) and
-  `src/aiq_agent/agents/clarifier/prompts/*.j2`.
+  `src/aiq_agent/agents/clarifier/prompts/*.j2`. Other agents have prompts too
+  (e.g. `shallow_researcher`, `chat_researcher`) — check
+  `src/aiq_agent/agents/*/prompts/`.
 
 Longer procedures live in this bundle:
 
@@ -63,8 +70,8 @@ Longer procedures live in this bundle:
    model.
 4. Keep token cost in mind: prefer reordering static instructions before dynamic
    content (KV-cache reuse) and a cheaper model for low-stakes roles.
-5. Validate (below): lint any changed Python, run the affected agent tests, and
-   smoke-run the CLI to confirm templates load and the agent uses the new model.
+5. Validate (below): lint any changed Python, run the agent's tests, and
+   smoke-run the CLI against the config you changed.
 6. Summarize changed files and paste the validation evidence.
 
 ## Validation
@@ -72,14 +79,16 @@ Longer procedures live in this bundle:
 Run the narrowest checks first; broaden only if you touched shared code.
 
 ```bash
-uv run ruff check src/aiq_agent             # only if you changed Python
-uv run pytest tests -k "<agent or prompt>"  # affected agent/prompt tests
-./scripts/start_cli.sh                       # smoke: templates load, agent runs
+uv run ruff check src/aiq_agent                      # only if you changed Python
+uv run pytest tests/aiq_agent/agents/<agent>         # the agent's tests (a prompt-only edit may have none)
+./scripts/start_cli.sh --config_file <your config>   # smoke against the config you edited
 ```
 
-Expected: the agent loads its templates without a Jinja2 error, runs with the
-configured model, and the affected tests pass. A prompt-only or config-only change
-needs no Python lint.
+Expected: the agent loads its templates without a Jinja2 error and runs with the
+configured model. A bare `./scripts/start_cli.sh` uses the fixed default
+(`configs/config_cli_default.yml`), so pass `--config_file` to exercise your
+change. For a prompt-only edit (which often has no dedicated unit test), the
+smoke run is the real check; a config/prompt-only change needs no Python lint.
 
 ## Common Mistakes
 
@@ -87,8 +96,10 @@ needs no Python lint.
   `docs/source/customization/prompts.md`, which degrades report grounding.
 - Hard-coding a model name in Python instead of using an `llms:` ref and the
   agent's role field, so the model can no longer be swapped from config.
-- Editing the default `llm` when you meant a single role (e.g. only the
-  `planner_llm`), changing every unset role's model unintentionally.
+- Changing an agent's default model when you meant a single sub-role. The deep
+  research agent's default is `orchestrator_llm` (there is no generic `llm`
+  field); the clarifier's default is `llm`. Editing the default shifts every
+  unset role.
 - Introducing a large dynamic prefix that defeats KV-cache reuse and raises cost.
 - Pointing an agent's role at a model whose entry is not defined in `llms:`.
 

--- a/.agents/skills/aiq-customize-prompts-models/SKILL.md
+++ b/.agents/skills/aiq-customize-prompts-models/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: aiq-customize-prompts-models
+description: Use when customizing AI-Q agent behavior through Jinja2 prompt templates or per-agent model selection — editing prompts under src/aiq_agent/agents/*/prompts/, adding template variables, or assigning/swapping LLMs per agent role via config (the llms section plus per-agent fields like orchestrator_llm, planner_llm, researcher_llm, writer_llm, source_router_llm).
+license: Apache-2.0
+compatibility: Claude Code, Codex, Cursor, OpenCode, and Agent Skills-compatible tools.
+metadata:
+  version: "0.1.0"
+  source-repo: "NVIDIA-AI-Blueprints/aiq"
+  tags: "aiq nemo-agent-toolkit prompts models jinja2 customization"
+allowed-tools: Read Bash Edit
+---
+
+# Customize AI-Q Prompts and Models
+
+Use this skill when a developer wants to change *how* an AI-Q agent reasons or
+*which* model it uses — by editing a Jinja2 prompt template or by assigning a
+different LLM to an agent role — without changing agent code. AI-Q agent behavior
+is driven by prompts and config, so most tuning is a template or YAML change.
+
+## Start Here
+
+- Confirm the change is prompt or model customization, not new tool/agent logic.
+  For a new retrieval source use `aiq-add-data-source`; for a new tool use
+  `aiq-add-tool`.
+- Read the authoritative docs and the existing templates/config below first.
+- Prefer editing an existing template or config field over adding new machinery.
+- Keep the prompt's STRICT citation rules intact, and never hard-code a model
+  name where an `llms:` ref belongs.
+
+## Authoritative References
+
+- `docs/source/customization/prompts.md`: canonical prompt guide — template
+  inventory, `load_prompt(path, name)`, `render_prompt_template(template, ...)`,
+  template variables, the STRICT citation rules, and how to edit or add a template.
+- `docs/source/customization/swapping-models.md`: choosing hosted vs. self-hosted
+  NIMs and pointing config at them.
+- `docs/source/customization/configuration-reference.md`: the `llms` section and
+  each agent's config fields (`deep_research_agent`, `clarifier_agent`, …).
+- `src/aiq_agent/common/prompt_utils.py`: `load_prompt` and
+  `render_prompt_template`.
+- `src/aiq_agent/common/llm_provider.py`: `LLMRole` and `LLMProvider.configure`,
+  which bind a resolved LLM to an agent role.
+- Templates to model on: `src/aiq_agent/agents/deep_researcher/prompts/*.j2`
+  (orchestrator, planner, researcher, source_router, writer) and
+  `src/aiq_agent/agents/clarifier/prompts/*.j2`.
+
+Longer procedures live in this bundle:
+
+- [references/prompt-templates.md](references/prompt-templates.md): where templates
+  live, how they load and render, template variables, citation rules, and how to
+  edit or add one safely.
+- [references/model-selection.md](references/model-selection.md): the `llms`
+  section, per-agent LLM fields, role binding via `LLMProvider`, and swapping models.
+
+## Workflow
+
+1. Identify the target agent and whether the change is a prompt or a model.
+2. For a prompt: edit the relevant `src/aiq_agent/agents/<agent>/prompts/*.j2`
+   template; keep its variables and citation rules intact (see the references).
+3. For a model: add or point an `llms:` entry in the config and set the agent's
+   role field (e.g. `orchestrator_llm`, `planner_llm`, `researcher_llm`,
+   `writer_llm`, `source_router_llm`) to that ref — do not edit Python to swap a
+   model.
+4. Keep token cost in mind: prefer reordering static instructions before dynamic
+   content (KV-cache reuse) and a cheaper model for low-stakes roles.
+5. Validate (below): lint any changed Python, run the affected agent tests, and
+   smoke-run the CLI to confirm templates load and the agent uses the new model.
+6. Summarize changed files and paste the validation evidence.
+
+## Validation
+
+Run the narrowest checks first; broaden only if you touched shared code.
+
+```bash
+uv run ruff check src/aiq_agent             # only if you changed Python
+uv run pytest tests -k "<agent or prompt>"  # affected agent/prompt tests
+./scripts/start_cli.sh                       # smoke: templates load, agent runs
+```
+
+Expected: the agent loads its templates without a Jinja2 error, runs with the
+configured model, and the affected tests pass. A prompt-only or config-only change
+needs no Python lint.
+
+## Common Mistakes
+
+- Breaking a template variable or the STRICT citation rules in
+  `docs/source/customization/prompts.md`, which degrades report grounding.
+- Hard-coding a model name in Python instead of using an `llms:` ref and the
+  agent's role field, so the model can no longer be swapped from config.
+- Editing the default `llm` when you meant a single role (e.g. only the
+  `planner_llm`), changing every unset role's model unintentionally.
+- Introducing a large dynamic prefix that defeats KV-cache reuse and raises cost.
+- Pointing an agent's role at a model whose entry is not defined in `llms:`.
+
+## Related Skills
+
+- `aiq-add-tool`
+- `aiq-add-data-source`
+- `aiq-release-qa`
+- `aiq-prepare-pr`

--- a/.agents/skills/aiq-customize-prompts-models/SKILL.md
+++ b/.agents/skills/aiq-customize-prompts-models/SKILL.md
@@ -28,6 +28,9 @@ change. The one exception is adding a brand-new template, which needs a one-line
 - Prefer editing an existing template or config field over adding new machinery.
 - Keep the prompt's STRICT citation rules intact, and never hard-code a model
   name where an `llms:` ref belongs.
+- Keep templates general-purpose: don't hard-code specific queries, domains, or
+  source/tool names — those come from the user's request and the
+  `data_source_registry` at runtime.
 
 ## Authoritative References
 
@@ -94,6 +97,10 @@ smoke run is the real check; a config/prompt-only change needs no Python lint.
 
 - Breaking a template variable or the STRICT citation rules in
   `docs/source/customization/prompts.md`, which degrades report grounding.
+- Hard-coding specific queries, domains, or source/tool names into a template,
+  which biases the agent toward one task and breaks generalization. Source/domain
+  selection is data-driven (`data_source_registry`, `source_router.j2`); keep
+  prompts task-agnostic.
 - Hard-coding a model name in Python instead of using an `llms:` ref and the
   agent's role field, so the model can no longer be swapped from config.
 - Changing an agent's default model when you meant a single sub-role. The deep

--- a/.agents/skills/aiq-customize-prompts-models/references/model-selection.md
+++ b/.agents/skills/aiq-customize-prompts-models/references/model-selection.md
@@ -1,0 +1,66 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Model selection
+
+Authoritative sources: `docs/source/customization/swapping-models.md` and the
+`llms` section of `docs/source/customization/configuration-reference.md`.
+
+## Define models once, reference them by name
+
+Declare each model in the config `llms:` section, then reference it by name from
+an agent. Do not hard-code model names in Python.
+
+```yaml
+llms:
+  nemotron_super_llm:
+    _type: nim
+    model_name: <a capable model>
+  gpt_oss_llm:
+    _type: nim          # `openai` is also supported
+    model_name: <a cheaper model>
+```
+
+## Assign a model to an agent role
+
+Agents expose per-role LLM fields so you can use different models for different
+jobs. For example, `src/aiq_agent/agents/deep_researcher/register.py` defines
+`orchestrator_llm` (required) plus `source_router_llm`, `researcher_llm`,
+`planner_llm`, and `writer_llm` (`LLMRef | None`); the clarifier defines
+`planner_llm`. When a role field is set, the agent resolves the ref via
+`builder.get_llm(...)` and binds it to a role through
+`LLMProvider.configure(LLMRole.<ROLE>, llm)` in
+`src/aiq_agent/common/llm_provider.py`. When unset, the role falls back to the
+agent's default `llm`.
+
+```yaml
+functions:
+  deep_research_agent:
+    _type: deep_research_agent
+    orchestrator_llm: nemotron_super_llm   # required
+    researcher_llm: nemotron_super_llm
+    planner_llm: gpt_oss_llm               # cheaper model for planning
+    writer_llm: gpt_oss_llm
+```
+
+This mirrors the real configs (for example
+`configs/config_domain_routing_and_skills.yml`); copy field names from there
+rather than guessing.
+
+## Swapping to a self-hosted NIM
+
+Follow `swapping-models.md`: run the NIM locally, then point the `llms:` entry's
+endpoint/model at it. Mind the hosted-API limitations and mitigations the doc
+lists.
+
+## Validation
+
+```bash
+./scripts/start_cli.sh           # confirm the agent starts with the assigned model
+uv run pytest tests -k "<agent>"
+```
+
+Expected: the agent starts with the configured models and the affected tests
+pass. Every role ref must resolve to an entry in `llms:`.

--- a/.agents/skills/aiq-customize-prompts-models/references/model-selection.md
+++ b/.agents/skills/aiq-customize-prompts-models/references/model-selection.md
@@ -19,27 +19,44 @@ llms:
     _type: nim
     model_name: <a capable model>
   gpt_oss_llm:
-    _type: nim          # `openai` is also supported
+    _type: nim          # `openai` is also supported (also takes model_name)
     model_name: <a cheaper model>
 ```
 
 ## Assign a model to an agent role
 
-Agents expose per-role LLM fields so you can use different models for different
-jobs. For example, `src/aiq_agent/agents/deep_researcher/register.py` defines
-`orchestrator_llm` (required) plus `source_router_llm`, `researcher_llm`,
-`planner_llm`, and `writer_llm` (`LLMRef | None`); the clarifier defines
-`planner_llm`. When a role field is set, the agent resolves the ref via
-`builder.get_llm(...)` and binds it to a role through
-`LLMProvider.configure(LLMRole.<ROLE>, llm)` in
-`src/aiq_agent/common/llm_provider.py`. When unset, the role falls back to the
-agent's default `llm`.
+Agents expose per-role LLM fields, but the two agents wire them differently — so
+check the agent you are editing.
+
+**Deep research agent** (`src/aiq_agent/agents/deep_researcher/register.py`)
+defines `orchestrator_llm` (required) plus `source_router_llm`, `researcher_llm`,
+`planner_llm`, and `writer_llm` (`LLMRef | None`). It seeds the provider default
+from `orchestrator_llm` (`LLMProvider.set_default(...)`) and binds each set role
+with `LLMProvider.configure(LLMRole.<ROLE>, llm)`
+(`src/aiq_agent/common/llm_provider.py`). Field → role:
+
+| Config field | `LLMRole` |
+| :-- | :-- |
+| `orchestrator_llm` (required) | `ORCHESTRATOR` — also the provider default |
+| `source_router_llm` | `ROUTER` |
+| `researcher_llm` | `RESEARCHER` |
+| `planner_llm` | `PLANNER` |
+| `writer_llm` | `REPORT_WRITER` |
+
+An unset role falls back to the provider default (the `orchestrator_llm` model).
+There is **no** generic `llm` field on the deep research agent.
+
+**Clarifier** (`src/aiq_agent/agents/clarifier/register.py`) defines `llm` (its
+default) and `planner_llm`. It does **not** use `LLMProvider.configure` for the
+role — it passes `planner_llm` straight to the agent constructor, and `planner_llm`
+falls back to `llm` when unset.
 
 ```yaml
 functions:
   deep_research_agent:
     _type: deep_research_agent
-    orchestrator_llm: nemotron_super_llm   # required
+    orchestrator_llm: nemotron_super_llm   # required; also the default for unset roles
+    source_router_llm: nemotron_super_llm
     researcher_llm: nemotron_super_llm
     planner_llm: gpt_oss_llm               # cheaper model for planning
     writer_llm: gpt_oss_llm
@@ -58,9 +75,10 @@ lists.
 ## Validation
 
 ```bash
-./scripts/start_cli.sh           # confirm the agent starts with the assigned model
-uv run pytest tests -k "<agent>"
+./scripts/start_cli.sh --config_file <the config where you set the role LLMs>   # agent starts with the assigned models
+uv run pytest tests/aiq_agent/agents/deep_researcher
 ```
 
-Expected: the agent starts with the configured models and the affected tests
-pass. Every role ref must resolve to an entry in `llms:`.
+Expected: the agent starts with the configured models and its tests pass. A bare
+`start_cli.sh` runs the fixed default config, so pass the config you edited. Every
+role ref must resolve to an entry in `llms:`.

--- a/.agents/skills/aiq-customize-prompts-models/references/prompt-templates.md
+++ b/.agents/skills/aiq-customize-prompts-models/references/prompt-templates.md
@@ -37,7 +37,10 @@ own as well.
    grounding depends on the model emitting citations exactly as instructed.
 3. Prefer putting static instructions before dynamic content so the KV cache is
    reused across calls (lower latency and token cost).
-4. Editing an existing `.j2` needs **no** code change.
+4. Keep the template task-agnostic — don't hard-code specific queries, domains, or
+   source/tool names; source/domain routing is data-driven (`data_source_registry`,
+   `source_router.j2`), and hard-coding it bypasses that routing.
+5. Editing an existing `.j2` needs **no** code change.
 
 ## Adding a new template
 

--- a/.agents/skills/aiq-customize-prompts-models/references/prompt-templates.md
+++ b/.agents/skills/aiq-customize-prompts-models/references/prompt-templates.md
@@ -5,9 +5,11 @@ SPDX-License-Identifier: Apache-2.0
 
 # Prompt templates
 
-Authoritative source: `docs/source/customization/prompts.md`. This is a quick
-operational summary; defer to that doc for the full template inventory and the
-exact variables each agent expects.
+Authoritative sources: the `.j2` files themselves (for the variables a template
+actually uses) and `docs/source/customization/prompts.md` (for the documented
+workflow and many template variables). Note `prompts.md` does not cover every
+template — e.g. `source_router.j2`, `writer.j2`, and `source_registry.j2` have no
+variable section there yet — so read the `.j2` file when in doubt.
 
 ## Where templates live
 
@@ -15,15 +17,17 @@ Each agent owns its Jinja2 templates under
 `src/aiq_agent/agents/<agent>/prompts/*.j2`. For example, the deep researcher has
 `orchestrator.j2`, `planner.j2`, `researcher.j2`, `source_router.j2`, `writer.j2`,
 and `source_registry.j2`; the clarifier has `plan_generation.j2` and
-`research_clarification.j2`.
+`research_clarification.j2`; `shallow_researcher` and `chat_researcher` have their
+own as well.
 
 ## How templates load and render
 
 - `load_prompt(path, name)` in `src/aiq_agent/common/prompt_utils.py` reads a
   template file as a string.
 - `render_prompt_template(template, **kwargs)` (same module) renders it with
-  Jinja2, injecting the documented template variables. See the "Template
-  Variables" section of `prompts.md` for the exact variables per agent.
+  Jinja2, injecting the variables. `prompts.md` has a "Template Variables" section
+  for many agents; for a template it doesn't list, read the `.j2` to see which
+  variables it references.
 
 ## Editing a template safely
 
@@ -33,20 +37,26 @@ and `source_registry.j2`; the clarifier has `plan_generation.j2` and
    grounding depends on the model emitting citations exactly as instructed.
 3. Prefer putting static instructions before dynamic content so the KV cache is
    reused across calls (lower latency and token cost).
-4. Edit the `.j2` template, not the Python, for wording or structure changes.
+4. Editing an existing `.j2` needs **no** code change.
 
 ## Adding a new template
 
-Follow "Creating a New Template" in `prompts.md`: add the `.j2` file under the
-agent's `prompts/` directory and load it with `load_prompt`. Keep variable names
-consistent with what the agent renders.
+This is the one prompt change that touches Python. Follow "Creating a New
+Template" in `prompts.md`:
+
+1. Add the `.j2` under the agent's `prompts/` directory.
+2. Write the template (keep variable names consistent with what the agent passes).
+3. **Wire it in the agent's Python** — load it with `load_prompt` and render it
+   with `render_prompt_template` (this is `prompts.md` Step 3). Without this step
+   the new template is never used.
 
 ## Validation
 
 ```bash
-./scripts/start_cli.sh           # confirm the template loads (no Jinja2 error)
-uv run pytest tests -k "<agent>"
+./scripts/start_cli.sh --config_file <a config using that agent>   # template loads (no Jinja2 error)
+uv run pytest tests/aiq_agent/agents/<agent>                        # if the agent has tests
 ```
 
-Expected: the agent starts and renders the template without error, and the
-affected tests pass.
+Expected: the agent starts and renders the template without error. A bare
+`start_cli.sh` runs the fixed default config, so pass the config that exercises
+the agent whose template you changed.

--- a/.agents/skills/aiq-customize-prompts-models/references/prompt-templates.md
+++ b/.agents/skills/aiq-customize-prompts-models/references/prompt-templates.md
@@ -1,0 +1,52 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Prompt templates
+
+Authoritative source: `docs/source/customization/prompts.md`. This is a quick
+operational summary; defer to that doc for the full template inventory and the
+exact variables each agent expects.
+
+## Where templates live
+
+Each agent owns its Jinja2 templates under
+`src/aiq_agent/agents/<agent>/prompts/*.j2`. For example, the deep researcher has
+`orchestrator.j2`, `planner.j2`, `researcher.j2`, `source_router.j2`, `writer.j2`,
+and `source_registry.j2`; the clarifier has `plan_generation.j2` and
+`research_clarification.j2`.
+
+## How templates load and render
+
+- `load_prompt(path, name)` in `src/aiq_agent/common/prompt_utils.py` reads a
+  template file as a string.
+- `render_prompt_template(template, **kwargs)` (same module) renders it with
+  Jinja2, injecting the documented template variables. See the "Template
+  Variables" section of `prompts.md` for the exact variables per agent.
+
+## Editing a template safely
+
+1. Keep every `{{ variable }}` the agent passes in; removing one breaks rendering
+   or silently drops context.
+2. Preserve the **Citation Rules (STRICT)** section in `prompts.md` — report
+   grounding depends on the model emitting citations exactly as instructed.
+3. Prefer putting static instructions before dynamic content so the KV cache is
+   reused across calls (lower latency and token cost).
+4. Edit the `.j2` template, not the Python, for wording or structure changes.
+
+## Adding a new template
+
+Follow "Creating a New Template" in `prompts.md`: add the `.j2` file under the
+agent's `prompts/` directory and load it with `load_prompt`. Keep variable names
+consistent with what the agent renders.
+
+## Validation
+
+```bash
+./scripts/start_cli.sh           # confirm the template loads (no Jinja2 error)
+uv run pytest tests -k "<agent>"
+```
+
+Expected: the agent starts and renders the template without error, and the
+affected tests pass.

--- a/.agents/skills/aiq-maintain-ci/SKILL.md
+++ b/.agents/skills/aiq-maintain-ci/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: aiq-maintain-ci
+description: Use when changing AI-Q continuous integration, pre-commit, or contributor governance — editing .github/workflows/ (ci, ui, skills-eval, request-nvskills-ci), .pre-commit-config.yaml hooks, .github/CODEOWNERS, .coderabbit.yaml, copy-pr-bot, or the .github/skill-eval harness — and validating those changes without breaking the gate.
+license: Apache-2.0
+compatibility: Claude Code, Codex, Cursor, OpenCode, and Agent Skills-compatible tools.
+metadata:
+  version: "0.1.0"
+  source-repo: "NVIDIA-AI-Blueprints/aiq"
+  tags: "aiq ci github-actions pre-commit governance skill-eval"
+allowed-tools: Read Bash Edit
+---
+
+# Maintain AI-Q CI and Governance
+
+Use this skill when a developer changes AI-Q's CI, pre-commit hooks, or
+contributor governance — the GitHub Actions workflows, the pre-commit config,
+CODEOWNERS, the CodeRabbit review config, the copy-pr-bot mirror, or the
+product-level skill-eval harness. These surfaces gate every PR, so a change must
+keep the gate working and must not weaken security or review rules.
+
+## Start Here
+
+- Identify the surface: a workflow (`.github/workflows/`), a pre-commit hook
+  (`.pre-commit-config.yaml`), governance (`.github/CODEOWNERS`,
+  `.coderabbit.yaml`, `.github/copy-pr-bot.yaml`), or the skill-eval harness
+  (`.github/skill-eval/`).
+- Read the authoritative files below and `CONTRIBUTING.md` "CI and Bot Workflow"
+  before editing — the bot/mirror flow is easy to break.
+- Make the smallest change; do not weaken secret detection, auth gating, or
+  code-owner review without a prior design discussion (see `AGENTS.md`).
+- Remember CI runs on the copy-pr-bot mirror after `/ok to test`, not on push.
+
+## Authoritative References
+
+- [CONTRIBUTING.md](../../../CONTRIBUTING.md): "CI and Bot Workflow" — copy-pr-bot
+  mirroring to `pull-request/<N>`, `/ok to test`, `/nvskills-ci`, `/merge`.
+- [AGENTS.md](../../../AGENTS.md): "Git and PR hygiene" and the validation
+  commands CI mirrors.
+- `.github/workflows/ci.yml`: jobs `pre-commit`, `test` (pytest + coverage),
+  `helm-lint`, `test-scripts`.
+- `.github/workflows/ui.yml`: frontend lint / type-check / test / build.
+- `.github/workflows/skills-eval.yml`: the Skills Eval gate (push +
+  `workflow_dispatch`, a `detect-changes` path gate, Harbor trials on the
+  self-hosted `aiq-eval` runner).
+- `.github/workflows/request-nvskills-ci.yml`: comment-triggered NVSkills CI.
+- `.pre-commit-config.yaml`: the hook set CI enforces (ruff, detect-secrets,
+  `validate-skills`, markdown-link-check, pytest, helm-lint, …).
+- `.github/CODEOWNERS`, `.coderabbit.yaml`, `.github/copy-pr-bot.yaml`: review
+  routing, path-scoped automated review, and the PR mirror.
+
+Longer procedures live in this bundle:
+
+- [references/workflows-and-hooks.md](references/workflows-and-hooks.md): the
+  workflows, their jobs/triggers, the copy-pr-bot mirror flow, and the pre-commit
+  hook inventory.
+- [references/skill-eval-harness.md](references/skill-eval-harness.md): how the
+  `.github/skill-eval/` regression gate finds specs, runs adapters, and verifies.
+
+## Workflow
+
+1. Locate the exact workflow, hook, or governance file and read it plus the
+   relevant `CONTRIBUTING.md` section.
+2. Make the smallest scoped change; keep job names, triggers, and the
+   `detect-changes` path gate intact unless that is the change.
+3. Lint the change: validate YAML and, for workflows, run `actionlint` if it is
+   installed.
+4. Reproduce the affected gate locally where possible — run the pre-commit hooks
+   or the job's underlying command (see the references).
+5. Note that the real CI run happens on the copy-pr-bot mirror after a maintainer
+   comments `/ok to test`.
+6. Summarize changed files and the local validation evidence.
+
+## Validation
+
+```bash
+uv run pre-commit run --all-files          # reproduce the pre-commit gate
+uv run pre-commit run --files <changed>    # faster, during iteration
+actionlint .github/workflows/<file>.yml    # if actionlint is installed
+```
+
+Expected: pre-commit passes (or only auto-fixes), and any edited workflow is
+syntactically valid. For skill-eval changes, see the harness reference — full
+Harbor runs need the self-hosted runner, so validate spec/adapter shape locally
+and rely on the mirrored CI run for the full sweep.
+
+## Common Mistakes
+
+- Adding a trigger `paths:` filter to `skills-eval.yml` instead of using the
+  `detect-changes` job — the comment in that workflow explains why path-filtering
+  the trigger is wrong here.
+- Weakening `detect-secrets`, auth gating, or code-owner review to make CI pass.
+- Expecting CI to run on push; it runs on the copy-pr-bot mirror after
+  `/ok to test`.
+- Editing `.github/CODEOWNERS` without updating the paths it routes, so reviews
+  go to the wrong owners.
+- Forgetting that `helm-lint` and `pytest` are pre-commit hooks too, so a local
+  `pre-commit run --all-files` can be heavier than expected.
+
+## Related Skills
+
+- `aiq-release-qa`
+- `aiq-prepare-pr`
+- `aiq-add-tool`

--- a/.agents/skills/aiq-maintain-ci/SKILL.md
+++ b/.agents/skills/aiq-maintain-ci/SKILL.md
@@ -37,14 +37,17 @@ keep the gate working and must not weaken security or review rules.
 - [AGENTS.md](../../../AGENTS.md): "Git and PR hygiene" and the validation
   commands CI mirrors.
 - `.github/workflows/ci.yml`: jobs `pre-commit`, `test` (pytest + coverage),
-  `helm-lint`, `test-scripts`.
-- `.github/workflows/ui.yml`: frontend lint / type-check / test / build.
+  `helm-lint`, `test-scripts`. The `pre-commit` job runs Ruff separately and
+  `SKIP=ruff-check,ruff-format,pytest,helm-lint pre-commit run --all-files` — so
+  pytest/helm-lint run as their own jobs, not via the hook.
+- `.github/workflows/ui.yml`: jobs `install`, `lint`, `type-check`, `unit-test`,
+  `build`.
 - `.github/workflows/skills-eval.yml`: the Skills Eval gate (push +
-  `workflow_dispatch`, a `detect-changes` path gate, Harbor trials on the
-  self-hosted `aiq-eval` runner).
+  `workflow_dispatch`; `detect-changes` path gate → `generate-datasets` spec
+  validation → `harbor-eval` on the self-hosted `aiq-eval` runner).
 - `.github/workflows/request-nvskills-ci.yml`: comment-triggered NVSkills CI.
-- `.pre-commit-config.yaml`: the hook set CI enforces (ruff, detect-secrets,
-  `validate-skills`, markdown-link-check, pytest, helm-lint, …).
+- `.pre-commit-config.yaml`: the hook set. Note `pytest` and `helm-lint` are
+  `stages: [push]` (see the reference for what that means locally).
 - `.github/CODEOWNERS`, `.coderabbit.yaml`, `.github/copy-pr-bot.yaml`: review
   routing, path-scoped automated review, and the PR mirror.
 
@@ -52,7 +55,7 @@ Longer procedures live in this bundle:
 
 - [references/workflows-and-hooks.md](references/workflows-and-hooks.md): the
   workflows, their jobs/triggers, the copy-pr-bot mirror flow, and the pre-commit
-  hook inventory.
+  hook inventory (incl. the push-stage hooks).
 - [references/skill-eval-harness.md](references/skill-eval-harness.md): how the
   `.github/skill-eval/` regression gate finds specs, runs adapters, and verifies.
 
@@ -73,15 +76,17 @@ Longer procedures live in this bundle:
 ## Validation
 
 ```bash
-uv run pre-commit run --all-files          # reproduce the pre-commit gate
-uv run pre-commit run --files <changed>    # faster, during iteration
-actionlint .github/workflows/<file>.yml    # if actionlint is installed
+uv run pre-commit run --all-files                     # default-stage hooks (NOT pytest/helm-lint)
+uv run pre-commit run --all-files --hook-stage push   # adds the push-stage pytest + helm-lint hooks
+uv run pre-commit run --files <changed>               # faster, during iteration
+actionlint .github/workflows/<file>.yml               # if actionlint is installed
 ```
 
-Expected: pre-commit passes (or only auto-fixes), and any edited workflow is
-syntactically valid. For skill-eval changes, see the harness reference — full
-Harbor runs need the self-hosted runner, so validate spec/adapter shape locally
-and rely on the mirrored CI run for the full sweep.
+Expected: hooks pass (or only auto-fix) and any edited workflow is valid YAML.
+`pytest` and `helm-lint` are push-stage, so the default `--all-files` run skips
+them — CI runs them as the dedicated `test` and `helm-lint` jobs. For skill-eval
+changes, see the harness reference: full Harbor runs need the self-hosted runner,
+so validate spec/adapter shape locally and rely on the mirrored CI run.
 
 ## Common Mistakes
 
@@ -91,13 +96,14 @@ and rely on the mirrored CI run for the full sweep.
 - Weakening `detect-secrets`, auth gating, or code-owner review to make CI pass.
 - Expecting CI to run on push; it runs on the copy-pr-bot mirror after
   `/ok to test`.
+- Assuming `pre-commit run --all-files` reproduces the whole gate — `pytest` and
+  `helm-lint` are `stages: [push]`, so they do not run at the default stage. Use
+  `--hook-stage push` (or run them directly), and remember CI runs them as
+  separate jobs.
 - Editing `.github/CODEOWNERS` without updating the paths it routes, so reviews
   go to the wrong owners.
-- Forgetting that `helm-lint` and `pytest` are pre-commit hooks too, so a local
-  `pre-commit run --all-files` can be heavier than expected.
 
 ## Related Skills
 
 - `aiq-release-qa`
 - `aiq-prepare-pr`
-- `aiq-add-tool`

--- a/.agents/skills/aiq-maintain-ci/references/skill-eval-harness.md
+++ b/.agents/skills/aiq-maintain-ci/references/skill-eval-harness.md
@@ -16,32 +16,36 @@ gates skill changes. It contains `skills_eval_agent.py`, `adapters/`,
 
 ## How it works
 
-1. It finds Agent Skill product-eval specs under
-   `skills/<skill>/evals/*-product.json`.
-2. It validates each spec's required fields (for example `skills`,
-   `resources.platforms`, `env`, and ordered `expects`).
-3. It uses a matching adapter under `.github/skill-eval/adapters/<skill>/` to run
-   Harbor trials, then a deterministic verifier checks the result against a reward
-   threshold.
+The `skills-eval.yml` workflow runs in stages:
+
+1. **`detect-changes`** — path-gates the run (the trigger has no `paths:` filter;
+   this job decides whether to proceed).
+2. **`generate-datasets`** ("Validate skill-eval specs") — finds specs under
+   `skills/<skill>/evals/*-product.json`, validates their required fields, and
+   generates datasets via the matching adapter under
+   `.github/skill-eval/adapters/<skill>/`. **No Harbor credentials needed** — this
+   is the stage you can reason about and reproduce locally.
+3. **`harbor-eval`** — runs the Harbor trials on the self-hosted `aiq-eval`
+   runner, then a deterministic verifier checks results against a reward threshold.
 
 The first supported skill is `aiq-research`
 (`skills/aiq-research/evals/*-product.json`).
 
 ## Changing the harness safely
 
-- Keep the `detect-changes` path gate in `skills-eval.yml` working; do not switch
-  it to a trigger `paths:` filter (the workflow comment explains why).
-- Full Harbor runs require the self-hosted `aiq-eval` runner and credentials, so
-  validate spec/adapter/verifier shape locally and rely on the mirrored CI run for
-  the full sweep.
+- Keep the `detect-changes` path gate working; do not switch it to a trigger
+  `paths:` filter (the workflow comment explains why).
+- `harbor-eval` requires the self-hosted runner + credentials; `generate-datasets`
+  does not, so validate spec/adapter/verifier shape there (locally) and rely on
+  the mirrored CI run for the full sweep.
 - When adding a skill to the harness, add its `*-product.json` spec and a matching
   adapter; mirror the existing `aiq-research` adapter.
 
 ## Validation
 
 Defer to `.github/skill-eval/README.md` for running the harness. For local sanity,
-confirm your `*-product.json` specs parse and follow the README's required fields,
-and after editing the workflow run:
+confirm your `*-product.json` specs parse and follow the README's required fields
+(this is what `generate-datasets` checks), and after editing the workflow run:
 
 ```bash
 uv run pre-commit run --files .github/workflows/skills-eval.yml

--- a/.agents/skills/aiq-maintain-ci/references/skill-eval-harness.md
+++ b/.agents/skills/aiq-maintain-ci/references/skill-eval-harness.md
@@ -1,0 +1,51 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Skill-eval harness
+
+Authoritative sources: `.github/skill-eval/README.md` and
+`.github/workflows/skills-eval.yml`.
+
+## What it is
+
+`.github/skill-eval/` is the product-level Agent Skill evaluation harness that
+gates skill changes. It contains `skills_eval_agent.py`, `adapters/`,
+`verifiers/`, and its own `README.md` / `AGENTS.md`.
+
+## How it works
+
+1. It finds Agent Skill product-eval specs under
+   `skills/<skill>/evals/*-product.json`.
+2. It validates each spec's required fields (for example `skills`,
+   `resources.platforms`, `env`, and ordered `expects`).
+3. It uses a matching adapter under `.github/skill-eval/adapters/<skill>/` to run
+   Harbor trials, then a deterministic verifier checks the result against a reward
+   threshold.
+
+The first supported skill is `aiq-research`
+(`skills/aiq-research/evals/*-product.json`).
+
+## Changing the harness safely
+
+- Keep the `detect-changes` path gate in `skills-eval.yml` working; do not switch
+  it to a trigger `paths:` filter (the workflow comment explains why).
+- Full Harbor runs require the self-hosted `aiq-eval` runner and credentials, so
+  validate spec/adapter/verifier shape locally and rely on the mirrored CI run for
+  the full sweep.
+- When adding a skill to the harness, add its `*-product.json` spec and a matching
+  adapter; mirror the existing `aiq-research` adapter.
+
+## Validation
+
+Defer to `.github/skill-eval/README.md` for running the harness. For local sanity,
+confirm your `*-product.json` specs parse and follow the README's required fields,
+and after editing the workflow run:
+
+```bash
+uv run pre-commit run --files .github/workflows/skills-eval.yml
+```
+
+Expected: the specs parse, and the workflow edit passes pre-commit (YAML check).
+The full evaluation runs on the self-hosted runner via the mirrored CI.

--- a/.agents/skills/aiq-maintain-ci/references/workflows-and-hooks.md
+++ b/.agents/skills/aiq-maintain-ci/references/workflows-and-hooks.md
@@ -1,0 +1,49 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Workflows and hooks
+
+Authoritative sources: the workflow files under `.github/workflows/` and
+`CONTRIBUTING.md` "CI and Bot Workflow".
+
+## Workflows
+
+- `ci.yml` ("AIQ CI") — jobs: `pre-commit` (runs the hook set), `test` (pytest
+  with a coverage gate), `helm-lint` (deploy charts), `test-scripts`.
+- `ui.yml` — frontend `lint`, `type-check`, unit tests, and `build` for
+  `frontends/ui/`.
+- `skills-eval.yml` ("Skills Eval") — runs on `push` and `workflow_dispatch`. A
+  `detect-changes` job path-gates the run; the trigger deliberately does not use a
+  `paths:` filter (see the comment in the file for why). Harbor trials run on the
+  self-hosted `aiq-eval` runner.
+- `request-nvskills-ci.yml` — comment-triggered NVSkills CI request.
+
+## The copy-pr-bot mirror flow
+
+Per `CONTRIBUTING.md`: pushing a branch does not run CI. A maintainer or vetter
+comments `/ok to test`; copy-pr-bot mirrors the PR to a `pull-request/<N>` branch,
+and CI runs there. `/nvskills-ci` requests NVSkills validation; `/merge` requests
+bot-driven merge once repository rules pass. The mirror behavior is configured in
+`.github/copy-pr-bot.yaml`.
+
+## Pre-commit hooks
+
+`.pre-commit-config.yaml` is the source of truth CI enforces. Current hooks
+include: `ruff-check`, `ruff-format`, `uv-lock`, `check-merge-conflict`,
+`check-added-large-files`, `check-yaml`, `end-of-file-fixer`, `trailing-whitespace`,
+`detect-secrets`, `validate-skills`, `clear-notebook-output-cells`, `helm-lint`,
+`pytest`, and `markdown-link-check`. Some hooks run a whole-project command
+regardless of the files passed (for example `pytest`), so
+`pre-commit run --files ...` can still be heavy.
+
+## Validation
+
+```bash
+uv run pre-commit run --all-files
+actionlint .github/workflows/<file>.yml   # if installed
+```
+
+Expected: hooks pass (or only auto-fix), and any edited workflow is valid YAML
+that `actionlint` accepts.

--- a/.agents/skills/aiq-maintain-ci/references/workflows-and-hooks.md
+++ b/.agents/skills/aiq-maintain-ci/references/workflows-and-hooks.md
@@ -10,14 +10,17 @@ Authoritative sources: the workflow files under `.github/workflows/` and
 
 ## Workflows
 
-- `ci.yml` ("AIQ CI") — jobs: `pre-commit` (runs the hook set), `test` (pytest
-  with a coverage gate), `helm-lint` (deploy charts), `test-scripts`.
-- `ui.yml` — frontend `lint`, `type-check`, unit tests, and `build` for
+- `ci.yml` ("AIQ CI") — jobs: `pre-commit`, `test` (pytest with a coverage gate),
+  `helm-lint` (deploy charts), `test-scripts`. The `pre-commit` job does **not**
+  run the full hook set: it runs `ruff check .` / `ruff format --check .`
+  separately and `SKIP=ruff-check,ruff-format,pytest,helm-lint pre-commit run
+  --all-files`, leaving pytest/helm-lint to their own jobs.
+- `ui.yml` — jobs `install`, `lint`, `type-check`, `unit-test`, `build` for
   `frontends/ui/`.
 - `skills-eval.yml` ("Skills Eval") — runs on `push` and `workflow_dispatch`. A
   `detect-changes` job path-gates the run; the trigger deliberately does not use a
-  `paths:` filter (see the comment in the file for why). Harbor trials run on the
-  self-hosted `aiq-eval` runner.
+  `paths:` filter (see the comment in the file). See the skill-eval-harness
+  reference for the stages.
 - `request-nvskills-ci.yml` — comment-triggered NVSkills CI request.
 
 ## The copy-pr-bot mirror flow
@@ -30,19 +33,24 @@ bot-driven merge once repository rules pass. The mirror behavior is configured i
 
 ## Pre-commit hooks
 
-`.pre-commit-config.yaml` is the source of truth CI enforces. Current hooks
-include: `ruff-check`, `ruff-format`, `uv-lock`, `check-merge-conflict`,
-`check-added-large-files`, `check-yaml`, `end-of-file-fixer`, `trailing-whitespace`,
-`detect-secrets`, `validate-skills`, `clear-notebook-output-cells`, `helm-lint`,
-`pytest`, and `markdown-link-check`. Some hooks run a whole-project command
-regardless of the files passed (for example `pytest`), so
-`pre-commit run --files ...` can still be heavy.
+`.pre-commit-config.yaml` is the source of truth. Default-stage hooks (run by a
+plain `pre-commit run`) include: `ruff-check`, `ruff-format`, `uv-lock`,
+`check-merge-conflict`, `check-added-large-files`, `check-yaml`,
+`end-of-file-fixer`, `trailing-whitespace`, `detect-secrets`, `validate-skills`,
+`clear-notebook-output-cells`, and `markdown-link-check`.
+
+Two hooks — `pytest` and `helm-lint` — are `stages: [push]`, so a default
+`pre-commit run` / `pre-commit run --all-files` **skips them**. Include them
+explicitly with `pre-commit run --all-files --hook-stage push`. CI does not run
+them via the `pre-commit` job either (it `SKIP=`s them); they run as the dedicated
+`test` and `helm-lint` jobs in `ci.yml`.
 
 ## Validation
 
 ```bash
-uv run pre-commit run --all-files
-actionlint .github/workflows/<file>.yml   # if installed
+uv run pre-commit run --all-files                     # default-stage hooks
+uv run pre-commit run --all-files --hook-stage push   # + pytest, helm-lint
+actionlint .github/workflows/<file>.yml               # if installed
 ```
 
 Expected: hooks pass (or only auto-fix), and any edited workflow is valid YAML

--- a/.claude/skills/aiq-customize-prompts-models
+++ b/.claude/skills/aiq-customize-prompts-models
@@ -1,0 +1,1 @@
+../../.agents/skills/aiq-customize-prompts-models

--- a/.claude/skills/aiq-maintain-ci
+++ b/.claude/skills/aiq-maintain-ci
@@ -1,0 +1,1 @@
+../../.agents/skills/aiq-maintain-ci

--- a/docs/source/integration/agent-skills.md
+++ b/docs/source/integration/agent-skills.md
@@ -17,7 +17,7 @@ the **API-consumer** skills. The maintainer skills are documented in their own
 | :-- | :-- | :-- |
 | **Audience** | Users calling a running AI-Q server | Developers changing the AI-Q repo |
 | **Location** | top-level `skills/` | `.agents/skills/` |
-| **Examples** | `aiq-deploy`, `aiq-research` | `aiq-add-data-source`, `aiq-add-tool`, `aiq-release-qa`, `aiq-prepare-pr` |
+| **Examples** | `aiq-deploy`, `aiq-research` | `aiq-add-data-source`, `aiq-add-tool`, `aiq-release-qa`, `aiq-prepare-pr`, `aiq-customize-prompts-models`, `aiq-maintain-ci` |
 | **Assumes** | A reachable AI-Q backend | A repo checkout and dev toolchain |
 
 The API-consumer skills are:
@@ -111,6 +111,8 @@ skills point into `skills/`; the maintainer skills point into `.agents/skills/`:
 .claude/skills/aiq-add-tool -> ../../.agents/skills/aiq-add-tool
 .claude/skills/aiq-release-qa -> ../../.agents/skills/aiq-release-qa
 .claude/skills/aiq-prepare-pr -> ../../.agents/skills/aiq-prepare-pr
+.claude/skills/aiq-customize-prompts-models -> ../../.agents/skills/aiq-customize-prompts-models
+.claude/skills/aiq-maintain-ci -> ../../.agents/skills/aiq-maintain-ci
 ```
 
 To recreate the consumer-skill repo-local install manually:


### PR DESCRIPTION
#### Overview

Adds two maintainer skills under `.agents/skills/`, moving them out of the
DEVSKILLS-8 "later skill backlog" (epic AIQ-3362) now that both surfaces are
active 2.2 release work:

- **`aiq-customize-prompts-models`** — Jinja2 prompt-template editing
  (`src/aiq_agent/agents/*/prompts/*.j2`, `load_prompt`/`render_prompt_template`)
  and per-agent model selection (the `llms` section + role fields like
  `orchestrator_llm`/`researcher_llm`/`planner_llm`/`writer_llm`, bound via
  `LLMProvider`/`LLMRole`). Prompt/model customization became release work in #267.
- **`aiq-maintain-ci`** — the GitHub Actions workflows, pre-commit hooks,
  CODEOWNERS/CodeRabbit/copy-pr-bot governance, and the `.github/skill-eval` harness.

Each skill is a `SKILL.md` + two `references/` files + a `.claude/skills`
compatibility symlink, following the existing maintainer-skill conventions and
`TEMPLATE.md`. Both are now enumerated in the `.agents/skills/README.md` and
`docs/source/integration/agent-skills.md` skill tables (all six maintainer skills).
Docs-only; no runtime code. Rebased on `develop` after #281 merged.

The middle commit addresses code-review feedback, each item verified against the
repo: corrected the pre-commit push-stage behavior (`pytest`/`helm-lint` are
`stages: [push]`, so `pre-commit run --all-files` skips them; CI runs them as
dedicated jobs), the deep-researcher vs clarifier LLM role binding (added a
field→`LLMRole` table; the deep research agent has no generic `llm` field), the
`ui.yml` job ids, the skill-eval stages (`detect-changes → generate-datasets →
harbor-eval`), the "adding a new template needs `load_prompt` wiring" caveat, and
`start_cli.sh --config_file` in the validation smokes.

#### Validation

```text
$ uv run python scripts/validate_skills.py .agents/skills
Skill validation passed: 8 skill(s) OK.

$ uv run pytest tests/test_agent_skills.py -q
4 passed

$ uv run pre-commit run --files <new skill markdown + doc tables>
Detect secrets ......... Passed
Validate agent skills .. Passed
Markdown Link Check .... Passed
```

- [x] I ran the relevant local checks or explained why they are not applicable.
- [ ] I added or updated tests for behavior changes. (N/A — skill docs, not runtime code; `validate_skills.py` + `tests/test_agent_skills.py` cover them and pass.)
- [x] I updated documentation for user-facing or contributor-facing changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the DCO and signed my commits with `git commit -s`.

#### Where should reviewers start?

`.agents/skills/aiq-customize-prompts-models/SKILL.md` and
`.agents/skills/aiq-maintain-ci/SKILL.md`, then their `references/`. The
model-selection field→`LLMRole` table mirrors `deep_researcher/register.py`, and
the CI reference reflects the real `.pre-commit-config.yaml` stages and `ci.yml` jobs.

#### Related Issues

- Relates to: AIQ-3362 / DEVSKILLS-8 (builds the two skills whose gates have opened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new skill guides for `aiq-customize-prompts-models`, including prompt template editing, model selection/config wiring, and related validation guidance
  * Added new skill guides for `aiq-maintain-ci`, covering CI/governance maintenance with workflow and evaluation-harness references
  * Included CLI and checklist-style validation steps and “common mistakes” sections across the new guides
  * Updated agent skills integration docs and Claude Code repo-local symlink instructions for both new skills
<!-- end of auto-generated comment: release notes by coderabbit.ai -->