### PR TITLE
fix(aiq-research): handle interrupted jobs and JSON escalation contract

### DIFF
--- a/skills/aiq-research/scripts/aiq.py
+++ b/skills/aiq-research/scripts/aiq.py
@@ -81,11 +81,15 @@ ERROR_INCREMENT = 1
 FIRST_RETRY_ATTEMPT = 1
 CAPTURE_GROUP_JOB_ID = 1
 
-_DONE_JOB_STATES = frozenset({"completed", "success", "failed", "cancelled", "failure"})
+_DONE_JOB_STATES = frozenset({"completed", "success", "failed", "cancelled", "failure", "interrupted"})
 _SUCCESS_JOB_STATES = frozenset({"completed", "success"})
-_FAILED_JOB_STATES = frozenset({"failed", "failure", "cancelled"})
+_FAILED_JOB_STATES = frozenset({"failed", "failure", "cancelled", "interrupted"})
 _STREAM_TERMINAL_EVENTS = frozenset({"complete", "error", "done"})
 _CHAT_JOB_ID_RE = re.compile(rf"Job ID:\s*([0-9a-f-]{{{JOB_ID_HEX_DASH_LENGTH}}})", re.IGNORECASE)
+
+_ESCALATION_TYPE = "job_escalation"
+_ESCALATION_KIND_DEEP_RESEARCH = "deep_research"
+_STATUS_DEEP_RESEARCH_RUNNING = "deep_research_running"
 
 
 class McpAuthRequiredError(RuntimeError):
@@ -450,13 +454,51 @@ def _command_health(_args: list[str]) -> None:
     print(json.dumps(health(), indent=JSON_INDENT_SPACES))
 
 
+def _escalation_job_id(payload: Any) -> str | None:
+    """Return a validated deep-research job_id from a job_escalation object, else None."""
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("type") != _ESCALATION_TYPE or payload.get("kind") != _ESCALATION_KIND_DEEP_RESEARCH:
+        return None
+    job_id = payload.get("job_id")
+    if not isinstance(job_id, str):
+        return None
+    try:
+        return _validate_job_id(job_id)
+    except RuntimeError:
+        return None
+
+
+def _detect_deep_research_escalation(result: dict[str, Any], content: str) -> str | None:
+    """Detect a 26.07 JSON job_escalation contract for deep research.
+
+    Recognizes the escalation object either as the top-level /chat result or as a
+    JSON string embedded in the OpenAI-style message content. Returns a validated
+    job_id, or None for malformed, non-escalation, or invalid payloads.
+    """
+    job_id = _escalation_job_id(result)
+    if job_id is not None:
+        return job_id
+    if content:
+        try:
+            embedded = json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        return _escalation_job_id(embedded)
+    return None
+
+
 def _command_chat(args: list[str]) -> None:
     query = _require_arg(args, "Usage: aiq.py chat <query>")
     result = chat_request(query)
     content = _extract_chat_content(result)
+    job_id = _detect_deep_research_escalation(result, content)
+    if job_id is not None:
+        print(json.dumps({"status": _STATUS_DEEP_RESEARCH_RUNNING, "job_id": job_id}))
+        return
     match = _CHAT_JOB_ID_RE.search(content)
     if match:
-        print(json.dumps({"status": "deep_research_running", "job_id": match.group(CAPTURE_GROUP_JOB_ID)}))
+        print(json.dumps({"status": _STATUS_DEEP_RESEARCH_RUNNING, "job_id": match.group(CAPTURE_GROUP_JOB_ID)}))
         return
     print(json.dumps(result, indent=JSON_INDENT_SPACES))
 

--- a/skills/aiq-research/scripts/aiq.py
+++ b/skills/aiq-research/scripts/aiq.py
@@ -498,8 +498,13 @@ def _command_chat(args: list[str]) -> None:
         return
     match = _CHAT_JOB_ID_RE.search(content)
     if match:
-        print(json.dumps({"status": _STATUS_DEEP_RESEARCH_RUNNING, "job_id": match.group(CAPTURE_GROUP_JOB_ID)}))
-        return
+        try:
+            legacy_job_id = _validate_job_id(match.group(CAPTURE_GROUP_JOB_ID))
+        except RuntimeError:
+            legacy_job_id = None
+        if legacy_job_id is not None:
+            print(json.dumps({"status": _STATUS_DEEP_RESEARCH_RUNNING, "job_id": legacy_job_id}))
+            return
     print(json.dumps(result, indent=JSON_INDENT_SPACES))
 
 

