### PR TITLE
fix(async-deep-research): declare and safely read async flag

### DIFF
--- a/frontends/aiq_api/src/aiq_api/jobs/runner.py
+++ b/frontends/aiq_api/src/aiq_api/jobs/runner.py
@@ -254,7 +254,7 @@ def _get_worker_function_type(config: Any) -> str | None:
     if config.workflow is None:
         return None
 
-    if config.workflow.use_async_deep_research:
+    if getattr(config.workflow, "use_async_deep_research", False):
         return _DEEP_RESEARCH_FUNCTION_TYPE
     return None
 

--- a/src/aiq_agent/agents/deep_researcher/register.py
+++ b/src/aiq_agent/agents/deep_researcher/register.py
@@ -318,7 +318,10 @@ class DeepResearchWorkflowConfig(FunctionBaseConfig, name="deep_research_workflo
     for the deep_research_agent. Use this as the workflow for evaluation.
     """
 
-    pass
+    use_async_deep_research: bool = Field(
+        default=False,
+        description="Submit deep research as an async job instead of running inline",
+    )
 
 
 @register_function(config_type=DeepResearchWorkflowConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])

--- a/tests/aiq_agent/jobs/test_runner.py
+++ b/tests/aiq_agent/jobs/test_runner.py
@@ -1188,17 +1188,23 @@ class TestToolArtifactMapping:
 
 
 def test_get_worker_function_type_maps_async_deep_research_flag():
-    """Async deep research selects the deep research function type."""
+    """Async deep research selects the deep research function type for supported workflows."""
     from types import SimpleNamespace
 
+    from aiq_agent.agents.deep_researcher.register import DeepResearchWorkflowConfig
     from aiq_api.jobs.runner import _get_worker_function_type
 
-    enabled_config = SimpleNamespace(workflow=SimpleNamespace(use_async_deep_research=True))
-    disabled_config = SimpleNamespace(workflow=SimpleNamespace(use_async_deep_research=False))
+    workflow = DeepResearchWorkflowConfig(use_async_deep_research=True)
+    enabled_config = SimpleNamespace(workflow=workflow)
+    disabled_config = SimpleNamespace(workflow=DeepResearchWorkflowConfig())
+    missing_flag_config = SimpleNamespace(workflow=SimpleNamespace())
     no_workflow_config = SimpleNamespace(workflow=None)
 
+    assert workflow.use_async_deep_research is True
+    assert workflow.model_dump()["use_async_deep_research"] is True
     assert _get_worker_function_type(enabled_config) == "deep_research_agent"
     assert _get_worker_function_type(disabled_config) is None
+    assert _get_worker_function_type(missing_flag_config) is None
     assert _get_worker_function_type(no_workflow_config) is None
 
 


### PR DESCRIPTION
#### Overview

Fixes AIQ-3571 by declaring the async deep-research flag on `DeepResearchWorkflowConfig` and safely reading it in the Dask job runner. Async jobs submitted with `config_domain_routing_and_skills.yml` now enter the deep-research workflow instead of failing with an `AttributeError`.

A focused regression test covers enabled, disabled, absent, and missing-workflow cases.

#### DCO sign-off for the squash commit

Signed-off-by: Kyle Zheng <kyzheng@nvidia.com>

#### Validation

- [x] `.venv/bin/ruff check frontends/aiq_api/src/aiq_api/jobs/runner.py src/aiq_agent/agents/deep_researcher/register.py tests/aiq_agent/jobs/test_runner.py` — passed.
- [x] `.venv/bin/ruff format --check frontends/aiq_api/src/aiq_api/jobs/runner.py src/aiq_agent/agents/deep_researcher/register.py tests/aiq_agent/jobs/test_runner.py` — 3 files already formatted.
- [x] `.venv/bin/pytest tests/aiq_agent/jobs/test_runner.py -q` — 114 passed.
- [x] Manual async regression with `config_domain_routing_and_skills.yml`: health and agent discovery passed; the Dask worker entered source routing and planning without the reported `AttributeError`. The report later stopped on unrelated model-provider 429 throttling.
- [x] Tests cover the behavior change.
- [x] Documentation is not required because this restores the existing configuration behavior.
- [x] This PR contains no secrets, credentials, or internal-only data.
- [x] The commit is DCO-signed and the squash sign-off above matches the GitHub identity.

#### Where should reviewers start?

Start with `_get_worker_function_type` in `frontends/aiq_api/src/aiq_api/jobs/runner.py` and its regression test in `tests/aiq_agent/jobs/test_runner.py`.

#### Related Issues

- Relates to AIQ-3571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to submit deep research tasks asynchronously instead of running them inline.
  * The option is disabled by default.

* **Bug Fixes**
  * Improved compatibility with workflow configurations where the asynchronous research option is not specified.
  * Added coverage for enabled, disabled, missing, and empty workflow configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->