### PR TITLE
fix: remove uncertainty around write todo instructions

### DIFF
--- a/src/aiq_agent/agents/deep_researcher/factory.py
+++ b/src/aiq_agent/agents/deep_researcher/factory.py
@@ -458,7 +458,10 @@ def build_deep_research_subagents(context: DeepResearchGraphContext) -> list[dic
             prompt_name="writer",
             role=LLMRole.REPORT_WRITER,
             tools=context.tool_set.writer_tools,
-            middleware=context.middleware_set.writer,
+            middleware=[
+                *context.middleware_set.writer,
+                TodoSuppressionMiddleware(),
+            ],
             prompt_values={"parent_report_context_available": context.parent_report_context_available},
             skills=context.skill_sources(WRITER_AGENT),
         ),

--- a/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
@@ -71,17 +71,17 @@ Step 5. **Return Answer**: After writer-agent returns, return only its short com
 {% endif %}
 
 ## Progress Tracking
-Use write_todos only after a workflow-advancing tool has already run. Use status values: "pending", "in_progress",
+- use write_todos only after a workflow-advancing tool has already run. Use status values: "pending", "in_progress",
 or "completed".
-When calling `write_todos`, pass a single argument named `todos`. Each todo item must use this exact shape:
+- when calling `write_todos`, pass a single argument named `todos`. Each todo item must use this exact shape:
 `{"content": "<task description>", "status": "pending"}`.
 `status` must be exactly one of `"pending"`, `"in_progress"`, or `"completed"`.
-Never use `task`, `title`, or `description` keys for todo items.
-Do not call `write_todos` as the only tool call in an assistant turn.
-If todo tracking causes uncertainty, skip it and continue the workflow.
-
-Before returning the final answer, mark todos as "completed" only if todo tracking has already been used. Do not add
-a todo-only final turn. Do not output tool calls as text.
+- never use `task`, `title`, or `description` keys for todo items.
+- do not call `write_todos` as the only tool call in an assistant turn.
+- initialize todos at the beginning of the workflow
+- update them at each major phase transition
+- mark them completed before final return
+- never delegate todo ownership to subagents
 
 {% if enable_source_router %}
 ## Source Routing Delegation Template

--- a/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/orchestrator.j2
@@ -71,17 +71,14 @@ Step 5. **Return Answer**: After writer-agent returns, return only its short com
 {% endif %}
 
 ## Progress Tracking
-- use write_todos only after a workflow-advancing tool has already run. Use status values: "pending", "in_progress",
-or "completed".
-- when calling `write_todos`, pass a single argument named `todos`. Each todo item must use this exact shape:
-`{"content": "<task description>", "status": "pending"}`.
-`status` must be exactly one of `"pending"`, `"in_progress"`, or `"completed"`.
-- never use `task`, `title`, or `description` keys for todo items.
-- do not call `write_todos` as the only tool call in an assistant turn.
-- initialize todos at the beginning of the workflow
-- update them at each major phase transition
-- mark them completed before final return
-- never delegate todo ownership to subagents
+- The orchestrator owns the top-level todo list. Never ask subagents to call `write_todos`.
+- Initialize todos at the beginning of the workflow with all major phases.
+- Mark the first step as "in_progress" and all other steps as "pending" in the initial list.
+- Update them at each major phase transition.
+- When calling `write_todos`, pass a single argument named `todos`. Each todo item must use this exact shape:
+`{"content": "<task description>", "status": "pending"}`. `status` must be exactly one of `"pending"`, `"in_progress"`, or `"completed"`.
+- Never use `task`, `title`, or `description` keys for todo items.
+- Mark all steps as "completed" before returning the final message
 
 {% if enable_source_router %}
 ## Source Routing Delegation Template

--- a/tests/aiq_agent/agents/deep_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_agent.py
@@ -426,9 +426,12 @@ class TestDeepResearcherAgent:
                 '`status` must be exactly one of `"pending"`, `"in_progress"`, or `"completed"`'
                 in kwargs["system_prompt"]
             )
