### PR TITLE
fix(aiq-api): preserve agent trace hierarchy

### DIFF
--- a/frontends/aiq_api/src/aiq_api/jobs/runner.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/runner.py
@@ -629,8 +629,10 @@ async def run_agent_job(
             from nat.data_models.intermediate_step import TraceMetadata
             from nat.data_models.invocation_node import InvocationNode
             from nat.observability.exporter_manager import ExporterManager
-            from nat.plugins.langchain.callback_handler import LangchainProfilerHandler
             from nat.utils.reactive.subject import Subject
+
+            from .telemetry import AgentLifecycleTelemetryCallback
+            from .telemetry import aiq_langchain_profiler_context
 
             telemetry_exporters = {
                 name: configured.instance for name, configured in builder._telemetry_exporters.items()
@@ -654,7 +656,7 @@ async def run_agent_job(
             _ = context_state.active_span_id_stack
 
             # Set up span hierarchy metadata
-            workflow_span_name = f"async_job:{agent_config_name}"
+            workflow_span_name = agent_config_name
             context_state.active_function.set(
                 InvocationNode(
                     function_name=workflow_span_name,
@@ -711,16 +713,15 @@ async def run_agent_job(
                         )
                     )
 
-                    # Create profiler callback AFTER workflow starts (ensures correct parent)
-                    nat_profiler_callback = LangchainProfilerHandler()
+                    agent_telemetry_callback = AgentLifecycleTelemetryCallback(context.intermediate_step_manager)
 
                     verbose = is_verbose(getattr(fn_config, "verbose", False))
                     callbacks = [VerboseTraceCallback()] if verbose else []
 
                     raw_event_store = EventStore(db_url, job_id, content_cipher=job_output_cipher)
                     event_store = BatchingEventStore(raw_event_store)
+                    callbacks.append(agent_telemetry_callback)
                     callbacks.append(AgentEventCallback(event_store))
-                    callbacks.append(nat_profiler_callback)
 
                     # Resolve per-user MCP source tools for the job owner (Context.user_id
                     # set above); connections stay open via mcp_stack for the agent run.
@@ -759,20 +760,22 @@ async def run_agent_job(
                         # agents without a sandbox runtime; close()/terminate() are then no-ops.
                         sandbox_runtime = getattr(agent, "deepagents_runtime", None)
 
-                        # Run agent - LLM/tool events will be nested under workflow span
-                        result = await _run_agent(
-                            agent=agent,
-                            input_text=input_text,
-                            builder=builder,
-                            config=config,
-                            function_name=agent_config_name,
-                            function_config=fn_config,
-                            monitor=cancellation_monitor,
-                            available_documents=available_documents,
-                            data_sources=data_sources,
-                            event_store=event_store,
-                            initial_files=initial_files,
-                        )
+                        # Replace NAT's inherited profiler for this invocation rather than adding a
+                        # second callback with duplicate LangChain run IDs.
+                        with aiq_langchain_profiler_context():
+                            result = await _run_agent(
+                                agent=agent,
+                                input_text=input_text,
+                                builder=builder,
+                                config=config,
+                                function_name=agent_config_name,
+                                function_config=fn_config,
+                                monitor=cancellation_monitor,
+                                available_documents=available_documents,
+                                data_sources=data_sources,
+                                event_store=event_store,
+                                initial_files=initial_files,
+                            )
 
                     # Emit WORKFLOW_END event for Phoenix
                     context.intermediate_step_manager.push_intermediate_step(

--- a/frontends/aiq_api/src/aiq_api/jobs/telemetry.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/telemetry.py
@@ -14,7 +14,6 @@ from langchain_core.callbacks import BaseCallbackHandler
 
 from nat.data_models.intermediate_step import IntermediateStepPayload
 from nat.data_models.intermediate_step import IntermediateStepType
-from nat.data_models.intermediate_step import StreamEventData
 from nat.data_models.intermediate_step import TraceMetadata
 from nat.plugins.langchain.callback_handler import LangchainProfilerHandler
 
@@ -70,7 +69,6 @@ class AgentLifecycleTelemetryCallback(BaseCallbackHandler):
                 UUID=run_id,
                 event_type=IntermediateStepType.WORKFLOW_START,
                 name=name,
-                data=StreamEventData(input=inputs),
                 metadata=TraceMetadata(
                     provided_metadata={
                         "agent_id": run_id,
@@ -108,7 +106,6 @@ class AgentLifecycleTelemetryCallback(BaseCallbackHandler):
                 UUID=run_id,
                 event_type=IntermediateStepType.WORKFLOW_END,
                 name=name,
-                data=StreamEventData(output=outputs if error is None else str(error)),
                 metadata=TraceMetadata(provided_metadata=metadata),
             )
         )

--- a/frontends/aiq_api/src/aiq_api/jobs/telemetry.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/telemetry.py
@@ -18,17 +18,17 @@ from nat.data_models.intermediate_step import TraceMetadata
 from nat.plugins.langchain.callback_handler import LangchainProfilerHandler
 
 
-def _chain_name(serialized: dict[str, Any] | None, kwargs: dict[str, Any]) -> str:
-    if serialized:
-        name = serialized.get("name") or serialized.get("id", [""])[-1]
-        if name:
-            return str(name)
-    return str(kwargs.get("name", "unknown"))
+def _deepagents_agent_name(kwargs: dict[str, Any]) -> str | None:
+    """Return the outer DeepAgents chain name, excluding internal graph nodes."""
+    metadata = kwargs.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
 
-
-def _is_agent_name(name: str) -> bool:
-    normalized = name.lower()
-    return "agent" in normalized and not any(part in normalized for part in ("middleware", "handler", "callback"))
+    semantic_name = metadata.get("lc_agent_name")
+    callback_name = kwargs.get("name")
+    if not isinstance(semantic_name, str) or callback_name != semantic_name:
+        return None
+    return semantic_name
 
 
 def _task_display_name(serialized: dict[str, Any], input_str: str, inputs: dict[str, Any] | None) -> str:
@@ -57,9 +57,9 @@ class AgentLifecycleTelemetryCallback(BaseCallbackHandler):
         self._agent_names: dict[str, str] = {}
 
     def on_chain_start(self, serialized: dict[str, Any] | None, inputs: dict[str, Any], **kwargs: Any) -> None:
-        name = _chain_name(serialized, kwargs)
+        name = _deepagents_agent_name(kwargs)
         run_id = str(kwargs.get("run_id", ""))
-        if not run_id or not _is_agent_name(name):
+        if not run_id or name is None:
             return
 
         self._agent_names[run_id] = name

--- a/frontends/aiq_api/src/aiq_api/jobs/telemetry.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/telemetry.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""AI-Q telemetry adapters for named LangChain agent spans."""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from langchain_core.callbacks import BaseCallbackHandler
+
+from nat.data_models.intermediate_step import IntermediateStepPayload
+from nat.data_models.intermediate_step import IntermediateStepType
+from nat.data_models.intermediate_step import StreamEventData
+from nat.data_models.intermediate_step import TraceMetadata
+from nat.plugins.langchain.callback_handler import LangchainProfilerHandler
+
+
+def _chain_name(serialized: dict[str, Any] | None, kwargs: dict[str, Any]) -> str:
+    if serialized:
+        name = serialized.get("name") or serialized.get("id", [""])[-1]
+        if name:
+            return str(name)
+    return str(kwargs.get("name", "unknown"))
+
+
+def _is_agent_name(name: str) -> bool:
+    normalized = name.lower()
+    return "agent" in normalized and not any(part in normalized for part in ("middleware", "handler", "callback"))
+
+
+def _task_display_name(serialized: dict[str, Any], input_str: str, inputs: dict[str, Any] | None) -> str:
+    name = str(serialized.get("name", ""))
+    if name != "task":
+        return name
+
+    parsed_inputs: Any = inputs
+    if not isinstance(parsed_inputs, dict):
+        try:
+            parsed_inputs = ast.literal_eval(input_str)
+        except (SyntaxError, ValueError):
+            parsed_inputs = None
+    subagent_type = parsed_inputs.get("subagent_type") if isinstance(parsed_inputs, dict) else None
+    return f"task: {subagent_type}" if subagent_type else name
+
+
+class AgentLifecycleTelemetryCallback(BaseCallbackHandler):
+    """Emit named NAT agent spans while preserving the active task/tool stack."""
+
+    run_inline = True
+
+    def __init__(self, step_manager: Any) -> None:
+        super().__init__()
+        self._step_manager = step_manager
+        self._agent_names: dict[str, str] = {}
+
+    def on_chain_start(self, serialized: dict[str, Any] | None, inputs: dict[str, Any], **kwargs: Any) -> None:
+        name = _chain_name(serialized, kwargs)
+        run_id = str(kwargs.get("run_id", ""))
+        if not run_id or not _is_agent_name(name):
+            return
+
+        self._agent_names[run_id] = name
+        parent_run_id = kwargs.get("parent_run_id")
+        self._step_manager.push_intermediate_step(
+            IntermediateStepPayload(
+                UUID=run_id,
+                event_type=IntermediateStepType.WORKFLOW_START,
+                name=name,
+                data=StreamEventData(input=inputs),
+                metadata=TraceMetadata(
+                    provided_metadata={
+                        "agent_id": run_id,
+                        "agent_name": name,
+                        "span_role": "agent",
+                        "langchain_parent_run_id": str(parent_run_id) if parent_run_id else None,
+                    }
+                ),
+            )
+        )
+
+    def on_chain_end(self, outputs: dict[str, Any], **kwargs: Any) -> None:
+        self._end_agent_run(outputs=outputs, error=None, **kwargs)
+
+    def on_chain_error(self, error: BaseException, **kwargs: Any) -> None:
+        self._end_agent_run(outputs=None, error=error, **kwargs)
+
+    def _end_agent_run(
+        self,
+        *,
+        outputs: dict[str, Any] | None,
+        error: BaseException | None,
+        **kwargs: Any,
+    ) -> None:
+        run_id = str(kwargs.get("run_id", ""))
+        name = self._agent_names.pop(run_id, None)
+        if name is None:
+            return
+
+        metadata = {"agent_id": run_id, "agent_name": name, "span_role": "agent"}
+        if error is not None:
+            metadata["error_type"] = type(error).__name__
+        self._step_manager.push_intermediate_step(
+            IntermediateStepPayload(
+                UUID=run_id,
+                event_type=IntermediateStepType.WORKFLOW_END,
+                name=name,
+                data=StreamEventData(output=outputs if error is None else str(error)),
+                metadata=TraceMetadata(provided_metadata=metadata),
+            )
+        )
+
+
+class AIQLangchainProfilerHandler(LangchainProfilerHandler):
+    """Preserve NAT's profiler behavior while naming DeepAgents task spans."""
+
+    async def on_tool_start(
+        self,
+        serialized: dict[str, Any],
+        input_str: str,
+        *,
+        inputs: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        serialized = dict(serialized)
+        serialized["name"] = _task_display_name(serialized, input_str, inputs)
+        return await super().on_tool_start(serialized, input_str, inputs=inputs, **kwargs)
+
+
+@contextmanager
+def aiq_langchain_profiler_context() -> Iterator[AIQLangchainProfilerHandler]:
+    """Replace NAT's inherited profiler for one AIQ job without adding a duplicate callback."""
+    from nat.plugins.profiler.decorators.framework_wrapper import callback_handler_var
+
+    profiler = AIQLangchainProfilerHandler()
+    token = callback_handler_var.set(profiler)
+    try:
+        yield profiler
+    finally:
+        callback_handler_var.reset(token)

--- a/tests/aiq_agent/jobs/test_telemetry.py
+++ b/tests/aiq_agent/jobs/test_telemetry.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID
+
+import pytest
+from langchain_core.messages import AIMessage
+from langchain_core.messages import HumanMessage
+from langchain_core.outputs import ChatGeneration
+from langchain_core.outputs import LLMResult
+
+from nat.builder.context import Context
+from nat.builder.context import ContextState
+from nat.data_models.intermediate_step import IntermediateStepPayload
+from nat.data_models.intermediate_step import IntermediateStepType
+from nat.data_models.invocation_node import InvocationNode
+from nat.utils.reactive.subject import Subject
+
+
+@pytest.fixture
+def telemetry_context():
+    """Provide an isolated NAT event stream and span stack for callback tests."""
+    state = ContextState.get()
+    event_stream = Subject()
+    tokens = [
+        (state.event_stream, state.event_stream.set(event_stream)),
+        (state.active_span_id_stack, state.active_span_id_stack.set(["root"])),
+        (
+            state.active_function,
+            state.active_function.set(InvocationNode(function_name="deep_research_agent", function_id="job-1")),
+        ),
+        (state.workflow_run_id, state.workflow_run_id.set("job-1")),
+        (state.workflow_trace_id, state.workflow_trace_id.set(0x1234)),
+    ]
+    manager = Context(state).intermediate_step_manager
+    events = []
+    event_stream.subscribe(events.append)
+
+    yield state, manager, events
+
+    for context_var, token in reversed(tokens):
+        context_var.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_agent_telemetry_nests_named_subagent_and_model_under_task(telemetry_context):
+    """DeepAgents task -> named agent -> model must be an explicit NAT span hierarchy."""
+    from aiq_api.jobs.telemetry import AgentLifecycleTelemetryCallback
+    from aiq_api.jobs.telemetry import AIQLangchainProfilerHandler
+
+    _, manager, events = telemetry_context
+    task_id = UUID("00000000-0000-0000-0000-000000000001")
+    agent_id = UUID("00000000-0000-0000-0000-000000000002")
+    model_id = UUID("00000000-0000-0000-0000-000000000003")
+
+    manager.push_intermediate_step(
+        IntermediateStepPayload(
+            UUID="job-1",
+            event_type=IntermediateStepType.WORKFLOW_START,
+            name="deep_research_agent",
+        )
+    )
+    agent_callback = AgentLifecycleTelemetryCallback(manager)
+    profiler_callback = AIQLangchainProfilerHandler()
+
+    await profiler_callback.on_tool_start(
+        {"name": "task"},
+        "{'subagent_type': 'planner-agent'}",
+        run_id=task_id,
+        inputs={"subagent_type": "planner-agent"},
+    )
+    agent_callback.on_chain_start(
+        None,
+        inputs={"messages": [HumanMessage(content="plan the research")]},
+        run_id=agent_id,
+        parent_run_id=task_id,
+        name="planner-agent",
+    )
+    await profiler_callback.on_chat_model_start(
+        {},
+        [[HumanMessage(content="plan the research")]],
+        run_id=model_id,
+        parent_run_id=agent_id,
+        metadata={"ls_model_name": "test-model"},
+        invocation_params={},
+    )
+
+    starts = {event.UUID: event for event in events if event.event_state.value == "START"}
+    assert starts[str(task_id)].payload.name == "task: planner-agent"
+    assert starts[str(task_id)].parent_id == "job-1"
+    assert starts[str(agent_id)].event_type == IntermediateStepType.WORKFLOW_START
+    assert starts[str(agent_id)].payload.name == "planner-agent"
+    assert starts[str(agent_id)].payload.metadata.provided_metadata["span_role"] == "agent"
+    assert starts[str(agent_id)].parent_id == str(task_id)
+    assert starts[str(model_id)].parent_id == str(agent_id)
+
+    result = LLMResult(
+        generations=[[ChatGeneration(message=AIMessage(content="plan complete"))]],
+        llm_output={"model_name": "test-model"},
+    )
+    await profiler_callback.on_llm_end(result, run_id=model_id)
+    agent_callback.on_chain_end({"messages": [AIMessage(content="plan complete")]}, run_id=agent_id)
+    await profiler_callback.on_tool_end("plan complete", run_id=task_id, name="task")
+    manager.push_intermediate_step(
+        IntermediateStepPayload(
+            UUID="job-1",
+            event_type=IntermediateStepType.WORKFLOW_END,
+            name="deep_research_agent",
+        )
+    )
+
+    started_ids = {event.UUID for event in events if event.event_state.value == "START"}
+    assert all(event.parent_id == "root" or event.parent_id in started_ids for event in events)
+    assert manager.get_outstanding_step_count() == 0
+    assert profiler_callback.step_manager.get_outstanding_step_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_parallel_researcher_spans_share_batch_parent_without_sharing_identity(telemetry_context):
+    """Concurrent researcher runs remain distinct children of one batch tool span."""
+    from aiq_api.jobs.telemetry import AgentLifecycleTelemetryCallback
+    from aiq_api.jobs.telemetry import AIQLangchainProfilerHandler
+
+    _, manager, events = telemetry_context
+    batch_id = UUID("00000000-0000-0000-0000-000000000010")
+    researcher_ids = [
+        UUID("00000000-0000-0000-0000-000000000011"),
+        UUID("00000000-0000-0000-0000-000000000012"),
+    ]
+
+    manager.push_intermediate_step(
+        IntermediateStepPayload(
+            UUID="job-1",
+            event_type=IntermediateStepType.WORKFLOW_START,
+            name="deep_research_agent",
+        )
+    )
+    agent_callback = AgentLifecycleTelemetryCallback(manager)
+    profiler_callback = AIQLangchainProfilerHandler()
+    await profiler_callback.on_tool_start(
+        {"name": "run_research_batch"},
+        "{}",
+        run_id=batch_id,
+        inputs={},
+    )
+
+    async def run_researcher(run_id: UUID) -> None:
+        agent_callback.on_chain_start(None, inputs={}, run_id=run_id, parent_run_id=batch_id, name="researcher-agent")
+        await asyncio.sleep(0)
+        agent_callback.on_chain_end({}, run_id=run_id)
+
+    await asyncio.gather(*(run_researcher(run_id) for run_id in researcher_ids))
+
+    starts = {
+        event.UUID: event
+        for event in events
+        if event.event_state.value == "START" and event.payload.name == "researcher-agent"
+    }
+    assert set(starts) == {str(run_id) for run_id in researcher_ids}
+    assert {event.parent_id for event in starts.values()} == {str(batch_id)}
+
+
+def test_aiq_profiler_context_replaces_and_restores_nat_profiler(telemetry_context):
+    """AIQ must customize NAT's inherited profiler instead of installing a duplicate callback."""
+    from aiq_api.jobs.telemetry import AIQLangchainProfilerHandler
+    from aiq_api.jobs.telemetry import aiq_langchain_profiler_context
+    from nat.plugins.langchain.callback_handler import LangchainProfilerHandler
+    from nat.plugins.profiler.decorators.framework_wrapper import callback_handler_var
+
+    nat_profiler = LangchainProfilerHandler()
+    token = callback_handler_var.set(nat_profiler)
+    try:
+        with aiq_langchain_profiler_context() as aiq_profiler:
+            assert isinstance(aiq_profiler, AIQLangchainProfilerHandler)
+            assert callback_handler_var.get() is aiq_profiler
+            assert callback_handler_var.get() is not nat_profiler
+
+        assert callback_handler_var.get() is nat_profiler
+    finally:
+        callback_handler_var.reset(token)

--- a/tests/aiq_agent/jobs/test_telemetry.py
+++ b/tests/aiq_agent/jobs/test_telemetry.py
@@ -78,6 +78,7 @@ async def test_agent_telemetry_nests_named_subagent_and_model_under_task(telemet
         run_id=agent_id,
         parent_run_id=task_id,
         name="planner-agent",
+        metadata={"lc_agent_name": "planner-agent"},
     )
     await profiler_callback.on_chat_model_start(
         {},
@@ -148,7 +149,14 @@ async def test_parallel_researcher_spans_share_batch_parent_without_sharing_iden
     )
 
     async def run_researcher(run_id: UUID) -> None:
-        agent_callback.on_chain_start(None, inputs={}, run_id=run_id, parent_run_id=batch_id, name="researcher-agent")
+        agent_callback.on_chain_start(
+            None,
+            inputs={},
+            run_id=run_id,
+            parent_run_id=batch_id,
+            name="researcher-agent",
+            metadata={"lc_agent_name": "researcher-agent"},
+        )
         await asyncio.sleep(0)
         agent_callback.on_chain_end({}, run_id=run_id)
 
@@ -176,6 +184,7 @@ def test_agent_lifecycle_spans_do_not_capture_graph_state(telemetry_context):
         inputs={"messages": [HumanMessage(content="sensitive input")]},
         run_id=run_id,
         name="researcher-agent",
+        metadata={"lc_agent_name": "researcher-agent"},
     )
     callback.on_chain_end(
         {"messages": [AIMessage(content="sensitive output")]},
@@ -184,6 +193,32 @@ def test_agent_lifecycle_spans_do_not_capture_graph_state(telemetry_context):
 
     assert len(events) == 2
     assert all(event.payload.data is None for event in events)
+    assert all("sensitive input" not in str(event.payload.metadata) for event in events)
+    assert all("sensitive output" not in str(event.payload.metadata) for event in events)
+
+
+@pytest.mark.parametrize(
+    ("name", "metadata", "expected"),
+    [
+        ("general-purpose", {"lc_agent_name": "general-purpose"}, True),
+        ("reviewer", {"lc_agent_name": "reviewer"}, True),
+        ("agent", {"langgraph_node": "agent"}, False),
+        ("model", {"lc_agent_name": "reviewer"}, False),
+    ],
+)
+def test_agent_lifecycle_requires_matching_deepagents_identity(telemetry_context, name, metadata, expected):
+    """Only the outer chain identified by DeepAgents metadata is an agent boundary."""
+    from aiq_api.jobs.telemetry import AgentLifecycleTelemetryCallback
+
+    _, manager, events = telemetry_context
+    callback = AgentLifecycleTelemetryCallback(manager)
+    run_id = UUID("00000000-0000-0000-0000-000000000030")
+
+    callback.on_chain_start(None, inputs={}, run_id=run_id, name=name, metadata=metadata)
+    callback.on_chain_end({}, run_id=run_id)
+
+    assert [event.payload.name for event in events] == ([name, name] if expected else [])
+    assert manager.get_outstanding_step_count() == 0
 
 
 def test_aiq_profiler_context_replaces_and_restores_nat_profiler(telemetry_context):

--- a/tests/aiq_agent/jobs/test_telemetry.py
+++ b/tests/aiq_agent/jobs/test_telemetry.py
@@ -163,6 +163,29 @@ async def test_parallel_researcher_spans_share_batch_parent_without_sharing_iden
     assert {event.parent_id for event in starts.values()} == {str(batch_id)}
 
 
+def test_agent_lifecycle_spans_do_not_capture_graph_state(telemetry_context):
+    """Structural agent spans must not duplicate LangGraph state into telemetry."""
+    from aiq_api.jobs.telemetry import AgentLifecycleTelemetryCallback
+
+    _, manager, events = telemetry_context
+    callback = AgentLifecycleTelemetryCallback(manager)
+    run_id = UUID("00000000-0000-0000-0000-000000000020")
+
+    callback.on_chain_start(
+        None,
+        inputs={"messages": [HumanMessage(content="sensitive input")]},
+        run_id=run_id,
+        name="researcher-agent",
+    )
+    callback.on_chain_end(
+        {"messages": [AIMessage(content="sensitive output")]},
+        run_id=run_id,
+    )
+
+    assert len(events) == 2
+    assert all(event.payload.data is None for event in events)
+
+
 def test_aiq_profiler_context_replaces_and_restores_nat_profiler(telemetry_context):
     """AIQ must customize NAT's inherited profiler instead of installing a duplicate callback."""
     from aiq_api.jobs.telemetry import AIQLangchainProfilerHandler


### PR DESCRIPTION
## Summary

- emit named NAT workflow spans for DeepAgents sub-agents so their model and tool activity is grouped correctly
- replace NAT's inherited LangChain profiler for the async invocation instead of installing a duplicate profiler callback
- preserve the existing cross-process parent bridge so completed deep-research traces remain under the originating workflow

## Root cause

AIQ manually attached a second `LangchainProfilerHandler` even though NAT already installs an inheritable handler through its framework wrapper. Both handlers emitted events for the same LangChain run IDs, producing overwritten or orphaned span relationships. DeepAgents chain callbacks also lacked explicit named NAT spans for sub-agents.

## User impact

Completed Phoenix traces now show `deep_research_agent -> task: <sub-agent> -> <sub-agent> -> model/tools`, nested beneath the original chat workflow. UI agent events remain unchanged.

## Before / After

| Before | After |
|---|---|
| <img width="544" alt="Before: orphaned sub-agent spans" src="https://github.com/user-attachments/assets/cd920a33-68bf-43a4-9264-3afb09d8fb42" /> | <img width="441" alt="After: nested sub-agent hierarchy" src="https://github.com/user-attachments/assets/a56d8b89-12ec-4e71-84ed-5cbaa6cd6b94" /> |
| Sub-agent spans appeared orphaned at the trace root. | Sub-agent activity is nested under `deep_research_agent → task → sub-agent`. |

## Validation

- `uv run pytest tests/aiq_agent/jobs/test_telemetry.py tests/aiq_agent/jobs/test_runner.py tests/aiq_agent/agents/deep_researcher/test_agent.py tests/aiq_agent/agents/deep_researcher/test_factory.py -q` (156 passed)
- `uv run ruff check frontends/aiq_api/src/aiq_api/jobs/runner.py frontends/aiq_api/src/aiq_api/jobs/telemetry.py tests/aiq_agent/jobs/test_telemetry.py`
- `uv run ruff format --check frontends/aiq_api/src/aiq_api/jobs/runner.py frontends/aiq_api/src/aiq_api/jobs/telemetry.py tests/aiq_agent/jobs/test_telemetry.py`
- manually validated a completed deep-research run in Phoenix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved agent job tracing with clearer workflow and task-related span naming.
  * Added lifecycle telemetry for agent execution, emitting consistent workflow start/end events with agent identity metadata.

* **Bug Fixes**
  * Fixed profiler integration to prevent duplicate callback handling while maintaining existing profiling behavior.
  * Corrected span nesting/parent relationships for nested and parallel agent runs, and ensured lifecycle telemetry does not capture graph state details.

* **Tests**
  * Added coverage for agent lifecycle telemetry, nested/parallel span parenting, lifecycle identity matching, and profiler context swap/restore behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->