### PR TITLE
fix(mcp): bump MCP SDK to 1.28.1 for CVE-2026-59950

### DIFF
--- a/mcp/REFERENCE_PARITY.md
+++ b/mcp/REFERENCE_PARITY.md
@@ -11,7 +11,7 @@ specification for compatibility reviews and future changes.
 
 ## Validated baseline
 
-The public implementation validates MCP 1.27.2, NAT Core 1.8.0, and AI-Q 2.0.
+The public implementation validates MCP 1.28.1, NAT Core 1.8.0, and AI-Q 2.0.
 The ordered contract over tool name, input schema, output schema, annotations,
 title, metadata, icons, and execution fields has the frozen SHA-256
 `81eba67fadd56e64b58a84b700b202841f8636c93c6cbf63752507c8bf5ca96a`
@@ -49,7 +49,7 @@ lookup-only synthetic states: not_ready | not_found
 | Authentication and principal | The standalone server has no authentication provider or actor-token propagation. Every call uses the constant `anonymous` principal; the UUID is the bearer capability. Authorization-like headers are ignored. |
 | Malformed or noncanonical capability IDs | The public server requires exact lowercase canonical UUID spelling and returns the same stable `not_found/job_not_found` shape used for unknown UUIDs. |
 | Transport path and health | The public endpoint defaults to configurable `/mcp`, with explicit `/live` and `/health`. The optional standalone SSE GET is rejected with 405. Host/Origin checks are DNS-rebinding/browser safeguards, not identity. |
-| Lifecycle ownership | MCP 1.27.2 is mounted beneath one outer Starlette lifespan that owns the NAT workflow, job manager, and MCP session manager once per worker. Stateless request teardown cannot stop process-owned work. |
+| Lifecycle ownership | MCP 1.28.1 is mounted beneath one outer Starlette lifespan that owns the NAT workflow, job manager, and MCP session manager once per worker. Stateless request teardown cannot stop process-owned work. |
 | Startup and environment | Startup validates the public workflow file and `AIQ_CHECKPOINT_DB`; public model/search credentials are `NVIDIA_API_KEY` and `TAVILY_API_KEY`, while transport settings use the `AIQ_MCP_*` namespace. |
 | Public workflow surface | The default workflow uses public NIM and Tavily configuration. Enterprise integrations and paper search are not part of this standalone profile. |
 | Certificates | No CA bundle or certificate-mount behavior is bundled. Ordinary platform trust and deployment-level TLS termination are outside this component. |
@@ -61,7 +61,7 @@ this document and its golden tests.
 
 ## Compatibility adaptations
 
-- The destination validates `mcp==1.27.2`, `nvidia-nat==1.8.0`, and
+- The destination validates `mcp==1.28.1`, `nvidia-nat==1.8.0`, and
   `nvidia-nat-core==1.8.0`.
 - MCP protocol `2025-11-25` is exercised with the supported
   `streamable_http_client` and `ClientSession`, including stateless

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "aiq-agent>=2.0,<3",
     "asyncpg>=0.29.0",
     "langchain-core>=1.2.0,<2",
-    "mcp==1.27.2",
+    "mcp==1.28.1",
     "msgpack>=1.2.1",
     "nvidia-nat-core==1.8.0",
     "python-dotenv>=1.0,<2",

--- a/mcp/scripts/check_runtime_dependencies.py
+++ b/mcp/scripts/check_runtime_dependencies.py
@@ -37,7 +37,7 @@ _REQUIRED_IMPORTS = (
     "asyncpg",
 )
 _PINNED_RELEASE_VERSIONS = {
-    "mcp": "1.27.2",
+    "mcp": "1.28.1",
     "nvidia-nat-core": "1.8.0",
 }
 _REQUIRED_ENTRY_POINTS = (("nat.plugins", "tavily_web_search"),)

--- a/mcp/tests/test_client_session_integration.py
+++ b/mcp/tests/test_client_session_integration.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Real MCP 1.27.2 client coverage for the complete asynchronous protocol."""
+"""Real MCP 1.28.1 client coverage for the complete asynchronous protocol."""
 
 from __future__ import annotations
 
@@ -306,7 +306,7 @@ async def _exercise_complete_client_flow(
         ):
             assert initialized.protocolVersion == LATEST_PROTOCOL_VERSION == "2025-11-25"
             assert initialized.serverInfo.name == "aiq_deep_research"
-            assert initialized.serverInfo.version == "1.27.2"
+            assert initialized.serverInfo.version == "1.28.1"
             assert initialized.capabilities.tools is not None
             assert initialized.capabilities.tools.listChanged is False
             assert get_submit_session_id() is None

--- a/mcp/tests/test_dependency_compatibility.py
+++ b/mcp/tests/test_dependency_compatibility.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Focused NAT 1.8 and MCP 1.27.2 compatibility contracts."""
+"""Focused NAT 1.8 and MCP 1.28.1 compatibility contracts."""
 
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ _PARITY_DOCUMENT = _REPO_ROOT / "mcp" / "REFERENCE_PARITY.md"
 
 
 def test_runtime_dependency_versions_are_the_validated_compatibility_baseline() -> None:
-    assert version("mcp") == "1.27.2"
+    assert version("mcp") == "1.28.1"
     assert version("nvidia-nat") == "1.8.0"
     assert version("nvidia-nat-core") == "1.8.0"
     assert version("aiq-agent") == "2.0.0"

--- a/mcp/tests/test_runtime_dependencies.py
+++ b/mcp/tests/test_runtime_dependencies.py
@@ -92,7 +92,7 @@ def test_verify_runtime_imports_rejects_release_pin_mismatch(monkeypatch: pytest
         return real_version(name)
 
     monkeypatch.setattr("importlib.metadata.version", fake_version)
-    with pytest.raises(ValueError, match="release pin mismatch: mcp==0.0.0, expected 1.27.2"):
+    with pytest.raises(ValueError, match="release pin mismatch: mcp==0.0.0, expected 1.28.1"):
         verify_runtime_imports()
 
 

--- a/mcp/tests/test_server_runtime.py
+++ b/mcp/tests/test_server_runtime.py
@@ -441,7 +441,7 @@ async def test_fastmcp_settings_and_exact_tool_schemas(tmp_path: Path) -> None:
             }
         )
     serialized_contract = json.dumps(schema_contract, sort_keys=True, separators=(",", ":")).encode()
-    # Frozen public compatibility contract for FastMCP 1.27.2. Descriptions
+    # Frozen public compatibility contract for FastMCP 1.28.1. Descriptions
     # use semantic assertions below so anonymous-capability wording stays clear.
     assert hashlib.sha256(serialized_contract).hexdigest() == (
         "81eba67fadd56e64b58a84b700b202841f8636c93c6cbf63752507c8bf5ca96a"  # pragma: allowlist secret

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -290,7 +290,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28,<1" },
     { name = "langchain-core", specifier = ">=1.2.0,<2" },
     { name = "langgraph", marker = "extra == 'dev'", specifier = ">=1.2,<2" },
-    { name = "mcp", specifier = "==1.27.2" },
+    { name = "mcp", specifier = "==1.28.1" },
     { name = "msgpack", specifier = ">=1.2.1" },
     { name = "nvidia-nat-core", specifier = "==1.8.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
@@ -3010,7 +3010,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.2"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3028,9 +3028,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
#### Overview

The MCP Python SDK 1.27.2 is affected by CVE-2026-59950 (GHSA-vj7q-gjh5-988w): the WebSocket server transport does not validate Host/Origin. Bump the pinned mcp dependency to 1.28.1, which contains the fix, so the MCP dependency vulnerability-audit gate passes.

Update the validated-baseline references that pin the MCP version: the check_runtime_dependencies release pin, the compatibility and runtime-dependency tests, the client-session serverInfo assertion, and REFERENCE_PARITY.md. The frozen FastMCP tool-schema contract hash is unchanged. Only mcp/uv.lock is re-resolved; the root workspace is unaffected.

#### DCO sign-off for the squash commit

<!--
The RAPIDS auto-merger copies this PR description into the generated squash
commit. GitHub may author that commit with a different email than your local
commits. Replace the placeholder below with the exact commit email configured
for your GitHub account. If you keep your email private, copy the
`@users.noreply.github.com` address shown at https://github.com/settings/emails.

If your local/work email differs from your GitHub commit email, you may include
both sign-offs. DCO passes when one sign-off exactly matches the generated
squash commit author:

Signed-off-by: Full Name <work.email@example.com>
Signed-off-by: Full Name <github-email@users.noreply.github.com>

Keep the angle brackets around the email address. They are part of the required
DCO format: `Signed-off-by: Full Name <email@example.com>`.

Do not delete the sign-off line, leave the placeholder unchanged, or remove the
angle brackets.
-->

Signed-off-by: Tanner Leach <tleach@nvidia.com>

#### Validation

<!-- List the exact commands, workflows, screenshots, or manual checks used. -->

- [x] I ran the relevant local checks or explained why they are not applicable.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-facing or contributor-facing changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.
- [x] I replaced the DCO sign-off placeholder with my GitHub commit identity and kept the required angle brackets around the email address.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated the supported MCP baseline to version 1.28.1.
  * Runtime validation now requires MCP 1.28.1.

* **Tests**
  * Updated integration and compatibility checks for MCP 1.28.1.
  * Confirmed server initialization and runtime dependency validation against the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->