### PR TITLE
fix(deep-research): source-routing guard recognizes sandbox 

### DIFF
--- a/src/aiq_agent/agents/deep_researcher/custom_middleware.py
+++ b/src/aiq_agent/agents/deep_researcher/custom_middleware.py
@@ -38,6 +38,11 @@ logger = logging.getLogger(__name__)
 # Path to this agent's prompts directory
 _PROMPTS_DIR = Path(__file__).parent / "prompts"
 _SOURCE_ROUTING_PATH = "/shared/source_routing.json"
+# When a sandbox provider is configured, CompositeBackend strips the /shared/ route
+# before delegating to StateBackend, so the router's file is stored under the
+# route-local key. The guard reads raw state, so it must accept both forms or it
+# blocks the orchestrator forever on sandboxed runs.
+_SOURCE_ROUTING_STATE_KEYS = (_SOURCE_ROUTING_PATH, "/source_routing.json")
 
 
 class SourceRoutingGuardMiddleware(AgentMiddleware):
@@ -50,7 +55,7 @@ class SourceRoutingGuardMiddleware(AgentMiddleware):
     @staticmethod
     def _routing_complete(state: object) -> bool:
         files = state.get("files", {}) if isinstance(state, dict) else getattr(state, "files", {})
-        return isinstance(files, dict) and _SOURCE_ROUTING_PATH in files
+        return isinstance(files, dict) and any(key in files for key in _SOURCE_ROUTING_STATE_KEYS)
 
     async def awrap_tool_call(self, request, handler):
         """Block out-of-order calls until the source router writes its route file."""

--- a/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
@@ -90,6 +90,19 @@ class TestSourceRoutingGuardMiddleware:
         assert result is expected
 
     @pytest.mark.asyncio
+    async def test_allows_normal_tools_after_routing_file_exists_sandbox_key(self):
+        """Under a sandbox provider the /shared/ route is stripped; the route-local key must also open the gate."""
+        middleware = SourceRoutingGuardMiddleware(enabled=True)
+        expected = ToolMessage(content="[]", tool_call_id="tc1")
+        handler = AsyncMock(return_value=expected)
+        request = self._request("ls", files={"/source_routing.json": {"content": "{}"}})
+
+        result = await middleware.awrap_tool_call(request, handler)
+
+        handler.assert_awaited_once_with(request)
+        assert result is expected
+
+    @pytest.mark.asyncio
     async def test_disabled_guard_is_noop(self):
         """Workflows with source routing disabled preserve their existing tool behavior."""
         middleware = SourceRoutingGuardMiddleware(enabled=False)


### PR DESCRIPTION
#### Overview

Sandboxed deep-research runs could get stuck: the orchestrator was rejected on every tool call with "Source routing is required before any other tool call," so it never made progress.

Root cause seems to be a key-name mismatch:
- The source-routing guard decides it's safe to proceed by checking `state["files"]`
  for `/shared/source_routing.json`.
- But when a sandbox provider is enabled, `CompositeBackend` drops the `/shared/`
  prefix before storing the file, so it actually lands under `/source_routing.json`.
- The guard never found its expected key, so it kept blocking. (Non-sandbox runs
  keep the `/shared/` prefix, so they were fine — this only hit sandbox runs.)

Fix: the guard now accepts **both** key forms (`/shared/source_routing.json` and the
sandbox `/source_routing.json`). Small, no behavior change for non-sandbox runs.


#### Validation

- `pytest test_custom_middleware.py test_factory.py` → **52 passed**, including a new
  test that seeds the sandbox key `/source_routing.json` and confirms the guard opens.
- `ruff check` on changed files → clean.

- [x] I ran the relevant local checks or explained why they are not applicable.
- [x] I added or updated tests for behavior changes.
- [ ] I updated documentation for user-facing or contributor-facing changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.

#### Where should reviewers start?

'custom_middleware.py` → `SourceRoutingGuardMiddleware._routing_complete`. Context for
why the key gets stripped is in `deepagents_runtime.py::_normalize_state_files`.


#### Related Issues

<!-- Use Closes / Fixes / Resolves / Relates to when applicable. -->

- Relates to #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source-routing detection so the app recognizes routing completion from either the shared or sandbox-local routing file.
  * Normal tool actions now proceed correctly in sandbox environments once routing data is present.
* **Tests**
  * Added coverage for sandbox-based routing to confirm the expected behavior and response flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->