### PR TITLE
docs: clarify DCO sign-off format

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,11 @@ commit. Replace the placeholder below with your name and the commit email
 configured for your GitHub account. If you keep your email private, use the
 GitHub-provided `@users.noreply.github.com` address shown in your email settings.
 
-Do not delete the sign-off line or leave the placeholder unchanged.
+Keep the angle brackets around the email address. They are part of the required
+DCO format: `Signed-off-by: Full Name <email@example.com>`.
+
+Do not delete the sign-off line, leave the placeholder unchanged, or remove the
+angle brackets.
 -->
 
 Signed-off-by: FULL NAME <EMAIL>
@@ -24,7 +28,7 @@ Signed-off-by: FULL NAME <EMAIL>
 - [ ] I updated documentation for user-facing or contributor-facing changes.
 - [ ] I confirmed this PR does not include secrets, credentials, or internal-only data.
 - [ ] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.
-- [ ] I replaced the DCO sign-off placeholder above with the identity GitHub will use for the squash commit.
+- [ ] I replaced the DCO sign-off placeholder above with the identity GitHub will use for the squash commit and kept the required angle brackets around the email address.
 
 #### Where should reviewers start?
 


### PR DESCRIPTION
#### Overview

Clarify that angle brackets around the email address are required syntax in the DCO `Signed-off-by` trailer copied into squash commits.

The existing template showed the canonical form but did not explicitly identify the brackets as syntax. Contributors could therefore remove them while replacing the placeholder and produce a malformed trailer. This update adds an exact valid example and makes preserving the brackets part of the checklist.

#### DCO sign-off for the squash commit

Signed-off-by: Ajay Thorve <athorve@nvidia.com>

#### Validation

- [x] I ran the relevant local checks or explained why they are not applicable.
  - `pre-commit run --files .github/pull_request_template.md` passed all applicable hooks, including Markdown Link Check and Detect secrets.
- [x] I added or updated tests for behavior changes.
  - Not applicable: this PR changes only contributor-facing Markdown and has no runtime behavior.
- [x] I updated documentation for user-facing or contributor-facing changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.
- [x] I replaced the DCO sign-off placeholder above with the identity GitHub will use for the squash commit and kept the required angle brackets around the email address.

#### Where should reviewers start?

Review `.github/pull_request_template.md`; it is the only changed file.

#### Related Issues

- Relates to #341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request sign-off instructions to require angle brackets around email addresses.
  * Clarified the validation checklist for replacing placeholder identity details in squash commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

