### PR TITLE
fix(deep-research): salvage inline report + persist planner plan

### DIFF
--- a/configs/config_cli_default.yml
+++ b/configs/config_cli_default.yml
@@ -132,7 +132,7 @@ functions:
     orchestrator_llm: gpt_oss_llm
     source_router_llm: nemotron_super_llm
     researcher_llm: nemotron_super_llm
-    planner_llm: gpt_oss_llm
+    planner_llm: nemotron_super_llm
     writer_llm: gpt_oss_llm
     exclude_tools:
       - web_search_tool

--- a/configs/config_cli_default.yml
+++ b/configs/config_cli_default.yml
@@ -38,16 +38,6 @@ llms:
     chat_template_kwargs:
       enable_thinking: true
 
-  gpt_oss_llm:
-    _type: nim
-    model_name: openai/gpt-oss-120b
-    base_url: https://integrate.api.nvidia.com/v1
-    temperature: 1.0
-    top_p: 1.0
-    max_tokens: 256000
-    api_key: ${NVIDIA_API_KEY}
-    max_retries: 10
-
 functions:
   # =========================================================================
   # Data Source Registry
@@ -129,11 +119,11 @@ functions:
   deep_research_agent:
     _type: deep_research_agent
     enable_citation_verification: true
-    orchestrator_llm: gpt_oss_llm
+    orchestrator_llm: nemotron_super_llm
     source_router_llm: nemotron_super_llm
     researcher_llm: nemotron_super_llm
     planner_llm: nemotron_super_llm
-    writer_llm: gpt_oss_llm
+    writer_llm: nemotron_super_llm
     exclude_tools:
       - web_search_tool
 

--- a/configs/config_domain_routing_and_skills.yml
+++ b/configs/config_domain_routing_and_skills.yml
@@ -208,7 +208,7 @@ functions:
     orchestrator_llm: gpt_oss_llm
     source_router_llm: nemotron_super_llm
     researcher_llm: nemotron_super_llm
-    planner_llm: gpt_oss_llm
+    planner_llm: nemotron_super_llm
     writer_llm: gpt_oss_llm
     # tools: omitted -> inherits all from data_source_registry
     exclude_tools:                     # Remove basic variant; deep uses advanced_web_search_tool

--- a/configs/config_domain_routing_and_skills.yml
+++ b/configs/config_domain_routing_and_skills.yml
@@ -58,16 +58,6 @@ llms:
     chat_template_kwargs:
       enable_thinking: true
 
-  gpt_oss_llm:
-    _type: nim
-    model_name: openai/gpt-oss-120b
-    base_url: https://integrate.api.nvidia.com/v1
-    temperature: 1.0
-    top_p: 1.0
-    max_tokens: 256000
-    api_key: ${NVIDIA_API_KEY}
-    max_retries: 10
-
   # LLM for document summaries (required when generate_summary: true)
   summary_llm:
     _type: nim
@@ -205,11 +195,11 @@ functions:
   deep_research_agent:
     _type: deep_research_agent
     enable_citation_verification: false
-    orchestrator_llm: gpt_oss_llm
+    orchestrator_llm: nemotron_super_llm
     source_router_llm: nemotron_super_llm
     researcher_llm: nemotron_super_llm
     planner_llm: nemotron_super_llm
-    writer_llm: gpt_oss_llm
+    writer_llm: nemotron_super_llm
     # tools: omitted -> inherits all from data_source_registry
     exclude_tools:                     # Remove basic variant; deep uses advanced_web_search_tool
       - web_search_tool

--- a/configs/config_web_default_llamaindex.yml
+++ b/configs/config_web_default_llamaindex.yml
@@ -206,7 +206,7 @@ functions:
     orchestrator_llm: gpt_oss_llm
     source_router_llm: nemotron_super_llm
     researcher_llm: nemotron_super_llm
-    planner_llm: gpt_oss_llm
+    planner_llm: nemotron_super_llm
     writer_llm: gpt_oss_llm
     # tools: omitted -> inherits all from data_source_registry
     exclude_tools:                     # Remove basic variant; deep uses advanced_web_search_tool

--- a/configs/config_web_default_llamaindex.yml
+++ b/configs/config_web_default_llamaindex.yml
@@ -69,16 +69,6 @@ llms:
     chat_template_kwargs:
       enable_thinking: true
 
-  gpt_oss_llm:
-    _type: nim
-    model_name: openai/gpt-oss-120b
-    base_url: https://integrate.api.nvidia.com/v1
-    temperature: 1.0
-    top_p: 1.0
-    max_tokens: 256000
-    api_key: ${NVIDIA_API_KEY}
-    max_retries: 10
-
   # LLM for document summaries (required when generate_summary: true)
   summary_llm:
     _type: nim
@@ -203,11 +193,11 @@ functions:
   deep_research_agent:
     _type: deep_research_agent
     enable_citation_verification: true
-    orchestrator_llm: gpt_oss_llm
+    orchestrator_llm: nemotron_super_llm
     source_router_llm: nemotron_super_llm
     researcher_llm: nemotron_super_llm
     planner_llm: nemotron_super_llm
-    writer_llm: gpt_oss_llm
+    writer_llm: nemotron_super_llm
     # tools: omitted -> inherits all from data_source_registry
     exclude_tools:                     # Remove basic variant; deep uses advanced_web_search_tool
       - web_search_tool

--- a/configs/config_web_frag.yml
+++ b/configs/config_web_frag.yml
@@ -71,16 +71,6 @@ llms:
     chat_template_kwargs:
       enable_thinking: true
 
-  gpt_oss_llm:
-    _type: nim
-    model_name: openai/gpt-oss-120b
-    base_url: https://integrate.api.nvidia.com/v1
-    temperature: 1.0
-    top_p: 1.0
-    max_tokens: 256000
-    api_key: ${NVIDIA_API_KEY}
-    max_retries: 10
-
 functions:
   # =========================================================================
   # Data Source Registry
@@ -171,11 +161,11 @@ functions:
   deep_research_agent:
     _type: deep_research_agent
     enable_citation_verification: true