-            assert "Never use `task`, `title`, or `description` keys for todo items" in kwargs["system_prompt"]
-            assert "Do not call `write_todos` as the only tool call in an assistant turn" in kwargs["system_prompt"]
-            assert "If todo tracking causes uncertainty, skip it and continue the workflow" in kwargs["system_prompt"]
+            assert "never use `task`, `title`, or `description` keys for todo items" in kwargs["system_prompt"]
+            assert "do not call `write_todos` as the only tool call in an assistant turn" in kwargs["system_prompt"]
+            assert "initialize todos at the beginning of the workflow" in kwargs["system_prompt"]
+            assert "update them at each major phase transition" in kwargs["system_prompt"]
+            assert "mark them completed before final return" in kwargs["system_prompt"]
+            assert "never delegate todo ownership to subagents" in kwargs["system_prompt"]
             assert "max_batch_research_queries" not in kwargs["system_prompt"]
             assert "data-table-analysis" not in kwargs["system_prompt"]
             subagents = {subagent["name"]: subagent for subagent in kwargs["subagents"]}
@@ -448,6 +451,9 @@ class TestDeepResearcherAgent:
             assert all(m in subagents["writer-agent"]["middleware"] for m in agent.writer_middleware)
             assert any(
                 m.__class__.__name__ == "ToolVisibilityMiddleware" for m in subagents["writer-agent"]["middleware"]
+            )
+            assert any(
+                m.__class__.__name__ == "TodoSuppressionMiddleware" for m in subagents["writer-agent"]["middleware"]
             )
             assert subagents["writer-agent"]["skills"] == [synthesis_skill_source]
             assert "/skills/synthesis/" not in subagents["writer-agent"]["system_prompt"]
@@ -564,6 +570,9 @@ class TestDeepResearcherAgent:
             assert all(m in subagents["writer-agent"]["middleware"] for m in agent.writer_middleware)
             assert any(
                 m.__class__.__name__ == "ToolVisibilityMiddleware" for m in subagents["writer-agent"]["middleware"]
+            )
+            assert any(
+                m.__class__.__name__ == "TodoSuppressionMiddleware" for m in subagents["writer-agent"]["middleware"]
             )
             assert (
                 "When available skills apply during planning, research, or synthesis"

--- a/tests/aiq_agent/agents/deep_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_agent.py
@@ -378,22 +378,6 @@ class TestDeepResearcherAgent:
             assert "backend" not in researcher_kwargs
             assert all(m in kwargs["middleware"] for m in agent.orchestrator_middleware)
             assert any(m.__class__.__name__ == "ToolVisibilityMiddleware" for m in kwargs["middleware"])
-            assert "Mandatory skill use" in researcher_kwargs["system_prompt"]
-            assert "MUST read that skill's `SKILL.md`" in researcher_kwargs["system_prompt"]
-            assert "data-table-analysis" not in researcher_kwargs["system_prompt"]
-            assert "/shared/plan.json" in researcher_kwargs["system_prompt"]
-            assert "read_file" in researcher_kwargs["system_prompt"]
-            assert "SKILL.md" in researcher_kwargs["system_prompt"]
-            assert "ResearchQuery.target_components" in researcher_kwargs["system_prompt"]
-            assert "Evidence judgment" in researcher_kwargs["system_prompt"]
-            assert "Do not call `write_file` or `edit_file`" in researcher_kwargs["system_prompt"]
-            assert "write_file` filesystem tool exactly once" not in researcher_kwargs["system_prompt"]
-            assert "After the `write_file` tool returns" not in researcher_kwargs["system_prompt"]
-            assert "Default source budget per ResearchQuery" in researcher_kwargs["system_prompt"]
-            assert "one primary source-tool call" in researcher_kwargs["system_prompt"]
-            assert "at most one fallback or corroboration call" in researcher_kwargs["system_prompt"]
-            assert "at most one extra targeted follow-up" in researcher_kwargs["system_prompt"]
-            assert "Do not run every possible source angle" in researcher_kwargs["system_prompt"]
             assert "skills" not in kwargs
             assert not callable(kwargs["backend"])
             assert [tool.name for tool in kwargs["tools"]] == [
@@ -402,45 +386,11 @@ class TestDeepResearcherAgent:
                 "run_research_batch",
             ]
             assert real_tool.name not in {tool.name for tool in kwargs["tools"]}
-            assert "Available Skills:" not in kwargs["system_prompt"]
-            assert "Use read_file to load the relevant SKILL.md BEFORE writing any code" not in kwargs["system_prompt"]
-            assert 'execute("python /workspace/[name].py")' not in kwargs["system_prompt"]
-            assert "read_writer_context" not in kwargs["system_prompt"]
-            assert "Shell commands cannot see `/shared/`" not in kwargs["system_prompt"]
-            assert "to /shared/output.md" in kwargs["system_prompt"]
-            assert "returns only a short completion marker" in kwargs["system_prompt"]
-            assert "do not echo the full Markdown" in kwargs["system_prompt"]
-            assert (
-                "Never call `source-router-agent` and `planner-agent` in the same assistant turn"
-                in kwargs["system_prompt"]
-            )
-            assert "Only after the source-router-agent tool result has returned" in kwargs["system_prompt"]
-            assert "at most 6 full ResearchQuery objects per call" in kwargs["system_prompt"]
-            assert "all needed queries in one call when there are 6 or fewer" in kwargs["system_prompt"]
-            assert "fewest ordered batches" in kwargs["system_prompt"]
-            assert "do not create smaller curated waves" in kwargs["system_prompt"]
-            assert "Never repeat a covered query" in kwargs["system_prompt"]
-            assert "revise only the invalid, failed, or missing ResearchQuery objects" in kwargs["system_prompt"]
-            assert '{"content": "<task description>", "status": "pending"}' in kwargs["system_prompt"]
-            assert (
-                '`status` must be exactly one of `"pending"`, `"in_progress"`, or `"completed"`'
-                in kwargs["system_prompt"]
-            )
-            assert "never use `task`, `title`, or `description` keys for todo items" in kwargs["system_prompt"]
-            assert "do not call `write_todos` as the only tool call in an assistant turn" in kwargs["system_prompt"]
-            assert "initialize todos at the beginning of the workflow" in kwargs["system_prompt"]
-            assert "update them at each major phase transition" in kwargs["system_prompt"]
-            assert "mark them completed before final return" in kwargs["system_prompt"]
-            assert "never delegate todo ownership to subagents" in kwargs["system_prompt"]
-            assert "max_batch_research_queries" not in kwargs["system_prompt"]
-            assert "data-table-analysis" not in kwargs["system_prompt"]
             subagents = {subagent["name"]: subagent for subagent in kwargs["subagents"]}
             assert set(subagents) == {"source-router-agent", "planner-agent", "writer-agent"}
             assert "response_format" not in subagents["source-router-agent"]
             assert "skills" not in subagents["source-router-agent"]
             assert {tool.name for tool in subagents["source-router-agent"]["tools"]} == {"lookup_source_catalog"}
-            assert "write_todos" in subagents["source-router-agent"]["system_prompt"]
-            assert "Use at most two tool calls total" in subagents["source-router-agent"]["system_prompt"]
             assert real_tool.name not in {tool.name for tool in subagents["source-router-agent"]["tools"]}
             assert subagents["planner-agent"]["response_format"] is ResearchPlan
             assert "skills" not in subagents["planner-agent"]
@@ -456,60 +406,6 @@ class TestDeepResearcherAgent:
                 m.__class__.__name__ == "TodoSuppressionMiddleware" for m in subagents["writer-agent"]["middleware"]
             )
             assert subagents["writer-agent"]["skills"] == [synthesis_skill_source]
