### PR TITLE
fix: surface batched researcher activity

### DIFF
--- a/frontends/ui/src/features/layout/components/AgentsTab.spec.tsx
+++ b/frontends/ui/src/features/layout/components/AgentsTab.spec.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { render, screen } from '@/test-utils'
+import { render, screen, within } from '@/test-utils'
 import { vi, describe, test, expect, beforeEach } from 'vitest'
 import { AgentsTab } from './AgentsTab'
 import { useChatStore } from '@/features/chat'
@@ -62,7 +62,9 @@ describe('AgentsTab', () => {
       render(<AgentsTab />)
 
       expect(
-        screen.getByText('Active planner, researcher, and writer agents executing tasks.')
+        screen.getByText(
+          'Active source router, planner, researcher, and writer agents executing tasks.'
+        )
       ).toBeInTheDocument()
     })
   })
@@ -119,6 +121,28 @@ describe('AgentsTab', () => {
 
       expect(screen.getByText('researcher-agent')).toBeInTheDocument()
       expect(screen.getAllByTestId('tool-call')).toHaveLength(2)
+    })
+
+    test('keeps concurrent researcher tool calls on their owning cards', () => {
+      useChatStore.setState({
+        deepResearchAgents: [
+          createStoreAgent({ id: 'researcher-1', name: 'researcher-agent' }),
+          createStoreAgent({ id: 'researcher-2', name: 'researcher-agent' }),
+        ],
+        deepResearchToolCalls: [
+          createToolCall({ id: 'tool-1', name: 'web_search', agentId: 'researcher-1' }),
+          createToolCall({ id: 'tool-2', name: 'tavily_search', agentId: 'researcher-2' }),
+        ],
+      })
+
+      render(<AgentsTab />)
+
+      const cards = screen.getAllByTestId('agent-card')
+      expect(cards).toHaveLength(2)
+      expect(within(cards[0]).getByText('web_search')).toBeInTheDocument()
+      expect(within(cards[0]).queryByText('tavily_search')).not.toBeInTheDocument()
+      expect(within(cards[1]).getByText('tavily_search')).toBeInTheDocument()
+      expect(within(cards[1]).queryByText('web_search')).not.toBeInTheDocument()
     })
 
     test('ignores orphaned tool calls without agentId', () => {

--- a/frontends/ui/src/features/layout/components/AgentsTab.tsx
+++ b/frontends/ui/src/features/layout/components/AgentsTab.tsx
@@ -70,7 +70,7 @@ export const AgentsTab: FC = () => {
           )}
         </Flex>
         <Text kind="body/regular/xs" className="text-subtle">
-          Active planner, researcher, and writer agents executing tasks.
+          Active source router, planner, researcher, and writer agents executing tasks.
         </Text>
       </Flex>
 

--- a/src/aiq_agent/agents/deep_researcher/tools/research.py
+++ b/src/aiq_agent/agents/deep_researcher/tools/research.py
@@ -36,6 +36,7 @@ from ..models import ResearchQuery
 _NO_TOOL_RUNTIME = cast(ToolRuntime, None)
 logger = logging.getLogger(__name__)
 _NOTE_SLUG_MAX_LENGTH = 64
+RESEARCHER_AGENT_NAME = "researcher-agent"
 
 
 def format_research_request(query: ResearchQuery) -> str:
@@ -61,6 +62,17 @@ def researcher_invoke_state(query: ResearchQuery, runtime: ToolRuntime | None) -
     return invoke_state
 
 
+def researcher_invoke_config(runtime: ToolRuntime | None, callbacks: list[Any]) -> dict[str, Any]:
+    """Build child-run config while preserving the active callback lineage."""
+    config = dict(runtime.config) if runtime is not None else {}
+    config.pop("run_id", None)
+    config.pop("configurable", None)
+    config["run_name"] = RESEARCHER_AGENT_NAME
+    if not config.get("callbacks") and callbacks:
+        config["callbacks"] = callbacks
+    return config
+
+
 async def _run_research_query(
     *,
     query: ResearchQuery,
@@ -74,7 +86,7 @@ async def _run_research_query(
         try:
             result = await researcher_runnable.ainvoke(
                 researcher_invoke_state(query, runtime),
-                config={"callbacks": callbacks} if callbacks else None,
+                config=researcher_invoke_config(runtime, callbacks),
             )
         except Exception as exc:  # noqa: BLE001 - captured as per-item failure
             raise RuntimeError(f"researcher worker failed for query {query.query!r}: {exc}") from exc

--- a/tests/aiq_agent/agents/deep_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_agent.py
@@ -17,9 +17,11 @@
 
 import asyncio
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
 from deepagents.backends.protocol import FileUploadResponse
@@ -27,17 +29,20 @@ from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import AIMessage
 from langchain_core.messages import HumanMessage
 from langchain_core.messages import ToolMessage
+from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import tool
 
 from aiq_agent.agents.deep_researcher.models import DeepResearchAgentState
 from aiq_agent.agents.deep_researcher.models import ResearchNotes
 from aiq_agent.agents.deep_researcher.models import ResearchPlan
 from aiq_agent.agents.deep_researcher.models import ResearchQuery
+from aiq_agent.agents.deep_researcher.tools import research as research_module
 from aiq_agent.agents.deep_researcher.tools.research import build_research_batch_tool
 from aiq_agent.agents.deep_researcher.tools.research import researcher_invoke_state
 from aiq_agent.common import LLMProvider
 from aiq_agent.common import LLMRole
 from aiq_agent.common.citation_verification import SourceEntry
+from aiq_api.jobs.callbacks import AgentEventCallback
 
 
 @tool
@@ -598,7 +603,7 @@ class TestDeepResearcherAgent:
         )
         assert '"subqueries": [' in call_state["messages"][0].content
         assert "Execution order" not in call_state["messages"][0].content
-        assert call_config == {"callbacks": agent.callbacks}
+        assert call_config == {"callbacks": agent.callbacks, "run_name": "researcher-agent"}
         fake_backend.upload_files.assert_called_once()
         persisted_files = fake_backend.upload_files.call_args.args[0]
         assert len(persisted_files) == 1
@@ -612,6 +617,83 @@ class TestDeepResearcherAgent:
         assert compact_sources is not None
         assert "https://example.test/opencl" in compact_sources
         assert "https://example.test/unused" not in compact_sources
+
+    def test_researcher_invoke_config_preserves_runtime_callbacks_and_starts_a_child_run(self):
+        """Nested researchers preserve callback lineage without reusing the parent run ID."""
+        runtime_callbacks = MagicMock(name="runtime_callbacks")
+        fallback_callbacks = [MagicMock(name="fallback_callback")]
+        parent_run_id = uuid4()
+        runtime = SimpleNamespace(
+            config={
+                "callbacks": runtime_callbacks,
+                "run_id": parent_run_id,
+                "tags": ["job"],
+                "metadata": {"job_id": "job-1"},
+                "configurable": {"thread_id": "parent-thread", "checkpoint_ns": "parent"},
+            }
+        )
+
+        config = research_module.researcher_invoke_config(runtime, fallback_callbacks)
+
+        assert config["callbacks"] is runtime_callbacks
+        assert config["run_name"] == "researcher-agent"
+        assert "run_id" not in config
+        assert config["tags"] == ["job"]
+        assert config["metadata"] == {"job_id": "job-1"}
+        assert "configurable" not in config
+        assert research_module.researcher_invoke_config(None, fallback_callbacks) == {
+            "callbacks": fallback_callbacks,
+            "run_name": "researcher-agent",
+        }
+
+    @pytest.mark.asyncio
+    async def test_researcher_event_attribution_uses_named_workflow_and_nested_agent_id(
+        self,
+        mock_llm_provider,
+        real_tool,
+    ):
+        """A batched researcher emits lifecycle events and owns its nested tools."""
+        from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+
+        event_store = MagicMock()
+        callback = AgentEventCallback(event_store=event_store)
+        researcher_runnable = (
+            RunnableLambda(lambda _state: {"query": "researcher observability"})
+            | real_tool
+            | RunnableLambda(lambda _output: self._structured_notes_response("Researcher Observability"))
+        )
+        agent = DeepResearcherAgent(llm_provider=mock_llm_provider, tools=[real_tool], callbacks=[callback])
+        batch_tool = self._build_batch_tool(agent, researcher_runnable)
+
+        await batch_tool.ainvoke(
+            {
+                "queries": [
+                    {
+                        "query": f"researcher observability {index}",
+                        "preferred_tools": ["web_search_tool"],
+                        "fallback_tools": [],
+                        "target_components": ["observability"],
+                        "rationale": "Verify researcher event attribution.",
+                    }
+                    for index in range(2)
+                ]
+            },
+            config={"callbacks": [callback]},
+        )
+
+        events = [call.args[0] for call in event_store.store.call_args_list]
+        workflow_starts = [event for event in events if event["type"] == "workflow.start"]
+        workflow_ends = [event for event in events if event["type"] == "workflow.end"]
+        search_starts = [
+            event for event in events if event["type"] == "tool.start" and event["name"] == "web_search_tool"
+        ]
+
+        assert [event["name"] for event in workflow_starts] == ["researcher-agent", "researcher-agent"]
+        assert [event["name"] for event in workflow_ends] == ["researcher-agent", "researcher-agent"]
+        researcher_ids = {event["metadata"]["agent_id"] for event in workflow_starts}
+        assert len(researcher_ids) == 2
+        assert len(search_starts) == 2
+        assert {event["metadata"]["agent_id"] for event in search_starts} == researcher_ids
 
     @pytest.mark.asyncio
     async def test_run_research_batch_rejects_unranked_oversized_batches(


### PR DESCRIPTION
## Summary

- preserve the active `ToolRuntime` callback context for batched researcher invocations
- name each nested researcher run `researcher-agent` so existing workflow events and tool `agent_id` attribution work
- verify concurrent researcher cards keep tool calls isolated and update the Agents tab copy for Source Router

## Root cause

`run_research_batch` replaced the active runtime callback manager with the raw callback list and invoked the researcher runnable without a stable run name. Researcher lifecycle events were therefore absent, and nested search/tool events could not be attributed to a researcher in the UI.

## Impact

Each concurrent researcher invocation now emits the existing `workflow.start`/`workflow.end` contract with a distinct agent ID. Its nested tools inherit that ID, allowing the current UI grouping logic to display researcher activity without a new event schema or hierarchy model.

<img width="1690" height="930" alt="image" src="https://github.com/user-attachments/assets/b25c7821-3ace-4e7d-aec2-b6e486f72f74" />


## Validation

- `uv run pytest -q tests/aiq_agent/agents/deep_researcher/test_agent.py tests/aiq_agent/agents/deep_researcher/test_factory.py tests/aiq_agent/jobs/test_runner.py` (`153 passed`)
- `uv run ruff check src/aiq_agent/agents/deep_researcher/tools/research.py tests/aiq_agent/agents/deep_researcher/test_agent.py`
- `uv run ruff format --check src/aiq_agent/agents/deep_researcher/tools/research.py tests/aiq_agent/agents/deep_researcher/test_agent.py`
- `npm run test:ci -- src/features/layout/components/AgentsTab.spec.tsx` (`8 passed`)
- `npx tsc --noEmit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Updated the Agents tab description to additionally list **“Active source router”** alongside planner, researcher, and writer.

* **Bug Fixes**
  * Fixed concurrent researcher display so each agent card shows only its own tool calls—even when agents share the same visible name.
  * Improved activity tracking/attribution for nested researcher runs to ensure workflow and tool events are consistently attributed to the correct agent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->