-    orchestrator_llm: gpt_oss_llm
+    orchestrator_llm: nemotron_super_llm
     source_router_llm: nemotron_super_llm
     researcher_llm: nemotron_super_llm
     planner_llm: nemotron_super_llm
-    writer_llm: gpt_oss_llm
+    writer_llm: nemotron_super_llm
     # tools: omitted -> inherits all from data_source_registry
     exclude_tools:
       - web_search_tool

--- a/configs/config_web_frag.yml
+++ b/configs/config_web_frag.yml
@@ -174,7 +174,7 @@ functions:
     orchestrator_llm: gpt_oss_llm
     source_router_llm: nemotron_super_llm
     researcher_llm: nemotron_super_llm
-    planner_llm: gpt_oss_llm
+    planner_llm: nemotron_super_llm
     writer_llm: gpt_oss_llm
     # tools: omitted -> inherits all from data_source_registry
     exclude_tools:

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -50,6 +50,14 @@ DEFAULT_MAX_RESEARCH_CONCURRENCY = 6
 # Path to this agent's directory (for loading prompts)
 AGENT_DIR = Path(__file__).parent
 
+# Salvage gate: when the orchestrator synthesizes the report inline instead of delegating to
+# writer-agent, no /shared/output.md is written. We accept the final message as the report only
+# when it is clearly a substantive report (long + has a markdown heading), so workflow chatter is
+# still rejected and the strict file-first contract is preserved.
+_WRITER_COMPLETION_MARKER = "Wrote /shared/output.md"
+_MIN_INLINE_REPORT_CHARS = 400
+_MD_HEADING_RE = re.compile(r"(?m)^#{1,6}\s")
+
 
 class DeepResearcherAgent:
     """
@@ -172,7 +180,31 @@ class DeepResearcherAgent:
                     output_entry = output_entry.decode("utf-8")
                 if isinstance(output_entry, str) and output_entry.strip():
                     return output_entry.strip()
-        return None
+        return self._salvage_inline_report(result)
+
+    @staticmethod
+    def _salvage_inline_report(result: dict | Any) -> str | None:
+        """Salvage a report the orchestrator wrote inline instead of via writer-agent.
+
+        When the orchestrator skips the writer-agent delegation and emits the full report in its
+        final message, no output file exists. Accept that message only when it is clearly a
+        substantive report so plain workflow chatter is still rejected.
+        """
+        messages = result.get("messages") if isinstance(result, dict) else getattr(result, "messages", None)
+        if not messages:
+            return None
+        content = getattr(messages[-1], "content", None)
+        if not isinstance(content, str):
+            return None
+        stripped = content.strip()
+        if (
+            not stripped
+            or stripped == _WRITER_COMPLETION_MARKER
+            or len(stripped) < _MIN_INLINE_REPORT_CHARS
+            or not _MD_HEADING_RE.search(stripped)
+        ):
+            return None
+        return stripped
 
     @staticmethod
     def _replace_last_message_content(result: dict | Any, content: str) -> None:

--- a/src/aiq_agent/agents/deep_researcher/custom_middleware.py
+++ b/src/aiq_agent/agents/deep_researcher/custom_middleware.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelResponse
 from langchain_core.messages import AIMessage
+from langchain_core.messages import SystemMessage
 from langchain_core.messages import ToolMessage
 
 from aiq_agent.common import get_source_id_for_tool
@@ -197,6 +198,47 @@ class ToolVisibilityMiddleware(AgentMiddleware):
     async def awrap_model_call(self, request, handler):
         """Filter hidden tools before an asynchronous model call."""
         return await handler(request.override(tools=self._filter_tools(request.tools)))
+
+
+class TodoSuppressionMiddleware(AgentMiddleware):
+    """Strip the framework's ``write_todos`` tool and its injected prompt for a subagent.
+
+    deepagents attaches ``TodoListMiddleware`` to every subagent, which adds the
+    ``write_todos`` tool plus a system-prompt block telling the agent to use it.
+    Agents that own no progress list - e.g. the planner, which returns a single
+    structured ``ResearchPlan`` - should not have it. Placed after the framework's
+    ``TodoListMiddleware`` in the stack, this removes both the tool and the injected
+    prompt block from the model request, keeping todo tracking solely with the
+    orchestrator. It is a no-op when neither is present.
+    """
+
+    _TODO_TOOL = "write_todos"
+    _TODO_PROMPT_MARKER = "## `write_todos`"
+
+    def _clean_request(self, request: object) -> object:
+        """Return the request with the write_todos tool and its prompt block removed."""
+        overrides: dict[str, object] = {
+            "tools": [tool for tool in request.tools if _request_tool_name(tool) != self._TODO_TOOL]
+        }
+        system_message = getattr(request, "system_message", None)
+        if system_message is not None:
+            blocks = system_message.content_blocks
+            kept = [
+                block
+                for block in blocks
+                if not (isinstance(block, dict) and self._TODO_PROMPT_MARKER in str(block.get("text", "")))
+            ]
+            if len(kept) != len(blocks):
+                overrides["system_message"] = SystemMessage(content=kept)
+        return request.override(**overrides)
+
+    def wrap_model_call(self, request, handler):
+        """Strip write_todos and its prompt before a synchronous model call."""
+        return handler(self._clean_request(request))
+
+    async def awrap_model_call(self, request, handler):
+        """Strip write_todos and its prompt before an asynchronous model call."""
+        return await handler(self._clean_request(request))
 
 
 class ToolRetryMiddleware(AgentMiddleware):
@@ -454,24 +496,17 @@ class PlanPersistenceMiddleware(AgentMiddleware):
         responses = self.backend.upload_files([(self.path, content)])
         errors = [f"{response.path}: {response.error}" for response in responses if getattr(response, "error", None)]
         if errors:
-            msg = f"Failed to persist plan to {self.path}: {'; '.join(errors)}"
-            logger.error(msg)
-            raise RuntimeError(msg)
-
-    async def awrap_model_call(self, request, handler):
-        """Persist the structured plan as soon as the model emits it."""
-        response = await handler(request)
-        plan = getattr(response, "structured_response", None)
-        if plan is not None:
-            await asyncio.to_thread(self._persist_plan, plan)
-        return response
+            # Raw backend detail stays in logs; the raised error reaches the job status /
+            # caller, so it must not echo backend-internal strings (hostnames, paths, etc.).
+            logger.error("Failed to persist plan to %s: %s", self.path, "; ".join(errors))
+            raise RuntimeError(f"Failed to persist the research plan to {self.path}")
 
     def after_agent(self, state, runtime):
-        """Persist the plan after a synchronous planner run completes."""
+        """Persist the plan once the synchronous planner run completes."""
         self._persist_plan(self._plan_from_state(state))
 
     async def aafter_agent(self, state, runtime):
-        """Persist the plan after an asynchronous planner run completes."""
+        """Persist the plan once the asynchronous planner run completes."""
         await asyncio.to_thread(self._persist_plan, self._plan_from_state(state))
 
 

--- a/src/aiq_agent/agents/deep_researcher/custom_middleware.py
+++ b/src/aiq_agent/agents/deep_researcher/custom_middleware.py
@@ -16,6 +16,7 @@
 """Custom middleware for the deep research agent."""
 
 import asyncio
+import json
 import logging
 from pathlib import Path
 
@@ -404,6 +405,80 @@ class SourceRegistryMiddleware(AgentMiddleware):
         returns the complete registry.
         """
         return self._render_source_list_text(self.get_source_entries(mode=mode))
