### PR TITLE
skills-eval: upload results as a scrubbed tarball (strip agent/ secrets)

### DIFF
--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -269,14 +269,30 @@ jobs:
           python3 .github/skill-eval/skills_eval_agent.py $SCOPE --run-harbor \
             --output-dir /tmp/aiq-skill-eval/datasets
 
+      - name: Package Harbor results (scrub agent tree)
+        if: always()
+        run: |
+          # Tar this job's results into a single .tar.gz, excluding the per-trial
+          # agent/ subtree. Those agent/ dirs hold live trajectories that can carry
+          # session credentials/tokens/API keys; shipping them raw leaked an NGC
+          # key in VSS (PR #516). Mirror VSS's `--exclude='agent'` so no secrets
+          # leave CI, and match the RAG/VSS single-tarball artifact convention.
+          RESULTS=/tmp/aiq-skill-eval/results/${{ github.run_id }}-${{ github.run_attempt }}
+          if [ -d "$RESULTS" ]; then
+            tar --exclude='agent' -czf /tmp/aiq-skill-eval/results.tar.gz -C "$RESULTS" .
+          else
+            echo "no results dir for this run — nothing to archive (expected if blocked before a trial)"
+          fi
+
       - name: Upload Harbor results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: aiq-skill-eval-results-${{ github.run_id }}
-          # Only this job's results (skills_eval_agent.py isolates output under
-          # <results>/<run_id>-<attempt>/), not the shared root's accumulated history.
-          path: /tmp/aiq-skill-eval/results/${{ github.run_id }}-${{ github.run_attempt }}
+          # Single scrubbed tarball (agent/ trajectories stripped by the packaging
+          # step above); isolates this job's run (skills_eval_agent.py writes under
+          # <results>/<run_id>-<attempt>/), matching the RAG/VSS one-.tar.gz convention.
+          path: /tmp/aiq-skill-eval/results.tar.gz
           if-no-files-found: ignore
           retention-days: 7
 


### PR DESCRIPTION
## Problem

`.github/workflows/skills-eval.yml` uploads Harbor eval results as a **raw directory**:

```yaml
path: /tmp/aiq-skill-eval/results/${{ github.run_id }}-${{ github.run_attempt }}
```

Two issues:

1. **Secret leak.** The raw dir ships the per-trial `agent/` subtree intact, which can contain session credentials, tokens, and API keys. VSS deliberately strips it at CI time with `tar --exclude='agent'` after a real NGC key leak (VSS PR #516). AIQ leaks the same way today.
2. **Inconsistent artifact shape.** VSS and RAG upload a single scrubbed `.tar.gz`; AIQ's raw dir forces the downstream skills-dashboard to re-tar it to persist evidence.

## Fix

Add a `Package Harbor results (scrub agent tree)` step before the upload that tars the run's results dir with `--exclude='agent'` into `/tmp/aiq-skill-eval/results.tar.gz`, and point `upload-artifact` at that tarball. Same artifact `name:`, `if-no-files-found: ignore`, and `retention-days: 7` are preserved. Mirrors VSS's `--exclude='agent'` convention (PR #516) so no secrets leave CI, and matches the RAG/VSS single-tarball artifact pattern.

## Independence

This is **independent of and stackable with** #299 (nightly schedule). It touches only the results-upload steps and is separately reviewable.
