### PR TITLE
chore: transfer rewritten signed PR 293 commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
       - id: end-of-file-fixer
         exclude: ^skills/[^/]+/skill\.oms\.sig$
       - id: trailing-whitespace
+        exclude: ^skills/[^/]+/skill-card\.md$
 
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0

--- a/skills/aiq-research/scripts/aiq.py
+++ b/skills/aiq-research/scripts/aiq.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Temporary draft used only to transfer the rewritten GPG-signed commit object to the upstream repository. It will be closed immediately after force-updating PR 293's direct-origin branch.