+
+
+class PlanPersistenceMiddleware(AgentMiddleware):
+    """Persists the planner's structured ResearchPlan to the shared filesystem.
+
+    The planner returns a schema-validated ``ResearchPlan`` (``response_format``).
+    This middleware writes that plan to ``/shared/plan.json`` deterministically via
+    the overwrite-safe ``backend.upload_files`` (the same state-channel write
+    ``run_research_batch`` uses for ResearchNotes), so the planner never performs
+    file I/O itself. Keeping the write off the LLM removes the ``write_file`` /
+    ``edit_file`` loop the planner otherwise hits when ``/shared/plan.json`` already
+    exists, since the LLM ``write_file`` tool refuses to overwrite while
+    ``upload_files`` overwrites in place.
+
+    Persistence failures are logged and never propagate into the agent loop.
+    """
+
+    def __init__(self, backend: object, *, path: str = "/shared/plan.json") -> None:
+        """Initialize the middleware.
+
+        Args:
+            backend: Shared filesystem backend exposing ``upload_files``.
+            path: Shared path the serialized plan is written to.
+        """
+        self.backend = backend
+        self.path = path
+
+    @staticmethod
+    def _plan_from_state(state: object) -> object:
+        """Extract the planner's ``structured_response`` from dict or attribute state."""
+        if isinstance(state, dict):
+            return state.get("structured_response")
+        return getattr(state, "structured_response", None)
+
+    def _persist_plan(self, plan: object) -> None:
+        """Serialize a structured ResearchPlan and upload it to shared state."""
+        if plan is None:
+            return
+        if hasattr(plan, "model_dump"):
+            payload = plan.model_dump(mode="json", exclude_none=True)
+        elif isinstance(plan, dict):
+            payload = plan
+        else:
+            return
+        content = json.dumps(payload, indent=2, ensure_ascii=False).encode("utf-8")
+        responses = self.backend.upload_files([(self.path, content)])
+        errors = [f"{response.path}: {response.error}" for response in responses if getattr(response, "error", None)]
+        if errors:
+            logger.warning("Failed to persist plan to %s: %s", self.path, "; ".join(errors))
+
+    async def awrap_model_call(self, request, handler):
+        """Persist the structured plan as soon as the model emits it."""
+        response = await handler(request)
+        plan = getattr(response, "structured_response", None)
+        if plan is not None:
+            try:
+                self._persist_plan(plan)
+            except Exception:
+                logger.warning("Plan persistence (model_call) failed", exc_info=True)
+        return response
+
+    def after_agent(self, state, runtime):
+        """Persist the plan after a synchronous planner run completes."""
+        try:
+            self._persist_plan(self._plan_from_state(state))
+        except Exception:
+            logger.warning("Plan persistence to %s failed", self.path, exc_info=True)
+
+    async def aafter_agent(self, state, runtime):
+        """Persist the plan after an asynchronous planner run completes."""
+        try:
+            self._persist_plan(self._plan_from_state(state))
+        except Exception:
+            logger.warning("Plan persistence to %s failed", self.path, exc_info=True)
 
 
 class ToolResultPruningMiddleware(AgentMiddleware):

--- a/src/aiq_agent/agents/deep_researcher/custom_middleware.py
+++ b/src/aiq_agent/agents/deep_researcher/custom_middleware.py
@@ -419,7 +419,8 @@ class PlanPersistenceMiddleware(AgentMiddleware):
     exists, since the LLM ``write_file`` tool refuses to overwrite while
     ``upload_files`` overwrites in place.
 
