### PR TITLE
docs: add DCO sign-off to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,19 @@
 
 <!-- Describe the change and why it is needed. -->
 
+#### DCO sign-off for the squash commit
+
+<!--
+The RAPIDS auto-merger copies this PR description into the generated squash
+commit. Replace the placeholder below with your name and the commit email
+configured for your GitHub account. If you keep your email private, use the
+GitHub-provided `@users.noreply.github.com` address shown in your email settings.
+
+Do not delete the sign-off line or leave the placeholder unchanged.
+-->
+
+Signed-off-by: FULL NAME <EMAIL>
+
 #### Validation
 
 <!-- List the exact commands, workflows, screenshots, or manual checks used. -->
@@ -11,6 +24,7 @@
 - [ ] I updated documentation for user-facing or contributor-facing changes.
 - [ ] I confirmed this PR does not include secrets, credentials, or internal-only data.
 - [ ] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.
+- [ ] I replaced the DCO sign-off placeholder above with the identity GitHub will use for the squash commit.
 
 #### Where should reviewers start?
 


### PR DESCRIPTION
#### Overview

Adds an explicit DCO sign-off field to the pull request template for repositories using the RAPIDS squash auto-merger.

The auto-merger copies the PR description into the generated squash commit. Without a matching `Signed-off-by` trailer in that description, the generated release commit fails DCO when it is subsequently forward-merged into `develop`.

The template directs contributors to use the commit identity configured by GitHub, including the GitHub-provided noreply address when email privacy is enabled.

#### DCO sign-off for the squash commit

Signed-off-by: Ajay Thorve <AjayThorve@users.noreply.github.com>

#### Validation

- [x] `git diff --check`
- [x] `uv run pre-commit run --files .github/pull_request_template.md`
- [x] Markdown link checking and secret detection passed.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO).

#### Where should reviewers start?

Review `.github/pull_request_template.md` and confirm that the sign-off instructions match the identity GitHub assigns to generated squash commits.

#### Related Issues

This is a process workaround for DCO failures on automated `release/2.2` to `develop` forward merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the pull request template with instructions for DCO sign-off on squash commits.
  * Added a required sign-off placeholder and a checklist item to confirm it has been replaced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->