--- a/tests/scripts/test_aiq_research_helper.py
+++ b/tests/scripts/test_aiq_research_helper.py
@@ -117,6 +117,19 @@ def test_legacy_job_id_format_still_detected(aiq: ModuleType, monkeypatch: pytes
     assert out == {"status": "deep_research_running", "job_id": _VALID_JOB_ID}
 
 
+def test_malformed_legacy_job_id_falls_through_to_raw(aiq: ModuleType, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    # 36 chars of [0-9a-f-] so _CHAT_JOB_ID_RE matches, but not a valid UUID layout.
+    bogus = "a" * 36
+    content = f"Deep research started. Job ID: {bogus}"
+    result = {"choices": [{"message": {"content": content}}]}
+    monkeypatch.setattr(aiq, "chat_request", lambda _query: result)
+
+    aiq._command_chat(["legacy malformed query"])
+
+    out = json.loads(capsys.readouterr().out)
+    assert out == result
+
+
 # --- SK-2 guards: no false positives ---------------------------------------------
 
 

--- a/tests/scripts/test_aiq_research_helper.py
+++ b/tests/scripts/test_aiq_research_helper.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the aiq-research helper's terminal-state and escalation contract (AIQ-018).
+
+Covers two 26.07 backend contract fixes in ``skills/aiq-research/scripts/aiq.py``:
+
+- SK-1: the ``interrupted`` job state is terminal and reported as a failure, so
+  polling stops immediately instead of running until the long-poll timeout.
+- SK-2: a JSON ``job_escalation`` deep-research response is recognized and surfaced
+  as ``deep_research_running``, while malformed / non-escalation payloads do not
+  produce a false positive and the legacy ``Job ID: <uuid>`` format still works.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "skills" / "aiq-research" / "scripts" / "aiq.py"
+
+_VALID_JOB_ID = "78f7130c-0000-4000-8000-000000000000"
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("aiq_research_helper", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def aiq() -> ModuleType:
+    return _load()
+
+
+# --- SK-1: interrupted is a terminal, failed state -------------------------------
+
+
+def test_interrupted_is_terminal_and_failed(aiq: ModuleType) -> None:
+    assert "interrupted" in aiq._DONE_JOB_STATES
+    assert "interrupted" in aiq._FAILED_JOB_STATES
+    assert "interrupted" not in aiq._SUCCESS_JOB_STATES
+
+
+def test_poll_returns_immediately_on_interrupted(aiq: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = {"status": 0, "sleep": 0}
+
+    def fake_status(_job_id: str) -> dict[str, object]:
+        calls["status"] += 1
+        return {"status": "interrupted"}
+
+    monkeypatch.setattr(aiq, "get_job_status", fake_status)
+    monkeypatch.setattr(aiq.time, "sleep", lambda _seconds: calls.__setitem__("sleep", calls["sleep"] + 1))
+
+    final = aiq.poll_until_complete(_VALID_JOB_ID)
+
+    assert final == {"status": "interrupted"}
+    assert calls["status"] == 1
+    assert calls["sleep"] == 0
+
+
+def test_research_poll_exits_failure_on_interrupted(aiq: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    report_calls = {"count": 0}
+
+    monkeypatch.setattr(aiq, "get_job_status", lambda _job_id: {"status": "interrupted"})
+    monkeypatch.setattr(aiq, "get_report", lambda _job_id: report_calls.__setitem__("count", report_calls["count"] + 1))
+    monkeypatch.setattr(aiq.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(SystemExit) as excinfo:
+        aiq._command_research_poll([_VALID_JOB_ID])
+
+    assert excinfo.value.code == aiq.EXIT_FAILURE
+    assert report_calls["count"] == 0
+
+
+# --- SK-2: JSON job_escalation detection -----------------------------------------
+
+
+def test_escalation_detected_from_top_level_result(aiq: ModuleType) -> None:
+    result = {"type": "job_escalation", "kind": "deep_research", "job_id": _VALID_JOB_ID}
+    assert aiq._detect_deep_research_escalation(result, "") == _VALID_JOB_ID
+
+
+def test_escalation_detected_from_embedded_content(aiq: ModuleType) -> None:
+    payload = {"type": "job_escalation", "kind": "deep_research", "job_id": _VALID_JOB_ID}
+    content = json.dumps(payload)
+    assert aiq._detect_deep_research_escalation({"choices": []}, content) == _VALID_JOB_ID
+
+
+def test_command_chat_emits_deep_research_running(aiq: ModuleType, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    result = {"type": "job_escalation", "kind": "deep_research", "job_id": _VALID_JOB_ID}
+    monkeypatch.setattr(aiq, "chat_request", lambda _query: result)
+
+    aiq._command_chat(["find me a deep research answer"])
+
+    out = json.loads(capsys.readouterr().out)
+    assert out == {"status": "deep_research_running", "job_id": _VALID_JOB_ID}
+
+
+def test_legacy_job_id_format_still_detected(aiq: ModuleType, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    content = f"Deep research started. Job ID: {_VALID_JOB_ID}"
+    result = {"choices": [{"message": {"content": content}}]}
+    monkeypatch.setattr(aiq, "chat_request", lambda _query: result)
+
+    aiq._command_chat(["legacy query"])
+
+    out = json.loads(capsys.readouterr().out)
+    assert out == {"status": "deep_research_running", "job_id": _VALID_JOB_ID}
+
+
+# --- SK-2 guards: no false positives ---------------------------------------------
+
+
+def test_malformed_json_content_is_not_escalation(aiq: ModuleType) -> None:
+    assert aiq._detect_deep_research_escalation({"choices": []}, "{not valid json") is None
+
+
+def test_non_escalation_json_is_not_escalation(aiq: ModuleType) -> None:
+    result = {"answer": "42", "type": "chat_response"}
+    assert aiq._detect_deep_research_escalation(result, "") is None
+
+
+def test_unsupported_escalation_kind_is_not_escalation(aiq: ModuleType) -> None:
+    result = {"type": "job_escalation", "kind": "some_other_flow", "job_id": _VALID_JOB_ID}
+    assert aiq._detect_deep_research_escalation(result, "") is None
+
+
+def test_missing_or_invalid_job_id_is_not_escalation(aiq: ModuleType) -> None:
+    missing = {"type": "job_escalation", "kind": "deep_research"}
+    invalid = {"type": "job_escalation", "kind": "deep_research", "job_id": "not-a-uuid"}
+    non_string = {"type": "job_escalation", "kind": "deep_research", "job_id": 12345}
+    assert aiq._detect_deep_research_escalation(missing, "") is None
+    assert aiq._detect_deep_research_escalation(invalid, "") is None
+    assert aiq._detect_deep_research_escalation(non_string, "") is None
+
+
+def test_non_escalation_result_falls_through_to_raw(aiq: ModuleType, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    result = {"choices": [{"message": {"content": "a plain shallow answer"}}]}
+    monkeypatch.setattr(aiq, "chat_request", lambda _query: result)
+
+    aiq._command_chat(["shallow query"])
+
+    out = json.loads(capsys.readouterr().out)
+    assert out == result


### PR DESCRIPTION
#### Overview

The `aiq-research` skill helper (`skills/aiq-research/scripts/aiq.py`) had two contract mismatches with the 26.07 backend. Both were verified to still reproduce at `release/2.2` HEAD, and the fix was checked against the backend source that defines each contract.

**1. `interrupted` was not a terminal job state.** `_DONE_JOB_STATES` and `_FAILED_JOB_STATES` omitted `interrupted`, but the backend sets a cancelled job to that state (`JobStatus.INTERRUPTED = "interrupted"` in `nat` `async_jobs/job_store.py`; the cancel route in `frontends/aiq_api/.../routes/jobs.py` returns `{"status": "interrupted"}`). Because the poll loop only exits on a member of `_DONE_JOB_STATES`, a cancelled job kept polling every 15s until the 3600s timeout. Adding `interrupted` to both sets makes polling stop immediately and report the job as failed rather than completed successfully.

**2. Deep-research escalation was detected only in the legacy text format.** `_command_chat` matched only `Job ID: <uuid>`, so the backend's structured escalation payload was printed raw and never surfaced as `deep_research_running`, leaving the documented `SKILL.md` Step 2/3 flow stuck. The backend emits the escalation as a compact JSON object placed in the assistant message content (`_job_escalation_message` in `src/aiq_agent/agents/chat_researcher/agent.py`):

```json
{"type": "job_escalation", "kind": "deep_research", "job_id": "<uuid>"}
```

A new `_detect_deep_research_escalation` helper recognizes this object both as the top-level `/chat` result and as JSON embedded in the message content, validates the `job_id` as a UUID, and emits the documented `{"status": "deep_research_running", "job_id": "<uuid>"}`. It is tried before the legacy `Job ID:` regex, which is retained for backward compatibility. Non-`deep_research` kinds (e.g. `report_edit`), malformed JSON, non-escalation JSON, and missing/invalid job IDs are deliberately ignored so they cannot produce a false `deep_research_running`.

No `SKILL.md` prose change is required: the emitted shape is unchanged, so the existing Steps 2–4 flow now advances as documented.

#### DCO sign-off for the squash commit

Signed-off-by: Tanner Leach <tleach@nvidia.com>

#### Validation

Run from the repo root:

```bash
uv run pytest tests/scripts/test_aiq_research_helper.py -q      # 12 passed
uv run ruff check skills/aiq-research/scripts/aiq.py tests/scripts/test_aiq_research_helper.py   # All checks passed
uv run pre-commit run --files skills/aiq-research/scripts/aiq.py tests/scripts/test_aiq_research_helper.py   # ruff, ruff-format, detect-secrets, EOF/whitespace all pass
```

Contract verification against `release/2.2` source (no live 26.07 backend was required, and the fix was not validated against assumptions alone):
- SK-1: `JobStatus.INTERRUPTED = "interrupted"` (nat `async_jobs/job_store.py`); cancel route returns `{"status": "interrupted"}` (`frontends/aiq_api/src/aiq_api/routes/jobs.py`).
- SK-2: `_job_escalation_message(kind, job_id)` returns `{"type":"job_escalation","kind":..., "job_id":...}` and is delivered as `AIMessage(content=...)` (`src/aiq_agent/agents/chat_researcher/agent.py`), matching the "escalation embedded in message content" path the helper handles.

New test matrix (`tests/scripts/test_aiq_research_helper.py`, loaded via `importlib` to match the standalone-script tests already in `tests/scripts/`):
- `interrupted` membership in the terminal/failed state sets;
- `poll_until_complete` returns on the first `interrupted` status (one status call, zero sleeps);
- `research_poll` exits failure on `interrupted` without another poll cycle and without fetching a report;
- JSON escalation detected as top-level result and as embedded content;
- `_command_chat` emits `deep_research_running`;
- legacy `Job ID: <uuid>` still detected;
- guards: malformed JSON, non-escalation JSON, unsupported `kind`, missing/invalid/non-string `job_id`, and shallow-answer fall-through.

- [x] I ran the relevant local checks or explained why they are not applicable.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-facing or contributor-facing changes.  <!-- No doc change needed: emitted contract is unchanged, so SKILL.md Steps 2–4 already describe the behavior. -->
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.
- [x] I replaced the DCO sign-off placeholder with my GitHub commit identity and kept the required angle brackets around the email address.

#### Where should reviewers start?

- `skills/aiq-research/scripts/aiq.py`: the state-set change (`_DONE_JOB_STATES` / `_FAILED_JOB_STATES`) and the new `_escalation_job_id` / `_detect_deep_research_escalation` helpers plus the reworked `_command_chat` ordering (JSON escalation first, legacy regex retained).
- `tests/scripts/test_aiq_research_helper.py`: the guard cases confirm no false `deep_research_running` on malformed / non-escalation / unsupported-kind / invalid-`job_id` payloads.

#### Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deep-research escalations are now detected reliably from chat responses.
  * Valid job IDs are reported with a `deep_research_running` status.
  * Interrupted research jobs are treated as terminal failures and stop polling promptly.
  * Invalid or malformed job IDs now safely fall back to displaying the original response.

* **Tests**
  * Added coverage for escalation formats, interrupted jobs, legacy job-ID parsing, and malformed responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->