-    Persistence failures are logged and never propagate into the agent loop.
+    Persistence failures propagate so the planner task fails before the
+    orchestrator reads a missing or stale ``/shared/plan.json``.
     """
 
     def __init__(self, backend: object, *, path: str = "/shared/plan.json") -> None:
@@ -453,32 +454,25 @@ class PlanPersistenceMiddleware(AgentMiddleware):
         responses = self.backend.upload_files([(self.path, content)])
         errors = [f"{response.path}: {response.error}" for response in responses if getattr(response, "error", None)]
         if errors:
-            logger.warning("Failed to persist plan to %s: %s", self.path, "; ".join(errors))
+            msg = f"Failed to persist plan to {self.path}: {'; '.join(errors)}"
+            logger.error(msg)
+            raise RuntimeError(msg)
 
     async def awrap_model_call(self, request, handler):
         """Persist the structured plan as soon as the model emits it."""
         response = await handler(request)
         plan = getattr(response, "structured_response", None)
         if plan is not None:
-            try:
-                self._persist_plan(plan)
-            except Exception:
-                logger.warning("Plan persistence (model_call) failed", exc_info=True)
+            await asyncio.to_thread(self._persist_plan, plan)
         return response
 
     def after_agent(self, state, runtime):
         """Persist the plan after a synchronous planner run completes."""
-        try:
-            self._persist_plan(self._plan_from_state(state))
-        except Exception:
-            logger.warning("Plan persistence to %s failed", self.path, exc_info=True)
+        self._persist_plan(self._plan_from_state(state))
 
     async def aafter_agent(self, state, runtime):
         """Persist the plan after an asynchronous planner run completes."""
-        try:
-            self._persist_plan(self._plan_from_state(state))
-        except Exception:
-            logger.warning("Plan persistence to %s failed", self.path, exc_info=True)
+        await asyncio.to_thread(self._persist_plan, self._plan_from_state(state))
 
 
 class ToolResultPruningMiddleware(AgentMiddleware):

--- a/src/aiq_agent/agents/deep_researcher/factory.py
+++ b/src/aiq_agent/agents/deep_researcher/factory.py
@@ -42,6 +42,7 @@ from aiq_agent.common import LLMRole
 from aiq_agent.common import render_prompt_template
 
 from .custom_middleware import EmptyContentFixMiddleware
+from .custom_middleware import PlanPersistenceMiddleware
 from .custom_middleware import SourceRegistryMiddleware
 from .custom_middleware import ToolNameSanitizationMiddleware
 from .custom_middleware import ToolResultPruningMiddleware
@@ -371,7 +372,7 @@ def build_deep_research_subagents(context: DeepResearchGraphContext) -> list[dic
             prompt_name="planner",
             role=LLMRole.PLANNER,
             tools=context.tool_set.researcher_tools,
-            middleware=context.middleware_set.planner,
+            middleware=[*context.middleware_set.planner, PlanPersistenceMiddleware(backend=context.backend)],
             prompt_values={
                 "tools": context.tool_set.tools_info,
                 "enable_source_router": context.enable_source_router,

--- a/src/aiq_agent/agents/deep_researcher/factory.py
+++ b/src/aiq_agent/agents/deep_researcher/factory.py
@@ -44,6 +44,7 @@ from aiq_agent.common import render_prompt_template
 from .custom_middleware import EmptyContentFixMiddleware
 from .custom_middleware import PlanPersistenceMiddleware
 from .custom_middleware import SourceRegistryMiddleware
+from .custom_middleware import TodoSuppressionMiddleware
 from .custom_middleware import ToolNameSanitizationMiddleware
 from .custom_middleware import ToolResultPruningMiddleware
 from .custom_middleware import ToolVisibilityMiddleware
@@ -372,7 +373,11 @@ def build_deep_research_subagents(context: DeepResearchGraphContext) -> list[dic
             prompt_name="planner",
             role=LLMRole.PLANNER,
             tools=context.tool_set.researcher_tools,
-            middleware=[*context.middleware_set.planner, PlanPersistenceMiddleware(backend=context.backend)],
+            middleware=[
+                *context.middleware_set.planner,
+                TodoSuppressionMiddleware(),
+                PlanPersistenceMiddleware(backend=context.backend),
+            ],
             prompt_values={
                 "tools": context.tool_set.tools_info,
                 "enable_source_router": context.enable_source_router,

--- a/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
@@ -56,9 +56,17 @@ Step 5. **Return Answer**: After writer-agent returns, return only its short com
 {% endif %}
 
 ## Progress Tracking
-Use write_todos to update progress after each workflow step. Use status values: "pending", "in_progress", or "completed".
+Use write_todos only after a workflow-advancing tool has already run. Use status values: "pending", "in_progress",
+or "completed".
+When calling `write_todos`, pass a single argument named `todos`. Each todo item must use this exact shape:
+`{"content": "<task description>", "status": "pending"}`.
+`status` must be exactly one of `"pending"`, `"in_progress"`, or `"completed"`.
+Never use `task`, `title`, or `description` keys for todo items.
+Do not call `write_todos` as the only tool call in an assistant turn.
+If todo tracking causes uncertainty, skip it and continue the workflow.
 
-Before returning the final answer, invoke write_todos to mark all tasks as "completed". Do not output tool calls as text.
+Before returning the final answer, mark todos as "completed" only if todo tracking has already been used. Do not add
+a todo-only final turn. Do not output tool calls as text.
 
 {% if enable_source_router %}
 ## Source Routing Delegation Template

--- a/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
@@ -38,21 +38,21 @@ Step 1. **Task Decomposition and Progress Tracking**: Use `write_todos` to track
 {% if enable_source_router %}
 Step 2. **Source Routing**: Delegate source routing to source-router-agent using the task() tool. The router writes `/shared/source_routing.json`. Do not call any other `task()` tool in the same assistant turn. After the source-router-agent task returns, read `/shared/source_routing.json` before planning. Treat this as advisory guidance for planning.
 
-Step 3. **Planning**: Delegate research planning to the planner-agent using the task() tool only after Step 2 has completed. The planner reads `/shared/source_routing.json` if present, returns a structured ResearchPlan, and writes the same raw JSON to `/shared/plan.json`.
+Step 3. **Planning**: Delegate research planning to the planner-agent using the task() tool only after Step 2 has completed. The planner reads `/shared/source_routing.json` if present and returns a structured ResearchPlan; the runtime persists it to `/shared/plan.json`.
 
 Step 4. **Research**: Read `/shared/plan.json`, collect the independent ResearchQuery objects needed by `answer_strategy.required_components`, then call `run_research_batch` with the largest valid batch: all needed queries in one call when there are {{ max_research_concurrency }} or fewer, otherwise the fewest ordered batches of at most {{ max_research_concurrency }}. Never conduct search yourself and never re-delegate to the planner-agent.
 
 Step 5. **Final Synthesis**: Delegate to writer-agent with task(). The writer writes the final output to `/shared/output.md` and returns only a short completion marker.
 
-Step 6. **Return Answer**: Return only the final Markdown answer in the final message. Do not add workflow commentary.
+Step 6. **Return Answer**: After writer-agent returns, return only its short completion marker. The runtime loads the final report from `/shared/output.md`; do not synthesize or write the report yourself.
 {% else %}
-Step 2. **Planning**: Delegate research planning to the planner-agent using the task() tool. The planner returns a structured ResearchPlan and writes the same raw JSON to `/shared/plan.json`.
+Step 2. **Planning**: Delegate research planning to the planner-agent using the task() tool. The planner returns a structured ResearchPlan; the runtime persists it to `/shared/plan.json`.
 
 Step 3. **Research**: Read `/shared/plan.json`, collect the independent ResearchQuery objects needed by `answer_strategy.required_components`, then call `run_research_batch` with the largest valid batch: all needed queries in one call when there are {{ max_research_concurrency }} or fewer, otherwise the fewest ordered batches of at most {{ max_research_concurrency }}. Never conduct search yourself and never re-delegate to the planner-agent.
 
 Step 4. **Final Synthesis**: Delegate to writer-agent with task(). The writer writes the final output to `/shared/output.md` and returns only a short completion marker.
 
-Step 5. **Return Answer**: Return only the final Markdown answer in the final message. Do not add workflow commentary.
+Step 5. **Return Answer**: After writer-agent returns, return only its short completion marker. The runtime loads the final report from `/shared/output.md`; do not synthesize or write the report yourself.
 {% endif %}
 
 ## Progress Tracking

--- a/src/aiq_agent/agents/deep_researcher/prompts/planner.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/planner.j2
@@ -21,8 +21,7 @@ Before generating the research plan, deeply analyze the user's request:
 
 ## Workflow
 - **Task Decomposition**: Break the research into focused answer components and ResearchQuery objects in the final
-  ResearchPlan. Do not call `write_todos`. Todo tracking is owned by the orchestrator; the planner's job is to use
-  discovery tools, reason with `think`, and return the final structured ResearchPlan.
+  ResearchPlan, using discovery tools and reasoning with `think`, then return the final structured ResearchPlan.
 {% if enable_source_router %}
 - **Source routing advisory**: First inspect `/shared/` with `ls`. If `/shared/source_routing.json` exists, read it before choosing source tools. Do not call `ls` and `read_file` for `/shared/source_routing.json` in the same assistant turn. If the route file is missing or `read_file` says it is not found, continue planning without source-routing guidance; do not fail, retry indefinitely, or search subdirectories. When a route is available, copy all highest-priority routed recommendations' exact `tool_names` into `preferred_tools` for the final ResearchQuery objects where they fit. Copy route fallback source tool names into `fallback_tools` when useful for corroboration or gaps. Never use tool names that are not listed below.
 {% endif %}

--- a/src/aiq_agent/agents/deep_researcher/prompts/planner.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/planner.j2
@@ -20,7 +20,9 @@ Before generating the research plan, deeply analyze the user's request:
 5. **Language**: What language is the user's request in?
 
 ## Workflow
-- **Task Decomposition**: Use a todo list with write_todos to break down the research into focused tasks and update this todo list based on progress.
+- **Task Decomposition**: Break the research into focused answer components and ResearchQuery objects in the final
+  ResearchPlan. Do not call `write_todos`. Todo tracking is owned by the orchestrator; the planner's job is to use
+  discovery tools, reason with `think`, and return the final structured ResearchPlan.
 {% if enable_source_router %}
 - **Source routing advisory**: First inspect `/shared/` with `ls`. If `/shared/source_routing.json` exists, read it before choosing source tools. Do not call `ls` and `read_file` for `/shared/source_routing.json` in the same assistant turn. If the route file is missing or `read_file` says it is not found, continue planning without source-routing guidance; do not fail, retry indefinitely, or search subdirectories. When a route is available, copy all highest-priority routed recommendations' exact `tool_names` into `preferred_tools` for the final ResearchQuery objects where they fit. Copy route fallback source tool names into `fallback_tools` when useful for corroboration or gaps. Never use tool names that are not listed below.
 {% endif %}

--- a/src/aiq_agent/agents/deep_researcher/prompts/planner.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/planner.j2
@@ -4,13 +4,11 @@ Your final response is validated against the ResearchPlan schema. Return the fin
 ## Other Tools
 - `think`: record your thoughts for downstream steps
 {% if enable_source_router %}
-- `ls`: filesystem tool to see if `/shared/source_routing.json` or `/shared/plan.json` exists
+- `ls`: filesystem tool to see if `/shared/source_routing.json` exists
 - `read_file`: filesystem tool to read `/shared/source_routing.json` only after a previous filesystem tool result shows it exists
-{% else %}
-- `ls`: filesystem tool to see if `/shared/plan.json` exists
 {% endif %}
-- `write_file`: filesystem tool to write plan to `/shared/plan.json` if it doesn't exist
-- `edit_file`: filesystem tool to edit the plan at `/shared/plan.json` if it exists
+
+Do not call `write_file` or `edit_file`. The runtime persists your returned `ResearchPlan` to `/shared/plan.json` automatically after you return.
 
 ## Task Analysis
 Before generating the research plan, deeply analyze the user's request:
@@ -34,7 +32,7 @@ Before generating the research plan, deeply analyze the user's request:
    - What routing, coverage, or query-shaping gaps remain?
    - What constraints or answer components should I add based on these findings?
 - **Evolve**: Refine answer_strategy and constraints based on findings.
-- **Output**: Write the raw ResearchPlan JSON object to `/shared/plan.json` with the `write_file` filesystem tool and return the same plan as your final structured response.
+- **Output**: Return the refined `ResearchPlan` as your final structured response. Do not write it to a file yourself; the runtime persists it to `/shared/plan.json` automatically.
 
 ## Dynamic Discovery Budget
 
@@ -130,11 +128,7 @@ Before returning the final research plan, verify:
 
 ## Final Output
 
-Return a `ResearchPlan` structured response.
-
-Before returning, write the same ResearchPlan object as raw JSON to `/shared/plan.json` using `write_file`.
-
-Do not wrap the file content in markdown fences or add prose outside the JSON.
+Return a `ResearchPlan` structured response. The runtime persists it to `/shared/plan.json` automatically; do not call `write_file` or `edit_file`.
 
 **Important**:
 - You MUST match the language of the task for all outputs e.g if the task is in Chinese, the outputs should be in Chinese.

--- a/tests/aiq_agent/agents/deep_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_agent.py
@@ -1292,6 +1292,39 @@ class TestFinalMarkdownExtraction:
 
             assert output is None
 
+    def test_extract_final_markdown_salvages_substantive_inline_report(self, mock_llm_provider, real_tool):
+        """A substantive report emitted inline (no output file) is salvaged, unlike plain chatter."""
+        with patch(
+            "aiq_agent.agents.deep_researcher.factory.create_deep_agent",
+            return_value=MagicMock(),
+        ):
+            from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+
+            agent = DeepResearcherAgent(llm_provider=mock_llm_provider, tools=[real_tool])
+            report = (
+                "# Quarterly CapEx Report\n\n"
+                + "NVIDIA and Samsung capital expenditure analysis across quarters. " * 12
+                + "\n\n## Sources\n[1] Example: https://example.com"
+            )
+            output = agent._extract_final_markdown({"messages": [AIMessage(content=report)], "files": {}})
+
+            assert output == report.strip()
+
+    def test_extract_final_markdown_rejects_writer_completion_marker(self, mock_llm_provider, real_tool):
+        """The short writer completion marker is never salvaged as the report."""
+        with patch(
+            "aiq_agent.agents.deep_researcher.factory.create_deep_agent",
+            return_value=MagicMock(),
+        ):
+            from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+
+            agent = DeepResearcherAgent(llm_provider=mock_llm_provider, tools=[real_tool])
+            output = agent._extract_final_markdown(
+                {"messages": [AIMessage(content="Wrote /shared/output.md")], "files": {}}
+            )
+
+            assert output is None
+
     @pytest.mark.asyncio
     async def test_run_fails_on_missing_writer_output_before_citation_verification(
         self,
@@ -1320,6 +1353,37 @@ class TestFinalMarkdownExtraction:
             state = DeepResearchAgentState(messages=[HumanMessage(content="Write a report")])
             with pytest.raises(ValueError, match="writer-agent did not produce a final Markdown answer"):
                 await agent.run(state)
+
+    @pytest.mark.asyncio
+    async def test_run_salvages_inline_report_when_writer_output_missing(self, mock_llm_provider, real_tool):
+        """A substantive inline report is salvaged into the final message when no output file exists."""
+        report = (
+            "# CapEx Report\n\n"
+            + "Detailed multi-quarter capital expenditure narrative for the comparison [1]. " * 12
+            + "\n\n## Sources\n[1] Example: https://example.com"
+        )
+        result_messages = [
+            HumanMessage(content="Original query"),
+            AIMessage(content=report),
+        ]
+
+        mock_agent = MagicMock()
+        mock_agent.with_config = MagicMock(return_value=mock_agent)
+        mock_agent.ainvoke = AsyncMock(return_value={"messages": result_messages, "files": {}})
+
+        with patch(
+            "aiq_agent.agents.deep_researcher.factory.create_deep_agent",
+            return_value=mock_agent,
+        ):
+            from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+
+            agent = DeepResearcherAgent(llm_provider=mock_llm_provider, tools=[real_tool])
+            agent.source_registry_middleware.registry.add(SourceEntry(url="https://example.com"))
+
+            state = DeepResearchAgentState(messages=[HumanMessage(content="Original query")])
+            result = await agent.run(state)
+
+            assert "# CapEx Report" in result.messages[-1].content
 
 
 class TestDeepResearcherCitationVerification:

--- a/tests/aiq_agent/agents/deep_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_agent.py
@@ -482,8 +482,9 @@ class TestDeepResearcherAgent:
             assert "answer_strategy" in planner_prompt
             assert "Dynamic Discovery Budget" in planner_prompt
             assert "Do not turn planning into full evidence gathering" in planner_prompt
-            assert "Do not call `write_todos`" in planner_prompt
-            assert "Todo tracking is owned by the orchestrator" in planner_prompt
+            # write_todos is suppressed for the planner at the middleware level
+            # (TodoSuppressionMiddleware), so the prompt no longer mentions it at all.
+            assert "write_todos" not in planner_prompt
             assert "configured batch concurrency of 6" in planner_prompt
             assert "Thorough evidence gathering is essential" not in planner_prompt
             assert "Table of Contents" not in planner_prompt

--- a/tests/aiq_agent/agents/deep_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_agent.py
@@ -413,6 +413,14 @@ class TestDeepResearcherAgent:
             assert "do not create smaller curated waves" in kwargs["system_prompt"]
             assert "Never repeat a covered query" in kwargs["system_prompt"]
             assert "revise only the invalid, failed, or missing ResearchQuery objects" in kwargs["system_prompt"]
+            assert '{"content": "<task description>", "status": "pending"}' in kwargs["system_prompt"]
+            assert (
+                '`status` must be exactly one of `"pending"`, `"in_progress"`, or `"completed"`'
+                in kwargs["system_prompt"]
+            )
+            assert "Never use `task`, `title`, or `description` keys for todo items" in kwargs["system_prompt"]
+            assert "Do not call `write_todos` as the only tool call in an assistant turn" in kwargs["system_prompt"]
+            assert "If todo tracking causes uncertainty, skip it and continue the workflow" in kwargs["system_prompt"]
             assert "max_batch_research_queries" not in kwargs["system_prompt"]
             assert "data-table-analysis" not in kwargs["system_prompt"]
             subagents = {subagent["name"]: subagent for subagent in kwargs["subagents"]}
@@ -474,6 +482,8 @@ class TestDeepResearcherAgent:
             assert "answer_strategy" in planner_prompt
             assert "Dynamic Discovery Budget" in planner_prompt
             assert "Do not turn planning into full evidence gathering" in planner_prompt
+            assert "Do not call `write_todos`" in planner_prompt
+            assert "Todo tracking is owned by the orchestrator" in planner_prompt
             assert "configured batch concurrency of 6" in planner_prompt
             assert "Thorough evidence gathering is essential" not in planner_prompt
             assert "Table of Contents" not in planner_prompt

--- a/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
@@ -23,6 +23,7 @@ import pytest
 from langchain_core.messages import AIMessage
 from langchain_core.messages import ToolMessage
 
+from aiq_agent.agents.deep_researcher.custom_middleware import PlanPersistenceMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import SourceRegistryMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import ToolNameSanitizationMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import ToolVisibilityMiddleware
@@ -463,3 +464,70 @@ class TestSourceRegistryMiddleware:
         result = await middleware.awrap_tool_call(request, handler)
 
         assert result.content == content
+
+
+class _RecordingBackend:
+    """Minimal backend stub capturing upload_files calls (overwrite-safe)."""
+
+    def __init__(self):
+        self.uploads: list[tuple[str, bytes]] = []
+
+    def upload_files(self, files):
+        self.uploads.extend(files)
+        return [SimpleNamespace(path=path, error=None) for path, _ in files]
+
+
+class TestPlanPersistenceMiddleware:
+    """Tests for PlanPersistenceMiddleware."""
+
+    @pytest.mark.asyncio
+    async def test_persists_structured_plan(self):
+        """A structured ResearchPlan in state is serialized and uploaded once."""
+        import json
+
+        backend = _RecordingBackend()
+        mw = PlanPersistenceMiddleware(backend=backend)
+        plan = SimpleNamespace(model_dump=lambda **_: {"answer_strategy": {"answer_type": "table"}})
+
+        result = await mw.aafter_agent({"structured_response": plan}, runtime=None)
+
+        assert result is None
+        assert len(backend.uploads) == 1
+        path, content = backend.uploads[0]
+        assert path == "/shared/plan.json"
+        assert json.loads(content.decode("utf-8")) == {"answer_strategy": {"answer_type": "table"}}
+
+    @pytest.mark.asyncio
+    async def test_no_structured_response_is_noop(self):
+        """Missing structured_response writes nothing rather than erroring."""
+        backend = _RecordingBackend()
+        mw = PlanPersistenceMiddleware(backend=backend)
+
+        await mw.aafter_agent({"structured_response": None}, runtime=None)
+        await mw.aafter_agent({}, runtime=None)
+
+        assert backend.uploads == []
+
+    def test_sync_after_agent_persists(self):
+        """The synchronous hook persists via the same path (dict payloads supported)."""
+        import json
+
+        backend = _RecordingBackend()
+        mw = PlanPersistenceMiddleware(backend=backend)
+
+        mw.after_agent({"structured_response": {"title": "Plan"}}, runtime=None)
+
+        assert len(backend.uploads) == 1
+        assert json.loads(backend.uploads[0][1].decode("utf-8")) == {"title": "Plan"}
+
+    @pytest.mark.asyncio
+    async def test_backend_failure_does_not_propagate(self):
+        """Upload errors are swallowed so the agent loop is never interrupted."""
+
+        class _BoomBackend:
+            def upload_files(self, files):
+                raise RuntimeError("boom")
+
+        mw = PlanPersistenceMiddleware(backend=_BoomBackend())
+
+        await mw.aafter_agent({"structured_response": {"title": "Plan"}}, runtime=None)

--- a/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
@@ -521,8 +521,8 @@ class TestPlanPersistenceMiddleware:
         assert json.loads(backend.uploads[0][1].decode("utf-8")) == {"title": "Plan"}
 
     @pytest.mark.asyncio
-    async def test_backend_failure_does_not_propagate(self):
-        """Upload errors are swallowed so the agent loop is never interrupted."""
+    async def test_backend_failure_propagates(self):
+        """Upload failures abort the planner task with the backend error."""
 
         class _BoomBackend:
             def upload_files(self, files):
@@ -530,4 +530,18 @@ class TestPlanPersistenceMiddleware:
 
         mw = PlanPersistenceMiddleware(backend=_BoomBackend())
 
-        await mw.aafter_agent({"structured_response": {"title": "Plan"}}, runtime=None)
+        with pytest.raises(RuntimeError, match="boom"):
+            await mw.aafter_agent({"structured_response": {"title": "Plan"}}, runtime=None)
+
+    @pytest.mark.asyncio
+    async def test_upload_error_response_propagates(self):
+        """Non-empty upload error responses abort the planner task."""
+
+        class _ErrorBackend:
+            def upload_files(self, files):
+                return [SimpleNamespace(path="/shared/plan.json", error="disk full")]
+
+        mw = PlanPersistenceMiddleware(backend=_ErrorBackend())
+
+        with pytest.raises(RuntimeError, match="disk full"):
+            await mw.aafter_agent({"structured_response": {"title": "Plan"}}, runtime=None)

--- a/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
@@ -15,16 +15,19 @@
 
 """Tests for custom middleware."""
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
 import pytest
 from langchain_core.messages import AIMessage
+from langchain_core.messages import SystemMessage
 from langchain_core.messages import ToolMessage
 
 from aiq_agent.agents.deep_researcher.custom_middleware import PlanPersistenceMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import SourceRegistryMiddleware
+from aiq_agent.agents.deep_researcher.custom_middleware import TodoSuppressionMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import ToolNameSanitizationMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import ToolVisibilityMiddleware
 from aiq_agent.agents.deep_researcher.tools.source_registry import build_get_verified_sources_tool
@@ -161,6 +164,83 @@ class TestToolVisibilityMiddleware:
         assert result == "ok"
         mock_request.override.assert_called_once_with(tools=[read_file_tool])
         mock_handler.assert_awaited_once_with(filtered_request)
+
+
+class TestTodoSuppressionMiddleware:
+    """Tests for stripping the framework's write_todos tool and its injected prompt."""
+
+    @staticmethod
+    def _request_with_todos():
+        todo_block = {"type": "text", "text": "\n\n## `write_todos`\nYou have access to the write_todos tool."}
+        base_block = {"type": "text", "text": "You are the planner."}
+        request = MagicMock()
+        request.tools = [SimpleNamespace(name="write_todos"), SimpleNamespace(name="think")]
+        request.system_message = SimpleNamespace(content_blocks=[base_block, todo_block])
+        request.override.return_value = "overridden"
+        return request
+
+    def test_strips_write_todos_tool_and_prompt_block(self):
+        request = self._request_with_todos()
+        handler = MagicMock(return_value="ok")
+
+        result = TodoSuppressionMiddleware().wrap_model_call(request, handler)
+
+        assert result == "ok"
+        kwargs = request.override.call_args.kwargs
+        assert [tool.name for tool in kwargs["tools"]] == ["think"]
+        new_system = kwargs["system_message"]
+        assert isinstance(new_system, SystemMessage)
+        assert "## `write_todos`" not in str(new_system.content)
+        assert "You are the planner." in str(new_system.content)
+        handler.assert_called_once_with("overridden")
+
+    @pytest.mark.asyncio
+    async def test_awrap_strips_write_todos(self):
+        request = self._request_with_todos()
+        handler = AsyncMock(return_value="ok")
+
+        result = await TodoSuppressionMiddleware().awrap_model_call(request, handler)
+
+        assert result == "ok"
+        assert [tool.name for tool in request.override.call_args.kwargs["tools"]] == ["think"]
+        handler.assert_awaited_once_with("overridden")
+
+    def test_noop_when_no_todos_present(self):
+        """Only tools are overridden (unchanged) when no write_todos tool or prompt exists."""
+        request = MagicMock()
+        request.tools = [SimpleNamespace(name="think")]
+        request.system_message = SimpleNamespace(content_blocks=[{"type": "text", "text": "You are the planner."}])
+        request.override.return_value = "overridden"
+
+        TodoSuppressionMiddleware().wrap_model_call(request, MagicMock(return_value="ok"))
+
+        kwargs = request.override.call_args.kwargs
+        assert [tool.name for tool in kwargs["tools"]] == ["think"]
+        assert "system_message" not in kwargs
+
+    def test_suppresses_real_langchain_todo_injection(self):
+        """Guard against drift: strip the ACTUAL langchain write_todos tool + prompt.
+
+        Builds the request the way TodoListMiddleware does - the real ``write_todos``
+        tool and the real ``WRITE_TODOS_SYSTEM_PROMPT`` block. If a langchain upgrade
+        renames the tool or changes the prompt header so our matcher misses it, this
+        test fails loudly instead of silently leaking todos back into the planner.
+        """
+        from langchain.agents.middleware import TodoListMiddleware
+        from langchain.agents.middleware.todo import WRITE_TODOS_SYSTEM_PROMPT
+
+        base_block = {"type": "text", "text": "You are the planner."}
+        todo_block = {"type": "text", "text": f"\n\n{WRITE_TODOS_SYSTEM_PROMPT}"}
+        request = MagicMock()
+        request.tools = [*TodoListMiddleware().tools, SimpleNamespace(name="think")]
+        request.system_message = SimpleNamespace(content_blocks=[base_block, todo_block])
+        request.override.return_value = "overridden"
+
+        TodoSuppressionMiddleware().wrap_model_call(request, MagicMock(return_value="ok"))
+
+        kwargs = request.override.call_args.kwargs
+        assert all(getattr(tool, "name", None) != "write_todos" for tool in kwargs["tools"])
+        assert "write_todos" not in str(kwargs["system_message"].content)
 
 
 class TestSourceRegistryMiddleware:
