### PR TITLE
fix(deep-research): return results in ResearchNotes, not write_file

### DIFF
--- a/src/aiq_agent/agents/deep_researcher/skills/research/data-table-analysis/SKILL.md
+++ b/src/aiq_agent/agents/deep_researcher/skills/research/data-table-analysis/SKILL.md
@@ -15,7 +15,7 @@ To ensure the calculation is reproducible and useful, you MUST:
 2. **Preserve Provenance:** Keep source URLs, filing names, or note references in the input table when available.
 3. **Normalize Units:** Convert currencies, magnitudes, periods, and date labels into consistent fields before comparing values.
 4. **Compute Deterministically:** Call the `execute` tool to run Python/pandas for arithmetic, rankings, growth rates, aggregates, and formatting. Do not hand-compute these values in prose.
-5. **Write Text Outputs:** Save markdown, CSV, or JSON outputs to `/shared/...` with descriptive filenames using `write_file`.
+5. **Return Text Outputs:** Include the markdown, CSV, or JSON output in your returned `ResearchNotes` (e.g. a `ResearchFinding`'s `evidence` and/or `narrative_notes`). Do not call `write_file`; `run_research_batch` persists your returned notes.
 6. **Report Caveats:** Include assumptions, missing values, restatements, estimated figures, or non-comparable metrics in the output notes.
 
 ## Execution Flow
@@ -36,10 +36,7 @@ To ensure the calculation is reproducible and useful, you MUST:
 
 4. Inspect the `execute` output. If the code fails, fix the code and call `execute` again. Do not continue with hand-computed fallback tables unless the sandbox or pandas is unavailable.
 
-5. Write final text artifacts from the successful `execute` output to `/shared/...` using `write_file`, for example:
-   - `/shared/capex_growth_table.md`
-   - `/shared/capex_normalized.csv`
-   - `/shared/capex_analysis.json`
+5. Return the final outputs from the successful `execute` run in your `ResearchNotes` — put the markdown table, CSV, or JSON into a `ResearchFinding`'s `evidence` and/or `narrative_notes`. Do not call `write_file`/`edit_file`; `run_research_batch` persists your returned notes under `/shared/` automatically.
 
 6. In the response or report, cite the original sources for the input figures. Computed columns should be clearly labeled as calculations.
 
@@ -72,12 +69,12 @@ To ensure the calculation is reproducible and useful, you MUST:
 
 ## Output Formats
 
-The sandbox supports text outputs that should be saved through `/shared/`:
-- `.md` - Markdown tables and explanatory notes for report inclusion.
-- `.csv` - Normalized tabular data for reuse.
-- `.json` - Structured records, assumptions, and summary metrics.
+Return text outputs in your `ResearchNotes` for synthesis:
+- a Markdown table - tables and explanatory notes for report inclusion.
+- CSV text - normalized tabular data for reuse.
+- a JSON block - structured records, assumptions, and summary metrics.
 
-**Storage Note:** Always use descriptive filenames (e.g., ai_capex_8q_growth.md) rather than generic names like output.md.
+**Note:** Label each output clearly (e.g. an "AI capex 8Q growth" table) so the writer can use it.
 
 ---
 

--- a/src/aiq_agent/agents/deep_researcher/skills/research/forecast-analysis/SKILL.md
+++ b/src/aiq_agent/agents/deep_researcher/skills/research/forecast-analysis/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: forecast-analysis
 description: >
-  Use this skill during research for lightweight forecast evidence analysis: base-rate checks, prediction-market anchors, scenario ranges, directional factor summaries, implied probabilities, and monitoring indicators. Triggers: "forecast", "prediction", "probability", "odds", "base rate", "scenario", "Polymarket", "prediction market", "will happen", "market-implied", "confidence interval", "price target", "expected value". Outputs: forecast evidence notes or compact forecast inputs saved under /shared/ for writer synthesis.
+  Use this skill during research for lightweight forecast evidence analysis: base-rate checks, prediction-market anchors, scenario ranges, directional factor summaries, implied probabilities, and monitoring indicators. Triggers: "forecast", "prediction", "probability", "odds", "base rate", "scenario", "Polymarket", "prediction market", "will happen", "market-implied", "confidence interval", "price target", "expected value". Outputs: forecast evidence notes or compact forecast inputs returned in your ResearchNotes for writer synthesis.
 ---
 
 # Forecast Analysis Skill
@@ -14,7 +14,7 @@ Use this skill when a researcher worker needs to prepare forecast evidence, not 
 2. Prefer explicit anchors from sources, such as prediction-market prices, base rates, latest measured values, official projections, analyst forecasts, or recent trend data.
 3. Use `execute` for any arithmetic: probability conversion, expected value, weighted scenario averages, interval arithmetic, or base-rate adjustments.
 4. Do not invent a final forecast when the assigned ResearchQuery only asks for evidence. Capture what the evidence implies and preserve uncertainty.
-5. Save compact forecast inputs to `/shared/...` only after any calculation has succeeded.
+5. Include compact forecast inputs in your `ResearchNotes` only after any calculation has succeeded.
 6. In `ResearchNotes`, cite original source IDs for every forecast anchor and material factor.
 
 ## Forecast Evidence Map

--- a/src/aiq_agent/agents/deep_researcher/skills/research/lightweight-calculation/SKILL.md
+++ b/src/aiq_agent/agents/deep_researcher/skills/research/lightweight-calculation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lightweight-calculation
 description: >
-  Use this skill for small deterministic calculations during research when pandas/table analysis is unnecessary. Triggers: "calculate", "arithmetic", "unit conversion", "percentage point", "expected value", "weighted average", "range", "ratio", "sanity check", "implied value", "probability conversion". Outputs: concise calculation notes, JSON snippets, or Markdown bullets saved under /shared/ for later synthesis.
+  Use this skill for small deterministic calculations during research when pandas/table analysis is unnecessary. Triggers: "calculate", "arithmetic", "unit conversion", "percentage point", "expected value", "weighted average", "range", "ratio", "sanity check", "implied value", "probability conversion". Outputs: concise calculation notes, JSON snippets, or Markdown bullets returned in your ResearchNotes for later synthesis.
 ---
 
 # Lightweight Calculation Skill
@@ -14,7 +14,7 @@ Use this skill when the research task needs a small reproducible calculation but
 2. Use `execute` with a short Python script for arithmetic, ratios, probability conversion, expected value, weighted averages, confidence/range arithmetic, or unit conversion.
 3. Do not hand-compute values in prose when the arithmetic affects a finding.
 4. Use `/workspace` for sandbox-local files. Sandbox code cannot read or write `/shared/` directly.
-5. Save the final text artifact to `/shared/...` with `write_file` after the successful `execute` call.
+5. Return the final result in your `ResearchNotes` after the successful `execute` call (not via `write_file`); `run_research_batch` persists your returned notes to `/shared/`.
 6. State assumptions, rounding rules, missing inputs, and source references.
 
 ## Execution Pattern
@@ -22,7 +22,7 @@ Use this skill when the research task needs a small reproducible calculation but
 1. Gather the relevant figures from source-tool output or research notes.
 2. Run a compact Python calculation with explicit variables.
 3. Inspect output and fix any code issue before using the result.
-4. Write a short artifact such as `/shared/calculation_check_[topic].md` or `/shared/calculation_check_[topic].json`.
+4. Include a short calculation summary (Markdown or JSON) in your `ResearchNotes` for synthesis.
 5. Cite the original source IDs in the eventual `ResearchFinding`; the calculation artifact is supporting work, not a substitute for sources.
 
 ## Python Template


### PR DESCRIPTION
#### Overview

Fixes a contradicted instruction in the deep researcher's `research/` sandbox skills.

The researcher worker is told via `research.py` (`format_research_request`):
> "Do not call write_file or edit_file; run_research_batch will persist the returned
> ResearchNotes under /shared/."

…and `_persist_research_notes` does exactly that automatically. But three skills
instructed the agent to persist artifacts to `/shared` **via `write_file`** —
`data-table-analysis`, `lightweight-calculation`, and `forecast-analysis` — i.e. an
instruction the researcher is explicitly told not to follow.

This reword changes each skill's persistence step to *"include the result in your
returned `ResearchNotes` (e.g. a `ResearchFinding`'s `evidence` / `narrative_notes`); do
not call `write_file`/`edit_file`."* The separate, still-correct rule that **sandbox
code** uses `/workspace` and cannot touch `/shared` is unchanged.

The same conflict exists in two in-flight skills, fixed/flagged separately:
`image-processing` carries this fix in #285; `chart-generation` in #280 still needs it
(flagged to its author).

#### Validation

```text
$ uv run pytest tests/aiq_agent/agents/deep_researcher/test_deepagents_runtime.py -q
18 passed

$ grep -rn "write_file" .../skills/research/   # now only "do not call write_file"
```

- [x] I ran the relevant local checks or explained why they are not applicable.
- [ ] I added or updated tests for behavior changes. (N/A — wording-only in skill docs; discovery/content tests unaffected and pass.)
- [x] I updated documentation for user-facing or contributor-facing changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the DCO and signed my commits with `git commit -s`.

#### Where should reviewers start?

`research/data-table-analysis/SKILL.md` (steps 5) vs `tools/research.py:46`
(`format_research_request`) — the reworded persistence step now matches what the
researcher is actually told to do.

#### Related Issues

- Relates to: AIQ-3362 (deep researcher skills). Companion to #285 (image-processing) and #280 (chart-generation).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated research skill guidance so calculated outputs are returned directly in research notes for later synthesis.
  * Clarified that compact forecast and calculation results should be captured only after successful processing.
  * Removed instructions that required saving generated artifacts to shared file locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->