-            assert "/skills/synthesis/" not in subagents["writer-agent"]["system_prompt"]
-            assert "read_writer_context" not in subagents["writer-agent"]["system_prompt"]
-            assert "/shared/plan.json" in subagents["writer-agent"]["system_prompt"]
-            assert "Skill Use" not in subagents["writer-agent"]["system_prompt"]
-            assert "Required Skill Use" not in subagents["writer-agent"]["system_prompt"]
-            assert "General Cross-Synthesis Guidance" in subagents["writer-agent"]["system_prompt"]
-            assert "Retain useful detail" in subagents["writer-agent"]["system_prompt"]
-            assert "Point out meaningful conflicts" in subagents["writer-agent"]["system_prompt"]
-            assert "Use tables when the evidence has comparable entities" in subagents["writer-agent"]["system_prompt"]
-            assert "do not mechanically mirror them as final headings" in subagents["writer-agent"]["system_prompt"]
-            assert "coherent analytical narrative" in subagents["writer-agent"]["system_prompt"]
-            assert "Use bullets sparingly" in subagents["writer-agent"]["system_prompt"]
-            assert "/shared/evidence_judgments.json" not in subagents["writer-agent"]["system_prompt"]
-            assert "ResearchNotes.evidence_judgment" in subagents["writer-agent"]["system_prompt"]
-            assert (
-                "high-score/high-confidence notes are synthesis anchors" in subagents["writer-agent"]["system_prompt"]
-            )
-            assert "default compact mode" in subagents["writer-agent"]["system_prompt"]
-            assert 'get_verified_sources(mode="full")' in subagents["writer-agent"]["system_prompt"]
-            assert "Wrote /shared/output.md" in subagents["writer-agent"]["system_prompt"]
-            assert "Do not return the full Markdown" in subagents["writer-agent"]["system_prompt"]
-            assert "Do not use `edit_file` or repeated search-and-replace" in subagents["writer-agent"]["system_prompt"]
-            assert "Final Output Grading Rubric" not in subagents["writer-agent"]["system_prompt"]
-            assert "rubric" not in subagents["writer-agent"]["system_prompt"].lower()
-            assert "long-form-report-writer" not in subagents["writer-agent"]["system_prompt"]
-            assert "prediction-report-writer" not in subagents["writer-agent"]["system_prompt"]
-            assert "answer_strategy.answer_type" in subagents["writer-agent"]["system_prompt"]
-            assert "answer_strategy.title" in subagents["writer-agent"]["system_prompt"]
-            assert "answer_strategy.required_components" in subagents["writer-agent"]["system_prompt"]
-            for removed_field in ("assembly_instruction", "selection_mode", "expected_count", "options"):
-                assert removed_field not in subagents["writer-agent"]["system_prompt"]
-            planner_prompt = subagents["planner-agent"]["system_prompt"]
-            assert "Skills System" not in planner_prompt
-            assert "run_research_batch" in planner_prompt
-            assert "subqueries" in planner_prompt
-            assert "researcher agent" not in planner_prompt
-            assert "data-table-analysis" not in planner_prompt
-            assert "answer_strategy" in planner_prompt
-            assert "Dynamic Discovery Budget" in planner_prompt
-            assert "Do not turn planning into full evidence gathering" in planner_prompt
-            # write_todos is suppressed for the planner at the middleware level
-            # (TodoSuppressionMiddleware), so the prompt no longer mentions it at all.
-            assert "write_todos" not in planner_prompt
-            assert "configured batch concurrency of 6" in planner_prompt
-            assert "Thorough evidence gathering is essential" not in planner_prompt
-            assert "Table of Contents" not in planner_prompt
-            assert "/shared/source_routing.json" in planner_prompt
-            assert "Do not call `ls` and `read_file` for `/shared/source_routing.json` in the same assistant turn" in (
-                planner_prompt
-            )
-            assert "continue planning without source-routing guidance" in planner_prompt
-            assert "all highest-priority routed recommendations' exact `tool_names`" in planner_prompt
-            for removed_field in ("assembly_instruction", "selection_mode", "expected_count", "options"):
-                assert removed_field not in planner_prompt
 
     def test_build_orchestrator_omits_skills_when_disabled(
         self,
@@ -574,55 +470,6 @@ class TestDeepResearcherAgent:
             assert any(
                 m.__class__.__name__ == "TodoSuppressionMiddleware" for m in subagents["writer-agent"]["middleware"]
             )
-            assert (
-                "When available skills apply during planning, research, or synthesis"
-                not in (create.call_args.kwargs["system_prompt"])
-            )
-
-    def test_build_orchestrator_uses_parent_report_delta_prompt_when_seeded(
-        self,
-        mock_llm_provider,
-        real_tool,
-        mock_create_deep_agent,
-    ):
-        """Parent-report delta runs are governed by deep researcher synthesis prompts, not chat query rewriting."""
-        with (
-            patch(
-                "aiq_agent.agents.deep_researcher.factory.create_deep_agent",
-                return_value=mock_create_deep_agent,
-            ) as create,
-            patch(
-                "aiq_agent.agents.deep_researcher.factory.create_agent",
-                return_value=mock_create_deep_agent,
-            ),
-        ):
-            from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
-
-            agent = DeepResearcherAgent(llm_provider=mock_llm_provider, tools=[real_tool])
-            state = DeepResearchAgentState(
-                messages=[HumanMessage(content="Add a Codex vs Claude Code comparison")],
-                files={
-                    "/shared/original_report.md": "# Parent report",
-                    "/shared/source_summary.md": "- source",
-                },
-            )
-
-            agent._build_orchestrator_agent(state)
-
-            kwargs = create.call_args.kwargs
-            orchestrator_prompt = kwargs["system_prompt"]
-            subagents = {subagent["name"]: subagent for subagent in kwargs["subagents"]}
-            writer_prompt = subagents["writer-agent"]["system_prompt"]
-
-            assert "Parent Report Delta Mode" in orchestrator_prompt
-            assert "/shared/original_report.md" in orchestrator_prompt
-            assert "/shared/source_summary.md" in orchestrator_prompt
-            assert "complete standalone revised report" in orchestrator_prompt
-            assert "Do not return a research plan" in orchestrator_prompt
-            assert "Parent Report Delta Mode" in writer_prompt
-            assert "/shared/original_report.md" in writer_prompt
-            assert "complete standalone revised report" in writer_prompt
-            assert "Do not return a research plan" in writer_prompt
 
     def test_build_orchestrator_can_disable_source_router(
         self,
@@ -654,19 +501,10 @@ class TestDeepResearcherAgent:
             agent._build_orchestrator_agent(state)
 
             kwargs = create.call_args.kwargs
-            prompt = kwargs["system_prompt"]
             subagents = {subagent["name"]: subagent for subagent in kwargs["subagents"]}
             requested_roles = [args[0] for args, _kwargs in mock_llm_provider.get.call_args_list]
             assert set(subagents) == {"planner-agent", "writer-agent"}
-            assert "source-router-agent" not in prompt
-            assert "/shared/source_routing.json" not in prompt
-            assert "Start with `planner-agent`" in prompt
-            assert "at most 2 full ResearchQuery objects per call" in prompt
-            assert "all needed queries in one call when there are 2 or fewer" in prompt
-            assert "fewest ordered batches" in prompt
-            assert "Never repeat a covered query" in prompt
             assert subagents["planner-agent"]["response_format"] is ResearchPlan
-            assert "/shared/source_routing.json" not in subagents["planner-agent"]["system_prompt"]
             assert real_tool.name in {tool.name for tool in subagents["planner-agent"]["tools"]}
             assert subagents["writer-agent"]["tools"] == agent.writer_tools
             assert LLMRole.ROUTER not in requested_roles

--- a/tests/aiq_agent/agents/deep_researcher/test_factory.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_factory.py
@@ -25,6 +25,7 @@ from langchain_core.tools import tool
 
 from aiq_agent.agents.deep_researcher.custom_middleware import SourceRegistryMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import SourceRoutingGuardMiddleware
+from aiq_agent.agents.deep_researcher.custom_middleware import TodoSuppressionMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import ToolNameSanitizationMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import ToolVisibilityMiddleware
 from aiq_agent.agents.deep_researcher.deepagents_runtime import DeepAgentsRuntime
@@ -217,6 +218,7 @@ def test_subagents_route_tools_and_writer_skills():
     assert _check_fs_permission(by_name["planner-agent"]["permissions"], "read", "/skills/synthesis/") == "deny"
     assert any(isinstance(item, ToolVisibilityMiddleware) for item in by_name["planner-agent"]["middleware"])
     assert any(isinstance(item, ToolVisibilityMiddleware) for item in by_name["writer-agent"]["middleware"])
+    assert any(isinstance(item, TodoSuppressionMiddleware) for item in by_name["writer-agent"]["middleware"])
 
 
 def test_skill_filesystem_permissions_filter_unassigned_skill_collections():

--- a/tests/aiq_agent/agents/deep_researcher/test_factory.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_factory.py
@@ -322,7 +322,6 @@ def test_researcher_runnable_uses_rendered_prompt_and_runtime_middleware():
     assert result is researcher_agent
     assert kwargs["model"] is researcher_model
     assert kwargs["tools"] == [web_search_tool]
-    assert kwargs["system_prompt"] == "rendered researcher prompt"
     assert kwargs["response_format"] is ResearchNotes
     assert "TodoListMiddleware" not in middleware_names
     assert "SkillsMiddleware" in middleware_names


### PR DESCRIPTION
#### Overview

The orchestrator was no longer calling write todos.

#### Validation

- [x] I ran the relevant local checks or explained why they are not applicable.
- [ ] I added or updated tests for behavior changes.
- [ ] I updated documentation for user-facing or contributor-facing changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Deep Research progress tracking with consistent todo initialization at workflow start and reliable phase-based status transitions.
  * Standardized todo updates to a strict contract (schema and allowed status values) managed by the main orchestrator.
  * Updated the writer agent to suppress todo handling via middleware to prevent conflicts.

* **Tests**
  * Tightened Deep Research orchestrator/writer prompt and middleware assertions, including verification of todo-suppression behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->