@@ -534,8 +614,8 @@ class TestPlanPersistenceMiddleware:
             await mw.aafter_agent({"structured_response": {"title": "Plan"}}, runtime=None)
 
     @pytest.mark.asyncio
-    async def test_upload_error_response_propagates(self):
-        """Non-empty upload error responses abort the planner task."""
+    async def test_upload_error_response_propagates(self, caplog):
+        """Non-empty upload errors abort the task; backend detail stays in logs only."""
 
         class _ErrorBackend:
             def upload_files(self, files):
@@ -543,5 +623,9 @@ class TestPlanPersistenceMiddleware:
 
         mw = PlanPersistenceMiddleware(backend=_ErrorBackend())
 
-        with pytest.raises(RuntimeError, match="disk full"):
-            await mw.aafter_agent({"structured_response": {"title": "Plan"}}, runtime=None)
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(RuntimeError, match="Failed to persist the research plan") as exc:
+                await mw.aafter_agent({"structured_response": {"title": "Plan"}}, runtime=None)
+
+        assert "disk full" not in str(exc.value)  # sanitized out of the raised error
+        assert "disk full" in caplog.text  # but preserved in logs


### PR DESCRIPTION
## Summary
Two sandbox-independent reliability fixes for the deep researcher agent, split out of the sandbox/artifact-runtime PR so they can be reviewed and merged on their own (PR-271 and other consumers hit these on shared `deep_researcher` code).

