### PR TITLE
fix(auth): propagate REST submit token to async workers

### DIFF
--- a/frontends/aiq_api/tests/test_job_submit_data_sources.py
+++ b/frontends/aiq_api/tests/test_job_submit_data_sources.py
@@ -166,6 +166,75 @@ async def test_submit_job_forwards_selected_data_sources(submit_app):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("credential_source", "expected_token"),
+    [
+        pytest.param(
+            "bearer-header",
+            "bearer-token",
+            id="bearer-header",
+        ),
+        pytest.param(
+            "id-token-cookie",
+            "cookie-token",
+            id="id-token-cookie",
+        ),
+    ],
+)
+async def test_submit_job_forwards_authenticated_request_token(
+    submit_app,
+    monkeypatch,
+    credential_source,
+    expected_token,
+):
+    """REST submit captures the validated request token without requiring NAT Context."""
+    import aiq_agent.auth
+    from aiq_agent.auth.utils import get_auth_token as real_get_auth_token
+    from aiq_api.auth.middleware import AuthMiddleware
+
+    class AcceptTokenValidator:
+        def can_handle(self, token: str) -> bool:  # noqa: ARG002 - accepts both test credentials
+            return True
+
+        async def validate(self, token: str):
+            return (
+                {
+                    "type": "jwt",
+                    "sub": "user-1",
+                    "email": "user@example.com",
+                    "name": "Test User",
+                    "token": token,
+                    "skip_clarifier": False,
+                },
+                None,
+            )
+
+    app, submitted_job, _builder = submit_app
+    monkeypatch.setattr(aiq_agent.auth, "get_auth_token", real_get_auth_token)
+    app.add_middleware(
+        AuthMiddleware,
+        validators=[AcceptTokenValidator()],
+        require_auth=True,
+        external_hostnames={"testserver"},
+    )
+
+    with TestClient(app) as client:
+        headers = None
+        if credential_source == "bearer-header":
+            headers = {"Authorization": f"Bearer {expected_token}"}
+        else:
+            client.cookies.set("idToken", expected_token)
+        response = client.post(
+            "/v1/jobs/async/submit",
+            json={"agent_type": "deep_researcher", "input": "query"},
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert submitted_job.await_args.kwargs["auth_token"] == expected_token
+
+
+@pytest.mark.asyncio
 async def test_submit_job_rejects_internal_agent(submit_app, monkeypatch):
     app, submitted_job, _builder = submit_app
     import aiq_api.routes.jobs as jobs_routes

--- a/src/aiq_agent/auth/utils.py
+++ b/src/aiq_agent/auth/utils.py
@@ -21,9 +21,13 @@ raw JWT payload decoding.
 
 Token sources checked in priority order by ``get_auth_token()``:
 
-1. **NAT/AIQ Context cookies** — ``idToken`` cookie set by the frontend auth layer
+1. **Registered token fetchers** — job-scoped sources such as the Dask worker
+   auth context.
+2. **AIQ auth middleware context** — the request token already validated by the
+   configured ``TokenValidator``.
+3. **NAT/AIQ Context cookies** — ``idToken`` cookie set by the frontend auth layer
    (server / web-UI mode).
-2. **NAT/AIQ Context Authorization header** — ``Authorization: Bearer <jwt>`` sent
+4. **NAT/AIQ Context Authorization header** — ``Authorization: Bearer <jwt>`` sent
    by API callers who authenticate with a JWT directly.
 """
 
@@ -152,10 +156,10 @@ def get_auth_token() -> str | None:
 
     Sources checked in order:
 
-    Tries registered token fetchers in priority order (highest first),
-    then falls back to the idToken cookie set by the frontend auth layer.
-    1. NAT ``Context`` cookies — ``idToken`` key (server / web-UI mode).
-    2. NAT ``Context`` Authorization header — ``Bearer <jwt>`` (API callers with JWT).
+    1. Registered token fetchers in priority order (highest first).
+    2. AIQ auth middleware's current request token.
+    3. NAT ``Context`` cookies — ``idToken`` key (server / web-UI mode).
+    4. NAT ``Context`` Authorization header — ``Bearer <jwt>`` (API callers with JWT).
 
     Returns:
         ID token string, or ``None`` if no valid token is available.
@@ -172,7 +176,23 @@ def get_auth_token() -> str | None:
         except Exception as e:
             logger.debug("Registered token fetcher failed: %s", e)
 
-    # Default: Context cookies
+    # Custom AIQ FastAPI routes run under AuthMiddleware but outside a NAT
+    # SessionManager session, so their headers/cookies are not represented in
+    # NAT Context. TokenValidator's contract preserves the validated raw token
+    # in the middleware user context; use that request-scoped value before
+    # falling back to NAT Context.
+    try:
+        from aiq_api.auth.middleware import get_current_user
+
+        current_user = get_current_user()
+        middleware_token = current_user.get("token") if isinstance(current_user, dict) else None
+        if isinstance(middleware_token, str) and middleware_token.strip():
+            logger.debug("Using token from AIQ auth middleware context")
+            return middleware_token.strip()
+    except Exception as e:
+        logger.debug("Failed to retrieve token from AIQ auth middleware context: %s", e)
+
+    # Fall back to NAT Context cookies and headers.
     try:
         from nat.builder.context import Context
 

--- a/src/aiq_agent/auth/utils.py
+++ b/src/aiq_agent/auth/utils.py
@@ -189,8 +189,8 @@ def get_auth_token() -> str | None:
         if isinstance(middleware_token, str) and middleware_token.strip():
             logger.debug("Using token from AIQ auth middleware context")
             return middleware_token.strip()
-    except Exception as e:
-        logger.debug("Failed to retrieve token from AIQ auth middleware context: %s", e)
+    except Exception:
+        logger.debug("Failed to retrieve token from AIQ auth middleware context")
 
     # Fall back to NAT Context cookies and headers.
     try:

--- a/tests/aiq_agent/auth/test_auth_utils.py
+++ b/tests/aiq_agent/auth/test_auth_utils.py
@@ -53,6 +53,25 @@ def test_get_auth_token_default_returns_none():
     assert get_auth_token() is None
 
 
+def test_get_auth_token_uses_middleware_request_token():
+    """Custom FastAPI routes can read the token already validated by AuthMiddleware."""
+    with patch(
+        "aiq_api.auth.middleware.get_current_user",
+        return_value={"type": "jwt", "sub": "user-1", "token": "request-token"},
+    ):
+        assert get_auth_token() == "request-token"
+
+
+def test_registered_token_fetcher_precedes_middleware_request_token():
+    """A worker's job-scoped token remains authoritative over ambient request context."""
+    register_token_fetcher(lambda: "worker-token", priority=5)
+    with patch(
+        "aiq_api.auth.middleware.get_current_user",
+        return_value={"type": "jwt", "sub": "user-1", "token": "request-token"},
+    ):
+        assert get_auth_token() == "worker-token"
+
+
 def test_register_token_fetcher_basic():
     """A registered fetcher that returns a token is used by get_auth_token."""
     register_token_fetcher(lambda: "my-token")


### PR DESCRIPTION
#### Overview

Fix authenticated token propagation for jobs submitted through `POST /v1/jobs/async/submit`.

`AuthMiddleware` validated Bearer and `idToken` credentials, but the custom async-submit route called `get_auth_token()` outside a NAT `SessionManager` request context. The submitter therefore passed `None` to Dask even though the request had an authenticated principal. Authenticated tools in the worker then ran without the submitting user's identity.

This change makes `get_auth_token()` consult the request token already validated and stored by `AuthMiddleware` before falling back to NAT request metadata. Registered token fetchers remain first so each Dask task's job-scoped token stays authoritative. Regression tests exercise the real async-submit route with both Bearer and `idToken` cookie credentials.


#### DCO sign-off for the squash commit

Signed-off-by: Ajay Thorve <athorve@nvidia.com>
Signed-off-by: Ajay Thorve <AjayThorve@users.noreply.github.com>

#### Validation

```text
uv run --frozen pytest -q tests/aiq_agent/auth/test_auth_utils.py frontends/aiq_api/tests/test_job_submit_data_sources.py
43 passed, 1 warning in 1.40s

uv run --frozen ruff check .
All checks passed!

uv run --frozen ruff format --check .
371 files already formatted

uv run --frozen pytest
1803 passed, 13 skipped, 24 warnings in 60.54s
```

- [x] I ran the relevant local checks or explained why they are not applicable.
- [x] I added or updated tests for behavior changes.
- [ ] I updated documentation for user-facing or contributor-facing changes. Existing documentation already specifies the intended async-worker token propagation contract.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.
- [x] I replaced the DCO sign-off placeholder with my GitHub commit identity and kept the required angle brackets around the email address.

#### Where should reviewers start?

Start with `src/aiq_agent/auth/utils.py`, then review `test_submit_job_forwards_authenticated_request_token` for the Bearer and cookie regression coverage at the actual REST submission boundary.

#### Related Issues

- N/A — QA-reported release issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication token handling for asynchronous job submissions.
  - Tokens validated by request authentication are now correctly used when submitting jobs.
  - Established clearer token-precedence behavior across registered token sources, validated request tokens, and fallback credentials.

- **Tests**
  - Added coverage for bearer-token and cookie-based authentication scenarios for async job submission.
  - Added validation that token precedence is honored during token extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->