- **Writer-agent salvage.** When the orchestrator synthesizes the report inline instead of delegating to `writer-agent`, no `/shared/output.md` is written and the job fails with `writer-agent did not produce a final Markdown answer`, discarding a complete report. `_extract_final_markdown` now falls back to the final assistant message, gated to a substantive report (>=400 chars + a markdown heading, never the completion marker), so workflow chatter is still rejected. The orchestrator Return-Answer step is reworded to return the writer marker rather than synthesize the report itself.
- **Planner plan persistence.** The planner previously wrote `/shared/plan.json` itself via the LLM file tools, which thrashed (`write_file` refuses to overwrite, `edit_file` needs an exact match) whenever the file already existed. `PlanPersistenceMiddleware` now writes the planner's schema-validated `ResearchPlan` to `/shared/plan.json` deterministically via the overwrite-safe `backend.upload_files`; the planner does no file I/O. `planner.j2`/`orchestrator.j2` updated to match.

## Scope
7 files, no sandbox coupling: `agent.py`, `custom_middleware.py`, `factory.py`, `prompts/orchestrator.j2`, `prompts/planner.j2`, and tests (`test_agent.py`, `test_custom_middleware.py`).

## Test plan
- [x] `ruff check` on changed files
- [x] `interrogate` docstring coverage passes (>=80%)
- [x] `pytest tests/aiq_agent/agents/deep_researcher/test_agent.py test_custom_middleware.py test_factory.py` (79 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deep research now persistently saves planner output automatically to a shared plan file.
  * Added optional “source routing” flow to insert a source-routing step before planning.
  * Final reports can be recovered from inline completion messages when the main report file isn’t available.

* **Bug Fixes**
  * Reduced cases where substantive reports were missed at the end of a run.
  * Improved progress tracking and final-turn behavior to enforce correct todo/status handling.

* **Chores**
  * Updated deep-research LLM configuration to remove `gpt_oss_llm` and consistently use `nemotron_super_llm`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->