### PR TITLE
fix(deep-research): require writer-committed final reports

### DIFF
--- a/docs/source/architecture/agents/deep-researcher.md
+++ b/docs/source/architecture/agents/deep-researcher.md
@@ -40,12 +40,10 @@ graph TD
     I --> J[Concurrent reusable researcher workers<br/>one worker per ResearchQuery]
     J --> K[Return structured ResearchNotes<br/>and persist /shared/research_note_*.json]
     K --> L[Normative task: writer-agent]
-    L --> M[Writer reads plan, notes, and captured sources<br/>then writes /shared/output.md]
-    M --> O[Runtime loads writer output]
-    K -.->|Defensive path if writer delegation is missed| S[Orchestrator emits inline Markdown]
-    S --> U{Passes substantive report gate?}
-    U -->|yes| O
-    U -->|no| V[Error: no final Markdown]
+    L --> M[Writer commits /shared/output.md<br/>through the shared-state backend]
+    M --> N{Current bytes match<br/>this run's writer digest?}
+    N -->|yes| O[Runtime loads writer output]
+    N -->|no| V[Error: writer_output_not_committed]
     O --> T{Citation verification enabled?}
     T -->|yes| P[Verify citations against captured sources]
     T -->|no| Q[Skip citation verification]
@@ -90,16 +88,25 @@ sequenceDiagram
     end
     B-->>O: Notes plus /shared/research_note_*.json
     O->>W: task(plan, notes, captured sources)
-    W-->>O: Write /shared/output.md
+    W-->>O: Commit /shared/output.md
     O-->>X: Writer completion marker
+    X->>X: Verify current bytes against the run-local writer digest
     X->>X: Load, optionally verify citations, and sanitize
 ```
 
 The orchestrator serializes dependent stages and tracks progress. It does not
-call source tools directly. The normative flow delegates final synthesis to
-the writer; source access is delegated to the planner and researcher workers.
-If the writer output file is missing, the runtime has a defensive fallback for
-a substantive report emitted inline by the orchestrator.
+call source tools directly. Final synthesis is delegated exclusively to the
+writer; source access is delegated to the planner and researcher workers. A
+non-empty file is not sufficient proof of completion: the runtime accepts the
+report only when its exact UTF-8 bytes match the digest recorded after a
+successful writer mutation in the current run. Missing, stale, or modified
+output fails closed with ``writer_output_not_committed``.
+
+The commit proof is intentionally run-local and is not restored from a
+checkpoint after a process restart. The guarantee is one overwrite-capable
+shared-state backend update followed by byte-exact digest verification; it does
+not claim cross-provider filesystem atomicity. A resumed run without its proof
+therefore fails closed rather than trusting pre-existing output.
 
 ## Runtime Roles
 
@@ -147,11 +154,11 @@ The roles use middleware appropriate to their contracts:
 
 | Role | Relevant behavior |
 | ---- | ----------------- |
-| Orchestrator | DeepAgents task, todo, and filesystem support; source-routing guard; tool-name validation restricted to helpers and `run_research_batch`; tool and model retry handling |
-| Source router | Minimal filesystem and retry middleware; catalog lookup and `write_file` only |
-| Planner | Source capture, retries, filesystem access, todo suppression, structured `ResearchPlan` validation, and automatic plan persistence |
-| Researcher worker | Filesystem context, optional skills, summarization, source capture, retries, and structured `ResearchNotes` validation |
-| Writer | Filesystem context, optional synthesis skills, source-registry access, retries, and todo suppression; no source-search tools |
+| Orchestrator | DeepAgents task, todo, and filesystem support; source-routing and final-report ownership guards; tool-name validation restricted to helpers and `run_research_batch`; tool and model retry handling |
+| Source router | Minimal filesystem and retry middleware; catalog lookup and `write_file` only; final-report mutation denied |
+| Planner | Source capture, retries, filesystem access, todo suppression, structured `ResearchPlan` validation, automatic plan persistence, and final-report mutation denial |
+| Researcher worker | Filesystem context, optional skills, summarization, source capture, retries, structured `ResearchNotes` validation, and final-report mutation denial |
+| Writer | Filesystem context, optional synthesis skills, source-registry access, retries, todo suppression, overwrite-safe `/shared/output.md` commit, and run-local digest verification; no source-search tools |
 
 The root graph is constructed with `create_deep_agent`. The reusable
 researcher runnable is constructed separately with `create_agent`, which is

--- a/docs/source/architecture/agents/deep-researcher.md
+++ b/docs/source/architecture/agents/deep-researcher.md
@@ -295,11 +295,18 @@ edit. The writer performs no new research, writes the complete final answer to
 `/shared/output.md`, and returns a short completion marker. The runtime loads
 the Markdown from that file.
 
-This is the normative synthesis contract. As a defensive compatibility path,
-`_salvage_inline_report()` accepts the orchestrator's final message when the
-output file is missing, but only if the message is substantive Markdown: at
-least 400 characters with a Markdown heading and not merely the writer
-completion marker. Otherwise, missing writer output remains an error.
+This is the only synthesis contract. The runtime accepts only non-empty writer
+output whose exact UTF-8 bytes match the digest recorded after a successful
+writer mutation in the current run. After one bounded corrective turn, missing,
+stale, or mismatched output fails closed with
+``writer_output_not_committed``; inline orchestrator messages are not salvaged
+as final reports.
+
+``/shared/output.md`` is the sole writer-facing path. When
+``CompositeBackend`` routes ``/shared/`` through ``StateBackend``, raw graph
+state may represent that file under the internal route-stripped key
+``/output.md``. Ownership and digest checks recognize that internal alias, but
+agents must not target it directly.
 
 ### Phase 5: Citation Verification (Post-Processing)
 

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -35,6 +35,7 @@ from aiq_agent.common.citation_verification import sanitize_report
 from aiq_agent.common.citation_verification import source_entries_from_parent_context
 from aiq_agent.common.citation_verification import verify_citations
 
+from .custom_middleware import FinalReportCommitTracker
 from .custom_middleware import SourceRegistryMiddleware
 from .deepagents_runtime import DeepAgentsRuntime
 from .deepagents_runtime import DeepResearchSandboxConfig
@@ -53,14 +54,6 @@ PARENT_REPORT_CONTEXT_PATH = "/shared/parent_report_context.json"
 
 # Path to this agent's directory (for loading prompts)
 AGENT_DIR = Path(__file__).parent
-
-# Salvage gate: when the orchestrator synthesizes the report inline instead of delegating to
-# writer-agent, no /shared/output.md is written. We accept the final message as the report only
-# when it is clearly a substantive report (long + has a markdown heading), so workflow chatter is
-# still rejected and the strict file-first contract is preserved.
-_WRITER_COMPLETION_MARKER = "Wrote /shared/output.md"
-_MIN_INLINE_REPORT_CHARS = 400
-_MD_HEADING_RE = re.compile(r"(?m)^#{1,6}\s")
 
 
 class DeepResearcherAgent:
@@ -181,7 +174,12 @@ class DeepResearcherAgent:
 
         return prompts
 
-    def _build_orchestrator_agent(self, state: DeepResearchAgentState) -> Any:
+    def _build_orchestrator_agent(
+        self,
+        state: DeepResearchAgentState,
+        *,
+        final_report_tracker: FinalReportCommitTracker,
+    ) -> Any:
         """Build the orchestrator graph for the current state."""
         return build_deep_research_graph(
             llm_provider=self.llm_provider,
@@ -196,51 +194,25 @@ class DeepResearcherAgent:
             domain_catalog_path=self.domain_catalog_path,
             enable_source_router=self.enable_source_router,
             max_research_concurrency=self.max_research_concurrency,
+            final_report_tracker=final_report_tracker,
         )
 
-    def _extract_final_markdown(self, result: dict | Any, files: dict[str, Any] | None = None) -> str | None:
-        """Extract final Markdown from output files."""
-        output_paths = ("/shared/output.md", "/output.md")
+    def _extract_final_markdown(
+        self,
+        result: dict | Any,
+        files: dict[str, Any] | None = None,
+        *,
+        final_report_tracker: FinalReportCommitTracker,
+    ) -> str | None:
+        """Extract only Markdown committed by the writer during this run."""
         # Resolve result files first, then fall back to the passed-in files (state.files) and
         # finally an empty dict. Without the explicit grouping, `or files or {}` bound only to
-        # the else branch, so a dict result lacking a usable "files" key silently discarded the
-        # fallback and skipped straight to inline salvage even when output files existed.
+        # the else branch, so a dict result lacking a usable "files" key silently discarded
+        # the fallback even when output files existed.
         result_files = result.get("files", None) if isinstance(result, dict) else getattr(result, "files", None)
         files = result_files or files or {}
-        if isinstance(files, dict):
-            for output_path in output_paths:
-                output_entry = files.get(output_path)
-                if isinstance(output_entry, dict):
-                    output_entry = output_entry.get("content")
-                if isinstance(output_entry, bytes):
-                    output_entry = output_entry.decode("utf-8")
-                if isinstance(output_entry, str) and output_entry.strip():
-                    return output_entry.strip()
-        return self._salvage_inline_report(result)
-
-    @staticmethod
-    def _salvage_inline_report(result: dict | Any) -> str | None:
-        """Salvage a report the orchestrator wrote inline instead of via writer-agent.
-
-        When the orchestrator skips the writer-agent delegation and emits the full report in its
-        final message, no output file exists. Accept that message only when it is clearly a
-        substantive report so plain workflow chatter is still rejected.
-        """
-        messages = result.get("messages") if isinstance(result, dict) else getattr(result, "messages", None)
-        if not messages:
-            return None
-        content = getattr(messages[-1], "content", None)
-        if not isinstance(content, str):
-            return None
-        stripped = content.strip()
-        if (
-            not stripped
-            or stripped == _WRITER_COMPLETION_MARKER
-            or len(stripped) < _MIN_INLINE_REPORT_CHARS
-            or not _MD_HEADING_RE.search(stripped)
-        ):
-            return None
-        return stripped
+        committed = final_report_tracker.committed_text(files)
+        return committed.strip() if committed is not None else None
 
     @staticmethod
     def _read_seed_file_text(files: dict[str, Any], path: str) -> str | None:
@@ -281,7 +253,8 @@ class DeepResearcherAgent:
         if prepared_files != state.files:
             state = state.model_copy(update={"files": prepared_files})
         self._seed_parent_sources(state.files)
-        agent = self._build_orchestrator_agent(state)
+        final_report_tracker = FinalReportCommitTracker()
+        agent = self._build_orchestrator_agent(state, final_report_tracker=final_report_tracker)
 
         messages = state.messages
         if messages:
@@ -295,9 +268,13 @@ class DeepResearcherAgent:
         try:
             result = await agent.ainvoke(state, config={"callbacks": self.callbacks} if self.callbacks else None)
 
-            final_message = self._extract_final_markdown(result, state.files)
+            final_message = self._extract_final_markdown(
+                result,
+                state.files,
+                final_report_tracker=final_report_tracker,
+            )
             if final_message is None:
-                raise ValueError("writer-agent did not produce a final Markdown answer")
+                raise RuntimeError("writer_output_not_committed")
 
             # Post-process: verify citations against source registry
             if self.enable_citation_verification and self.source_registry_middleware.has_sources():

--- a/src/aiq_agent/agents/deep_researcher/custom_middleware.py
+++ b/src/aiq_agent/agents/deep_researcher/custom_middleware.py
@@ -16,9 +16,12 @@
 """Custom middleware for the deep research agent."""
 
 import asyncio
+import hashlib
 import json
 import logging
+import posixpath
 import re
+import threading
 from pathlib import Path
 from pathlib import PurePosixPath
 
@@ -47,9 +50,90 @@ _SOURCE_ROUTING_PATH = "/shared/source_routing.json"
 # route-local key. The guard reads raw state, so it must accept both forms or it
 # blocks the orchestrator forever on sandboxed runs.
 _SOURCE_ROUTING_STATE_KEYS = (_SOURCE_ROUTING_PATH, "/source_routing.json")
+FINAL_REPORT_PATH = "/shared/output.md"
+FINAL_REPORT_STATE_PATHS = (FINAL_REPORT_PATH, "/output.md")
 _UNRESOLVED_SANDBOX_PATH_PATTERN = re.compile(
     r"<\s*sandbox_(?:artifact_dir|workdir)\s*>|\{\{\s*sandbox_(?:artifact_dir|workdir)\s*\}\}"
 )
+
+
+def _normalized_virtual_path(path: object) -> str | None:
+    """Return a canonical virtual path without weakening backend validation."""
+    if not isinstance(path, str) or not path:
+        return None
+    normalized = posixpath.normpath(path.replace("\\", "/"))
+    return normalized if normalized.startswith("/") else f"/{normalized}"
+
+
+def _tool_file_path(tool_call: object) -> str | None:
+    """Read and normalize a filesystem tool's target path."""
+    if not isinstance(tool_call, dict):
+        return None
+    args = tool_call.get("args")
+    if not isinstance(args, dict):
+        return None
+    return _normalized_virtual_path(args.get("file_path", args.get("path")))
+
+
+def _entry_text(entry: object) -> str | None:
+    """Read exact text from a DeepAgents state-file entry."""
+    if isinstance(entry, dict):
+        entry = entry.get("content")
+    if isinstance(entry, bytes):
+        try:
+            return entry.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+    if isinstance(entry, str):
+        return entry
+    return None
+
+
+def _tool_result_failed(result: object) -> bool:
+    """Return whether a filesystem tool result reports an error."""
+    status = result.get("status") if isinstance(result, dict) else getattr(result, "status", None)
+    return status == "error"
+
+
+class FinalReportCommitTracker:
+    """Run-local proof of the writer's most recent successful report mutation."""
+
+    def __init__(self) -> None:
+        self._digest: str | None = None
+        self._lock = threading.Lock()
+
+    @staticmethod
+    def _digest_text(content: str) -> str:
+        return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+    def record(self, content: str) -> str:
+        """Record the exact UTF-8 digest after a successful writer mutation."""
+        digest = self._digest_text(content)
+        with self._lock:
+            self._digest = digest
+        return digest
+
+    @property
+    def digest(self) -> str | None:
+        """Return the most recently committed digest for this run."""
+        with self._lock:
+            return self._digest
+
+    def committed_text(
+        self,
+        files: object,
+        *,
+        paths: tuple[str, ...] = FINAL_REPORT_STATE_PATHS,
+    ) -> str | None:
+        """Return the non-empty state file matching the writer's exact digest."""
+        digest = self.digest
+        if digest is None or not isinstance(files, dict):
+            return None
+        for path in paths:
+            content = _entry_text(files.get(path))
+            if content is not None and content.strip() and self._digest_text(content) == digest:
+                return content
+        return None
 
 
 class SourceRoutingGuardMiddleware(AgentMiddleware):
@@ -199,6 +283,124 @@ class FilesystemToolCallGuardMiddleware(AgentMiddleware):
         return await handler(request)
 
 
+class FinalReportOwnershipGuardMiddleware(AgentMiddleware):
+    """Reserve final-report mutation for the writer role."""
+
+    async def awrap_tool_call(self, request, handler):
+        """Reject non-writer mutations of either final-report state path."""
+        tool_call = request.tool_call if isinstance(getattr(request, "tool_call", None), dict) else {}
+        if tool_call.get("name") not in {"write_file", "edit_file"}:
+            return await handler(request)
+        if _tool_file_path(tool_call) not in FINAL_REPORT_STATE_PATHS:
+            return await handler(request)
+        return ToolMessage(
+            content=(
+                "final_report_writer_only: only writer-agent may write or edit "
+                f"{FINAL_REPORT_PATH}; hand off evidence through the normal research workflow."
+            ),
+            tool_call_id=tool_call.get("id", "final-report-ownership"),
+            name=tool_call.get("name"),
+            status="error",
+        )
+
+
+class FinalReportCommitMiddleware(AgentMiddleware):
+    """Commit writer-owned output with overwrite and exact-digest verification."""
+
+    def __init__(self, *, backend: object, tracker: FinalReportCommitTracker) -> None:
+        self.backend = backend
+        self.tracker = tracker
+        self._mutation_lock = asyncio.Lock()
+
+    @staticmethod
+    def _tool_error(tool_call: dict[str, object], reason: str, guidance: str) -> ToolMessage:
+        return ToolMessage(
+            content=f"{reason}: {guidance}",
+            tool_call_id=tool_call.get("id", "final-report-commit"),
+            name=tool_call.get("name"),
+            status="error",
+        )
+
+    @staticmethod
+    def _response_error(response: object) -> object:
+        return response.get("error") if isinstance(response, dict) else getattr(response, "error", None)
+
+    async def _commit_write(self, tool_call: dict[str, object]) -> ToolMessage:
+        args = tool_call.get("args")
+        content = args.get("content") if isinstance(args, dict) else None
+        if not isinstance(content, str):
+            return self._tool_error(tool_call, "writer_output_commit_failed", "report content must be text")
+        try:
+            responses = await self.backend.aupload_files([(FINAL_REPORT_PATH, content.encode("utf-8"))])
+        except Exception as exc:  # noqa: BLE001 - return a stable, sanitized tool error
+            logger.warning("Writer final-report commit failed (%s)", type(exc).__name__)
+            return self._tool_error(tool_call, "writer_output_commit_failed", "the backend rejected the write")
+        if not isinstance(responses, list) or len(responses) != 1 or self._response_error(responses[0]):
+            logger.warning("Writer final-report commit returned an unsuccessful upload response")
+            return self._tool_error(tool_call, "writer_output_commit_failed", "the backend rejected the write")
+        self.tracker.record(content)
+        return ToolMessage(
+            content=f"Updated file {FINAL_REPORT_PATH}",
+            tool_call_id=tool_call.get("id", "final-report-commit"),
+            name="write_file",
+            status="success",
+        )
+
+    async def _refresh_after_edit(self, tool_call: dict[str, object], result: object) -> object:
+        if _tool_result_failed(result):
+            return result
+        try:
+            responses = await self.backend.adownload_files([FINAL_REPORT_PATH])
+        except Exception as exc:  # noqa: BLE001 - return a stable, sanitized tool error
+            logger.warning("Writer final-report verification failed (%s)", type(exc).__name__)
+            return self._tool_error(
+                tool_call,
+                "writer_output_commit_failed",
+                "the edited report could not be verified",
+            )
+        response = responses[0] if isinstance(responses, list) and len(responses) == 1 else None
+        content = response.get("content") if isinstance(response, dict) else getattr(response, "content", None)
+        if response is None or self._response_error(response) or not isinstance(content, bytes):
+            logger.warning("Writer final-report verification returned an unsuccessful download response")
+            return self._tool_error(
+                tool_call,
+                "writer_output_commit_failed",
+                "the edited report could not be verified",
+            )
+        try:
+            text = content.decode("utf-8")
+        except UnicodeDecodeError:
+            return self._tool_error(tool_call, "writer_output_commit_failed", "the edited report is not UTF-8")
+        self.tracker.record(text)
+        return result
+
+    async def awrap_tool_call(self, request, handler):
+        """Upsert writer output and track successful writes or edits only."""
+        tool_call = request.tool_call if isinstance(getattr(request, "tool_call", None), dict) else {}
+        tool_name = tool_call.get("name")
+        if tool_name not in {"write_file", "edit_file"}:
+            return await handler(request)
+        target = _tool_file_path(tool_call)
+        if target not in FINAL_REPORT_STATE_PATHS:
+            return await handler(request)
+        if target != FINAL_REPORT_PATH:
+            return self._tool_error(
+                tool_call,
+                "writer_output_path_invalid",
+                f"write the final report to {FINAL_REPORT_PATH}",
+            )
+
+        async with self._mutation_lock:
+            if tool_name == "write_file":
+                return await self._commit_write(tool_call)
+            try:
+                result = await handler(request)
+            except Exception as exc:  # noqa: BLE001 - return a stable, sanitized tool error
+                logger.warning("Writer final-report edit failed (%s)", type(exc).__name__)
+                return self._tool_error(tool_call, "writer_output_commit_failed", "the backend rejected the edit")
+            return await self._refresh_after_edit(tool_call, result)
+
+
 class RequiredOutputFileMiddleware(AgentMiddleware):
     """Verify a model's file-backed completion marker before ending its run.
 
@@ -210,22 +412,25 @@ class RequiredOutputFileMiddleware(AgentMiddleware):
     def __init__(
         self,
         *,
-        paths: tuple[str, ...] = ("/shared/output.md", "/output.md"),
+        tracker: FinalReportCommitTracker,
+        paths: tuple[str, ...] = FINAL_REPORT_STATE_PATHS,
         completion_marker: str = "Wrote /shared/output.md",
         max_retries: int = 1,
-        reason_code: str = "writer_output_missing",
+        reason_code: str = "writer_output_not_committed",
     ) -> None:
         """Configure the accepted state paths and bounded corrective turns."""
         if not paths:
             raise ValueError("paths must not be empty")
         if max_retries < 0:
             raise ValueError("max_retries must be non-negative")
+        self.tracker = tracker
         self.paths = paths
         self.completion_marker = completion_marker
         self.max_retries = max_retries
         self.reason_code = reason_code
         self._retry_message = (
-            "The required final output file is missing or empty. Do not repeat research or regenerate artifacts. "
+            "The final report is missing, empty, or was not committed by this writer run. "
+            "Do not repeat research or regenerate artifacts. "
             f"Call write_file with file_path={paths[0]} and the complete final Markdown, confirm the tool "
             f"succeeds, and only then return `{completion_marker}`."
         )
@@ -234,21 +439,9 @@ class RequiredOutputFileMiddleware(AgentMiddleware):
     def _files_from_state(state: object) -> object:
         return state.get("files", {}) if isinstance(state, dict) else getattr(state, "files", {})
 
-    @staticmethod
-    def _entry_has_content(entry: object) -> bool:
-        if isinstance(entry, dict):
-            entry = entry.get("content")
-        if isinstance(entry, bytes):
-            return bool(entry.strip())
-        if isinstance(entry, str):
-            return bool(entry.strip())
-        if isinstance(entry, list):
-            return any(isinstance(line, str) and line.strip() for line in entry)
-        return False
-
-    def _required_output_exists(self, state: object) -> bool:
+    def _required_output_is_committed(self, state: object) -> bool:
         files = self._files_from_state(state)
-        return isinstance(files, dict) and any(self._entry_has_content(files.get(path)) for path in self.paths)
+        return self.tracker.committed_text(files, paths=self.paths) is not None
 
     def _retry_count(self, messages: list[object]) -> int:
         return sum(isinstance(message, HumanMessage) and message.content == self._retry_message for message in messages)
@@ -262,16 +455,14 @@ class RequiredOutputFileMiddleware(AgentMiddleware):
             return None
         if last_message.text.strip() != self.completion_marker:
             return None
-        if self._required_output_exists(state):
+        if self._required_output_is_committed(state):
             return None
 
         retry_count = self._retry_count(messages)
         if retry_count >= self.max_retries:
             raise RuntimeError(self.reason_code)
 
-        logger.warning(
-            "Agent reported file-backed completion before the required output existed; requesting corrective turn"
-        )
+        logger.warning("Agent reported completion before committing the required output; requesting corrective turn")
         return {
             "messages": [HumanMessage(content=self._retry_message)],
             "jump_to": "model",

--- a/src/aiq_agent/agents/deep_researcher/factory.py
+++ b/src/aiq_agent/agents/deep_researcher/factory.py
@@ -45,6 +45,9 @@ from .custom_middleware import ArtifactHarvestMiddleware
 from .custom_middleware import EmptyContentFixMiddleware
 from .custom_middleware import ExecuteTimeoutClampMiddleware
 from .custom_middleware import FilesystemToolCallGuardMiddleware
+from .custom_middleware import FinalReportCommitMiddleware
+from .custom_middleware import FinalReportCommitTracker
+from .custom_middleware import FinalReportOwnershipGuardMiddleware
 from .custom_middleware import PlanPersistenceMiddleware
 from .custom_middleware import RequiredOutputFileMiddleware
 from .custom_middleware import SourceRegistryMiddleware
@@ -133,6 +136,7 @@ class DeepResearchGraphContext:
     enable_source_router: bool
     backend: Any
     visibility_middleware: list[Any]
+    final_report_tracker: FinalReportCommitTracker
 
     @property
     def available_documents(self) -> list[dict[str, Any]]:
@@ -428,7 +432,10 @@ def build_deep_research_subagents(context: DeepResearchGraphContext) -> list[dic
                 prompt_name="source_router",
                 role=LLMRole.ROUTER,
                 tools=[source_catalog_tool],
-                middleware=build_source_router_middleware(extra_valid_tool_names=[source_catalog_tool.name]),
+                middleware=[
+                    *build_source_router_middleware(extra_valid_tool_names=[source_catalog_tool.name]),
+                    FinalReportOwnershipGuardMiddleware(),
+                ],
                 prompt_values={"clarifier_result": context.state.clarifier_result},
             )
         )
@@ -446,6 +453,7 @@ def build_deep_research_subagents(context: DeepResearchGraphContext) -> list[dic
             tools=context.tool_set.researcher_tools,
             middleware=[
                 *context.middleware_set.planner,
+                FinalReportOwnershipGuardMiddleware(),
                 TodoSuppressionMiddleware(),
                 PlanPersistenceMiddleware(backend=context.backend),
             ],
@@ -470,8 +478,12 @@ def build_deep_research_subagents(context: DeepResearchGraphContext) -> list[dic
             tools=context.tool_set.writer_tools,
             middleware=[
                 *context.middleware_set.writer,
+                FinalReportCommitMiddleware(
+                    backend=context.backend,
+                    tracker=context.final_report_tracker,
+                ),
                 TodoSuppressionMiddleware(),
-                RequiredOutputFileMiddleware(),
+                RequiredOutputFileMiddleware(tracker=context.final_report_tracker),
             ],
             prompt_values={"parent_report_context_available": context.parent_report_context_available},
             skills=context.skill_sources(WRITER_AGENT),
@@ -493,6 +505,7 @@ def build_deep_research_graph(
     callbacks: list[Any],
     domain_catalog_path: str | None,
     max_research_concurrency: int,
+    final_report_tracker: FinalReportCommitTracker,
     enable_source_router: bool = True,
 ) -> Any:
     """Build the full DeepAgents graph for one deep research run."""
@@ -524,6 +537,7 @@ def build_deep_research_graph(
         enable_source_router=enable_source_router,
         backend=runtime.backend,
         visibility_middleware=cross_cutting_middleware,
+        final_report_tracker=final_report_tracker,
     )
     researcher_model = context.llm_provider.get(LLMRole.RESEARCHER)
     researcher_skill_sources = context.skill_sources(RESEARCHER_AGENT)
@@ -535,7 +549,10 @@ def build_deep_research_graph(
             tools=context.tool_set.tools_info,
             execution_enabled=context.runtime.execution_enabled,
         ),
-        researcher_middleware=context.middleware_set.researcher,
+        researcher_middleware=[
+            *context.middleware_set.researcher,
+            FinalReportOwnershipGuardMiddleware(),
+        ],
         skill_sources=researcher_skill_sources,
         backend=context.backend,
         visibility_middleware=context.visibility_middleware,
@@ -571,7 +588,12 @@ def build_deep_research_graph(
         ),
         subagents=build_deep_research_subagents(context),
         store=InMemoryStore(),
-        middleware=context.middleware(context.middleware_set.orchestrator),
+        middleware=context.middleware(
+            [
+                *context.middleware_set.orchestrator,
+                FinalReportOwnershipGuardMiddleware(),
+            ]
+        ),
         permissions=context.permissions(ORCHESTRATOR_AGENT),
         backend=context.backend,
     )

--- a/tests/aiq_agent/agents/deep_researcher/test_agent.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_agent.py
@@ -32,6 +32,7 @@ from langchain_core.messages import ToolMessage
 from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import tool
 
+from aiq_agent.agents.deep_researcher.custom_middleware import FinalReportCommitTracker
 from aiq_agent.agents.deep_researcher.models import DeepResearchAgentState
 from aiq_agent.agents.deep_researcher.models import ResearchNotes
 from aiq_agent.agents.deep_researcher.models import ResearchPlan
@@ -51,14 +52,24 @@ def web_search_tool(query: str) -> str:
     return f"Results for: {query}"
 
 
+DEFAULT_REPORT = "Deep research answer [1].\n\n## Sources\n[1] Example: https://example.com"
+
+
 def output_markdown_file(markdown: str | None = None) -> dict:
     """Return virtual filesystem content for /shared/output.md."""
     return {
         "/shared/output.md": {
-            "content": markdown or "Deep research answer [1].\n\n## Sources\n[1] Example: https://example.com",
+            "content": markdown or DEFAULT_REPORT,
             "encoding": "utf-8",
         }
     }
+
+
+def committed_tracker(markdown: str) -> FinalReportCommitTracker:
+    """Return a run-local tracker committed to the exact test report."""
+    tracker = FinalReportCommitTracker()
+    tracker.record(markdown)
+    return tracker
 
 
 @pytest.fixture(autouse=True)
@@ -410,7 +421,7 @@ class TestDeepResearcherAgent:
             )
             state = DeepResearchAgentState(messages=[HumanMessage(content="Compare revenue growth")])
 
-            agent._build_orchestrator_agent(state)
+            agent._build_orchestrator_agent(state, final_report_tracker=FinalReportCommitTracker())
 
             assert create.call_count == 1
             assert create_researcher.call_count == 1
@@ -480,7 +491,7 @@ class TestDeepResearcherAgent:
             agent = DeepResearcherAgent(llm_provider=mock_llm_provider, tools=[real_tool])
             state = DeepResearchAgentState(messages=[HumanMessage(content="Compare CUDA vs OpenCL")])
 
-            agent._build_orchestrator_agent(state)
+            agent._build_orchestrator_agent(state, final_report_tracker=FinalReportCommitTracker())
 
             assert create.call_count == 1
             assert create_researcher.call_count == 1
@@ -549,7 +560,7 @@ class TestDeepResearcherAgent:
             )
             state = DeepResearchAgentState(messages=[HumanMessage(content="Compare CUDA vs OpenCL")])
 
-            agent._build_orchestrator_agent(state)
+            agent._build_orchestrator_agent(state, final_report_tracker=FinalReportCommitTracker())
 
             kwargs = create.call_args.kwargs
             subagents = {subagent["name"]: subagent for subagent in kwargs["subagents"]}
@@ -1107,7 +1118,13 @@ class TestDeepResearcherAgent:
     @pytest.mark.asyncio
     async def test_provider_roles_used_on_init(self, mock_llm_provider, real_tool, mock_create_deep_agent):
         """Test LLM roles (planner, researcher, orchestrator) are requested when run() is invoked."""
-        with patch("aiq_agent.agents.deep_researcher.factory.create_deep_agent", return_value=mock_create_deep_agent):
+        with (
+            patch("aiq_agent.agents.deep_researcher.factory.create_deep_agent", return_value=mock_create_deep_agent),
+            patch(
+                "aiq_agent.agents.deep_researcher.agent.FinalReportCommitTracker",
+                return_value=committed_tracker(DEFAULT_REPORT),
+            ),
+        ):
             from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
 
             agent = DeepResearcherAgent(
@@ -1129,7 +1146,13 @@ class TestDeepResearcherAgent:
     @pytest.mark.asyncio
     async def test_run_basic_query(self, mock_llm_provider, real_tool, mock_create_deep_agent):
         """Test run() with a basic query."""
-        with patch("aiq_agent.agents.deep_researcher.factory.create_deep_agent", return_value=mock_create_deep_agent):
+        with (
+            patch("aiq_agent.agents.deep_researcher.factory.create_deep_agent", return_value=mock_create_deep_agent),
+            patch(
+                "aiq_agent.agents.deep_researcher.agent.FinalReportCommitTracker",
+                return_value=committed_tracker(DEFAULT_REPORT),
+            ),
+        ):
             from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
 
             agent = DeepResearcherAgent(
@@ -1149,7 +1172,13 @@ class TestDeepResearcherAgent:
     @pytest.mark.asyncio
     async def test_run_empty_messages(self, mock_llm_provider, real_tool, mock_create_deep_agent):
         """Test run() with empty messages."""
-        with patch("aiq_agent.agents.deep_researcher.factory.create_deep_agent", return_value=mock_create_deep_agent):
+        with (
+            patch("aiq_agent.agents.deep_researcher.factory.create_deep_agent", return_value=mock_create_deep_agent),
+            patch(
+                "aiq_agent.agents.deep_researcher.agent.FinalReportCommitTracker",
+                return_value=committed_tracker(DEFAULT_REPORT),
+            ),
+        ):
             from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
 
             agent = DeepResearcherAgent(
@@ -1167,7 +1196,13 @@ class TestDeepResearcherAgent:
     @pytest.mark.asyncio
     async def test_run_with_callbacks(self, mock_llm_provider, real_tool, mock_create_deep_agent):
         """Test run() uses callbacks."""
-        with patch("aiq_agent.agents.deep_researcher.factory.create_deep_agent", return_value=mock_create_deep_agent):
+        with (
+            patch("aiq_agent.agents.deep_researcher.factory.create_deep_agent", return_value=mock_create_deep_agent),
+            patch(
+                "aiq_agent.agents.deep_researcher.agent.FinalReportCommitTracker",
+                return_value=committed_tracker(DEFAULT_REPORT),
+            ),
+        ):
             from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
 
             mock_callback = MagicMock()
@@ -1193,7 +1228,13 @@ class TestDeepResearcherAgent:
         mock_agent.with_config = MagicMock(return_value=mock_agent)
         mock_agent.ainvoke = AsyncMock(side_effect=Exception("Agent error"))
 
-        with patch("aiq_agent.agents.deep_researcher.factory.create_deep_agent", return_value=mock_agent):
+        with (
+            patch("aiq_agent.agents.deep_researcher.factory.create_deep_agent", return_value=mock_agent),
+            patch(
+                "aiq_agent.agents.deep_researcher.agent.FinalReportCommitTracker",
+                return_value=committed_tracker(DEFAULT_REPORT),
+            ),
+        ):
             from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
 
             agent = DeepResearcherAgent(
@@ -1214,7 +1255,13 @@ class TestDeepResearcherAgent:
         mock_agent.with_config = MagicMock(return_value=mock_agent)
         mock_agent.ainvoke = AsyncMock(return_value={"messages": [], "files": output_markdown_file()})
 
-        with patch("aiq_agent.agents.deep_researcher.factory.create_deep_agent", return_value=mock_agent):
+        with (
+            patch("aiq_agent.agents.deep_researcher.factory.create_deep_agent", return_value=mock_agent),
+            patch(
+                "aiq_agent.agents.deep_researcher.agent.FinalReportCommitTracker",
+                return_value=committed_tracker(DEFAULT_REPORT),
+            ),
+        ):
             from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
 
             agent = DeepResearcherAgent(
@@ -1249,7 +1296,14 @@ class TestDeepResearcherAgent:
             }
         )
 
-        with patch("aiq_agent.agents.deep_researcher.factory.create_deep_agent", return_value=mock_agent):
+        writer_report = "Writer markdown [1].\n\n## Sources\n[1] Example: https://example.com"
+        with (
+            patch("aiq_agent.agents.deep_researcher.factory.create_deep_agent", return_value=mock_agent),
+            patch(
+                "aiq_agent.agents.deep_researcher.agent.FinalReportCommitTracker",
+                return_value=committed_tracker(writer_report),
+            ),
+        ):
             from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
 
             agent = DeepResearcherAgent(
@@ -1306,7 +1360,10 @@ class TestFinalMarkdownExtraction:
             fake_backend = MagicMock()
             agent.deepagents_runtime._backend = fake_backend
 
-            output = agent._extract_final_markdown({"messages": [AIMessage(content="done")], "files": {}})
+            output = agent._extract_final_markdown(
+                {"messages": [AIMessage(content="done")], "files": {}},
+                final_report_tracker=FinalReportCommitTracker(),
+            )
 
             assert output is None
             fake_backend.download_files.assert_not_called()
@@ -1325,7 +1382,8 @@ class TestFinalMarkdownExtraction:
                 {
                     "messages": [AIMessage(content="done")],
                     "files": {"/shared/output.md": {"content": report}},
-                }
+                },
+                final_report_tracker=committed_tracker(report),
             )
 
             assert output == report
@@ -1346,13 +1404,18 @@ class TestFinalMarkdownExtraction:
                         AIMessage(content="Let's call get_verified_sources now."),
                     ],
                     "files": {},
-                }
+                },
+                final_report_tracker=FinalReportCommitTracker(),
             )
 
             assert output is None
 
-    def test_extract_final_markdown_salvages_substantive_inline_report(self, mock_llm_provider, real_tool):
-        """A substantive report emitted inline (no output file) is salvaged, unlike plain chatter."""
+    def test_extract_final_markdown_rejects_substantive_inline_non_writer_report(
+        self,
+        mock_llm_provider,
+        real_tool,
+    ):
+        """Substantive orchestrator prose cannot bypass writer ownership."""
         with patch(
             "aiq_agent.agents.deep_researcher.factory.create_deep_agent",
             return_value=MagicMock(),
@@ -1365,9 +1428,12 @@ class TestFinalMarkdownExtraction:
                 + "NVIDIA and Samsung capital expenditure analysis across quarters. " * 12
                 + "\n\n## Sources\n[1] Example: https://example.com"
             )
-            output = agent._extract_final_markdown({"messages": [AIMessage(content=report)], "files": {}})
+            output = agent._extract_final_markdown(
+                {"messages": [AIMessage(content=report)], "files": {}},
+                final_report_tracker=FinalReportCommitTracker(),
+            )
 
-            assert output == report.strip()
+            assert output is None
 
     def test_extract_final_markdown_rejects_writer_completion_marker(self, mock_llm_provider, real_tool):
         """The short writer completion marker is never salvaged as the report."""
@@ -1379,7 +1445,27 @@ class TestFinalMarkdownExtraction:
 
             agent = DeepResearcherAgent(llm_provider=mock_llm_provider, tools=[real_tool])
             output = agent._extract_final_markdown(
-                {"messages": [AIMessage(content="Wrote /shared/output.md")], "files": {}}
+                {"messages": [AIMessage(content="Wrote /shared/output.md")], "files": {}},
+                final_report_tracker=FinalReportCommitTracker(),
+            )
+
+            assert output is None
+
+    def test_extract_final_markdown_rejects_uncommitted_stale_file(self, mock_llm_provider, real_tool):
+        """A pre-existing planner file is never accepted without a current writer mutation."""
+        with patch(
+            "aiq_agent.agents.deep_researcher.factory.create_deep_agent",
+            return_value=MagicMock(),
+        ):
+            from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
+
+            agent = DeepResearcherAgent(llm_provider=mock_llm_provider, tools=[real_tool])
+            output = agent._extract_final_markdown(
+                {
+                    "messages": [AIMessage(content="Wrote /shared/output.md")],
+                    "files": {"/shared/output.md": {"content": "# Planner prose"}},
+                },
+                final_report_tracker=FinalReportCommitTracker(),
             )
 
             assert output is None
@@ -1410,12 +1496,12 @@ class TestFinalMarkdownExtraction:
             agent.source_registry_middleware.registry.add(SourceEntry(url="https://example.com"))
 
             state = DeepResearchAgentState(messages=[HumanMessage(content="Write a report")])
-            with pytest.raises(ValueError, match="writer-agent did not produce a final Markdown answer"):
+            with pytest.raises(RuntimeError, match="^writer_output_not_committed$"):
                 await agent.run(state)
 
     @pytest.mark.asyncio
-    async def test_run_salvages_inline_report_when_writer_output_missing(self, mock_llm_provider, real_tool):
-        """A substantive inline report is salvaged into the final message when no output file exists."""
+    async def test_run_rejects_inline_report_when_writer_output_missing(self, mock_llm_provider, real_tool):
+        """Substantive orchestrator prose cannot replace a writer commit."""
         report = (
             "# CapEx Report\n\n"
             + "Detailed multi-quarter capital expenditure narrative for the comparison [1]. " * 12
@@ -1440,9 +1526,8 @@ class TestFinalMarkdownExtraction:
             agent.source_registry_middleware.registry.add(SourceEntry(url="https://example.com"))
 
             state = DeepResearchAgentState(messages=[HumanMessage(content="Original query")])
-            result = await agent.run(state)
-
-            assert "# CapEx Report" in result.messages[-1].content
+            with pytest.raises(RuntimeError, match="^writer_output_not_committed$"):
+                await agent.run(state)
 
     @pytest.mark.asyncio
     async def test_run_seeds_parent_sources_for_delta_citation_verification(
@@ -1477,9 +1562,15 @@ class TestFinalMarkdownExtraction:
             }
         )
 
-        with patch(
-            "aiq_agent.agents.deep_researcher.factory.create_deep_agent",
-            return_value=mock_agent,
+        with (
+            patch(
+                "aiq_agent.agents.deep_researcher.factory.create_deep_agent",
+                return_value=mock_agent,
+            ),
+            patch(
+                "aiq_agent.agents.deep_researcher.agent.FinalReportCommitTracker",
+                return_value=committed_tracker(report),
+            ),
         ):
             from aiq_agent.agents.deep_researcher.agent import DeepResearcherAgent
 
@@ -1538,9 +1629,15 @@ class TestDeepResearcherCitationVerification:
         mock_agent.with_config = MagicMock(return_value=mock_agent)
         mock_agent.ainvoke = AsyncMock(return_value=deep_result)
 
-        with patch(
-            "aiq_agent.agents.deep_researcher.factory.create_deep_agent",
-            return_value=mock_agent,
+        with (
+            patch(
+                "aiq_agent.agents.deep_researcher.factory.create_deep_agent",
+                return_value=mock_agent,
+            ),
+            patch(
+                "aiq_agent.agents.deep_researcher.agent.FinalReportCommitTracker",
+                return_value=committed_tracker(report),
+            ),
         ):
             agent = DeepResearcherAgent(llm_provider=mock_llm_provider, tools=[real_tool])
 
@@ -1595,9 +1692,15 @@ class TestDeepResearcherCitationVerification:
         mock_agent.with_config = MagicMock(return_value=mock_agent)
         mock_agent.ainvoke = AsyncMock(return_value=deep_result)
 
-        with patch(
-            "aiq_agent.agents.deep_researcher.factory.create_deep_agent",
-            return_value=mock_agent,
+        with (
+            patch(
+                "aiq_agent.agents.deep_researcher.factory.create_deep_agent",
+                return_value=mock_agent,
+            ),
+            patch(
+                "aiq_agent.agents.deep_researcher.agent.FinalReportCommitTracker",
+                return_value=committed_tracker(raw_answer),
+            ),
         ):
             agent = DeepResearcherAgent(llm_provider=mock_llm_provider, tools=[real_tool])
             agent.source_registry_middleware.registry.add(

--- a/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_custom_middleware.py
@@ -34,6 +34,9 @@ from langchain_core.messages import ToolMessage
 from aiq_agent.agents.deep_researcher.custom_middleware import ArtifactHarvestMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import ExecuteTimeoutClampMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import FilesystemToolCallGuardMiddleware
+from aiq_agent.agents.deep_researcher.custom_middleware import FinalReportCommitMiddleware
+from aiq_agent.agents.deep_researcher.custom_middleware import FinalReportCommitTracker
+from aiq_agent.agents.deep_researcher.custom_middleware import FinalReportOwnershipGuardMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import PlanPersistenceMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import RequiredOutputFileMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import SourceRegistryMiddleware
@@ -278,8 +281,189 @@ class TestFilesystemToolCallGuardMiddleware:
         handler.assert_awaited_once_with(request)
 
 
+class TestFinalReportOwnershipGuardMiddleware:
+    """Only the writer may mutate an accepted final-report path."""
+
+    @staticmethod
+    def _request(tool_name: str, path: str) -> MagicMock:
+        request = MagicMock()
+        request.tool_call = {"name": tool_name, "args": {"file_path": path}, "id": "tc1"}
+        return request
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tool_name", ["write_file", "edit_file"])
+    @pytest.mark.parametrize("path", ["/shared/output.md", "/output.md", "/shared/./output.md"])
+    async def test_rejects_final_report_mutation(self, tool_name: str, path: str) -> None:
+        middleware = FinalReportOwnershipGuardMiddleware()
+        handler = AsyncMock()
+
+        result = await middleware.awrap_tool_call(self._request(tool_name, path), handler)
+
+        handler.assert_not_awaited()
+        assert result.status == "error"
+        assert str(result.content).startswith("final_report_writer_only:")
+
+    @pytest.mark.asyncio
+    async def test_allows_unrelated_file_mutation(self) -> None:
+        middleware = FinalReportOwnershipGuardMiddleware()
+        request = self._request("write_file", "/shared/plan.md")
+        expected = ToolMessage(content="ok", tool_call_id="tc1")
+        handler = AsyncMock(return_value=expected)
+
+        result = await middleware.awrap_tool_call(request, handler)
+
+        assert result is expected
+        handler.assert_awaited_once_with(request)
+
+
+class TestFinalReportCommitMiddleware:
+    """Writer mutations are overwrite-capable and recorded only after success."""
+
+    @staticmethod
+    def _request(tool_name: str, *, path: str = "/shared/output.md", **args: object) -> MagicMock:
+        request = MagicMock()
+        request.tool_call = {
+            "name": tool_name,
+            "args": {"file_path": path, **args},
+            "id": "tc1",
+        }
+        return request
+
+    @pytest.mark.asyncio
+    async def test_successful_write_records_exact_digest(self) -> None:
+        tracker = FinalReportCommitTracker()
+        backend = MagicMock()
+        backend.aupload_files = AsyncMock(return_value=[SimpleNamespace(error=None)])
+        middleware = FinalReportCommitMiddleware(backend=backend, tracker=tracker)
+        handler = AsyncMock()
+        report = "# Final\r\n\r\nExact bytes.\r\n"
+
+        result = await middleware.awrap_tool_call(
+            self._request("write_file", content=report),
+            handler,
+        )
+
+        handler.assert_not_awaited()
+        backend.aupload_files.assert_awaited_once_with([("/shared/output.md", report.encode("utf-8"))])
+        assert result.status == "success"
+        assert tracker.committed_text({"/shared/output.md": {"content": report}}) == report
+        assert tracker.committed_text({"/shared/output.md": {"content": report.replace("\r\n", "\n")}}) is None
+
+    @pytest.mark.asyncio
+    async def test_failed_write_is_not_recorded(self) -> None:
+        tracker = FinalReportCommitTracker()
+        backend = MagicMock()
+        backend.aupload_files = AsyncMock(return_value=[SimpleNamespace(error="internal detail")])
+        middleware = FinalReportCommitMiddleware(backend=backend, tracker=tracker)
+
+        result = await middleware.awrap_tool_call(
+            self._request("write_file", content="# Final"),
+            AsyncMock(),
+        )
+
+        assert result.status == "error"
+        assert str(result.content).startswith("writer_output_commit_failed:")
+        assert "internal detail" not in str(result.content)
+        assert tracker.digest is None
+
+    @pytest.mark.asyncio
+    async def test_write_exception_is_sanitized_and_not_recorded(self) -> None:
+        tracker = FinalReportCommitTracker()
+        backend = MagicMock()
+        backend.aupload_files = AsyncMock(side_effect=RuntimeError("sensitive backend detail"))
+        middleware = FinalReportCommitMiddleware(backend=backend, tracker=tracker)
+
+        result = await middleware.awrap_tool_call(
+            self._request("write_file", content="# Final"),
+            AsyncMock(),
+        )
+
+        assert result.status == "error"
+        assert str(result.content).startswith("writer_output_commit_failed:")
+        assert "sensitive backend detail" not in str(result.content)
+        assert tracker.digest is None
+
+    @pytest.mark.asyncio
+    async def test_route_local_alias_is_not_a_writer_destination(self) -> None:
+        middleware = FinalReportCommitMiddleware(backend=MagicMock(), tracker=FinalReportCommitTracker())
+
+        result = await middleware.awrap_tool_call(
+            self._request("write_file", path="/output.md", content="# Final"),
+            AsyncMock(),
+        )
+
+        assert result.status == "error"
+        assert str(result.content).startswith("writer_output_path_invalid:")
+
+    @pytest.mark.asyncio
+    async def test_successful_edit_refreshes_digest_from_downloaded_bytes(self) -> None:
+        tracker = FinalReportCommitTracker()
+        tracker.record("# Baseline")
+        backend = MagicMock()
+        backend.adownload_files = AsyncMock(
+            return_value=[SimpleNamespace(error=None, content=b"# Baseline\n\n![Chart](artifact://chart.png)")]
+        )
+        middleware = FinalReportCommitMiddleware(backend=backend, tracker=tracker)
+        expected = ToolMessage(content="edited", tool_call_id="tc1", status="success")
+
+        result = await middleware.awrap_tool_call(
+            self._request("edit_file", old_string="# Baseline", new_string="# Baseline"),
+            AsyncMock(return_value=expected),
+        )
+
+        assert result is expected
+        assert tracker.committed_text(
+            {"/shared/output.md": {"content": "# Baseline\n\n![Chart](artifact://chart.png)"}}
+        )
+
+    @pytest.mark.asyncio
+    async def test_failed_edit_keeps_previous_digest(self) -> None:
+        tracker = FinalReportCommitTracker()
+        tracker.record("# Baseline")
+        backend = MagicMock()
+        backend.adownload_files = AsyncMock()
+        middleware = FinalReportCommitMiddleware(backend=backend, tracker=tracker)
+        failed = ToolMessage(content="edit failed", tool_call_id="tc1", status="error")
+
+        result = await middleware.awrap_tool_call(
+            self._request("edit_file", old_string="missing", new_string="new"),
+            AsyncMock(return_value=failed),
+        )
+
+        assert result is failed
+        backend.adownload_files.assert_not_awaited()
+        assert tracker.committed_text({"/shared/output.md": {"content": "# Baseline"}}) == "# Baseline"
+
+    @pytest.mark.asyncio
+    async def test_edit_exception_is_sanitized_and_keeps_previous_digest(self) -> None:
+        tracker = FinalReportCommitTracker()
+        tracker.record("# Baseline")
+        backend = MagicMock()
+        backend.adownload_files = AsyncMock()
+        middleware = FinalReportCommitMiddleware(backend=backend, tracker=tracker)
+
+        result = await middleware.awrap_tool_call(
+            self._request("edit_file", old_string="# Baseline", new_string="# Revised"),
+            AsyncMock(side_effect=RuntimeError("sensitive backend detail")),
+        )
+
+        assert result.status == "error"
+        assert str(result.content).startswith("writer_output_commit_failed:")
+        assert "sensitive backend detail" not in str(result.content)
+        backend.adownload_files.assert_not_awaited()
+        assert tracker.committed_text({"/shared/output.md": {"content": "# Baseline"}}) == "# Baseline"
+
+    def test_trackers_do_not_share_commit_state_between_runs(self) -> None:
+        first = FinalReportCommitTracker()
+        second = FinalReportCommitTracker()
+        first.record("# First run")
+
+        assert first.committed_text({"/shared/output.md": {"content": "# First run"}}) == "# First run"
+        assert second.committed_text({"/shared/output.md": {"content": "# First run"}}) is None
+
+
 class TestRequiredOutputFileMiddleware:
-    """The writer may only claim completion after a non-empty report exists."""
+    """The writer may only claim completion after committing the current bytes."""
 
     marker = "Wrote /shared/output.md"
 
@@ -291,15 +475,27 @@ class TestRequiredOutputFileMiddleware:
         }
 
     @pytest.mark.parametrize("path", ["/shared/output.md", "/output.md"])
-    def test_accepts_non_empty_output_in_both_backend_path_forms(self, path: str) -> None:
-        middleware = RequiredOutputFileMiddleware()
-        state = self._state(files={path: {"content": "# Final report"}})
+    @pytest.mark.parametrize("content", ["# Final report\n", "# Final report\r\n"])
+    def test_accepts_committed_output_in_both_backend_path_forms(self, path: str, content: str) -> None:
+        tracker = FinalReportCommitTracker()
+        tracker.record(content)
+        middleware = RequiredOutputFileMiddleware(tracker=tracker)
+        state = self._state(files={path: {"content": content}})
 
         assert middleware.after_model(state, None) is None
 
+    def test_rejects_non_empty_stale_output_without_writer_mutation(self) -> None:
+        middleware = RequiredOutputFileMiddleware(tracker=FinalReportCommitTracker())
+        state = self._state(files={"/output.md": {"content": "# Planner prose"}})
+
+        update = middleware.after_model(state, None)
+
+        assert update is not None
+        assert update["jump_to"] == "model"
+
     @pytest.mark.parametrize("content", ["", "   ", b"\n", []])
     def test_empty_output_requests_one_local_corrective_turn(self, content: object) -> None:
-        middleware = RequiredOutputFileMiddleware()
+        middleware = RequiredOutputFileMiddleware(tracker=FinalReportCommitTracker())
         state = self._state(files={"/output.md": {"content": content}})
 
         update = middleware.after_model(state, None)
@@ -311,8 +507,32 @@ class TestRequiredOutputFileMiddleware:
         assert "Call write_file" in str(correction.content)
         assert "Do not repeat research" in str(correction.content)
 
+    def test_committed_whitespace_only_output_is_still_rejected(self) -> None:
+        content = " \r\n"
+        tracker = FinalReportCommitTracker()
+        tracker.record(content)
+        middleware = RequiredOutputFileMiddleware(tracker=tracker)
+
+        update = middleware.after_model(self._state(files={"/shared/output.md": {"content": content}}), None)
+
+        assert update is not None
+        assert update["jump_to"] == "model"
+
+    def test_rejects_post_commit_tampering(self) -> None:
+        tracker = FinalReportCommitTracker()
+        tracker.record("# Writer report")
+        middleware = RequiredOutputFileMiddleware(tracker=tracker)
+
+        update = middleware.after_model(
+            self._state(files={"/shared/output.md": {"content": "# Modified report"}}),
+            None,
+        )
+
+        assert update is not None
+        assert update["jump_to"] == "model"
+
     def test_does_not_interrupt_intermediate_tool_call(self) -> None:
-        middleware = RequiredOutputFileMiddleware()
+        middleware = RequiredOutputFileMiddleware(tracker=FinalReportCommitTracker())
         state = self._state(
             messages=[
                 AIMessage(
@@ -326,9 +546,11 @@ class TestRequiredOutputFileMiddleware:
 
     @pytest.mark.asyncio
     async def test_async_retry_accepts_repaired_route_local_output(self) -> None:
-        middleware = RequiredOutputFileMiddleware()
+        tracker = FinalReportCommitTracker()
+        middleware = RequiredOutputFileMiddleware(tracker=tracker)
         first = middleware.after_model(self._state(), None)
         correction = first["messages"][0]
+        tracker.record("# Final report")
         repaired = self._state(
             files={"/output.md": {"content": "# Final report"}},
             messages=[AIMessage(content=self.marker), correction, AIMessage(content=self.marker)],
@@ -337,29 +559,28 @@ class TestRequiredOutputFileMiddleware:
         assert await middleware.aafter_model(repaired, None) is None
 
     def test_repeated_false_completion_fails_with_stable_reason_code(self) -> None:
-        middleware = RequiredOutputFileMiddleware()
+        middleware = RequiredOutputFileMiddleware(tracker=FinalReportCommitTracker())
         first = middleware.after_model(self._state(), None)
         correction = first["messages"][0]
         still_missing = self._state(
             messages=[AIMessage(content=self.marker), correction, AIMessage(content=self.marker)]
         )
 
-        with pytest.raises(RuntimeError, match="^writer_output_missing$"):
+        with pytest.raises(RuntimeError, match="^writer_output_not_committed$"):
             middleware.after_model(still_missing, None)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("shared_route", [False, True])
-    async def test_graph_retry_stays_local_and_writes_required_output(self, shared_route: bool) -> None:
-        """The jump performs one corrective model turn and then follows the normal tool loop."""
+    async def test_graph_overwrites_stale_planner_output_and_commits_writer_report(self, shared_route: bool) -> None:
+        """A create-only collision cannot leave planner prose as the final report."""
         model = _ToolBindingFakeChatModel(
             responses=[
-                AIMessage(content=self.marker),
                 AIMessage(
                     content="",
                     tool_calls=[
                         {
                             "name": "write_file",
-                            "args": {"file_path": "/shared/output.md", "content": "# Final report"},
+                            "args": {"file_path": "/shared/output.md", "content": "# Writer report"},
                             "id": "tc1",
                         }
                     ],
@@ -368,19 +589,31 @@ class TestRequiredOutputFileMiddleware:
             ]
         )
         backend = (
-            CompositeBackend(default=StateBackend(), routes={"/shared/": StateBackend()}) if shared_route else None
+            CompositeBackend(default=StateBackend(), routes={"/shared/": StateBackend()})
+            if shared_route
+            else StateBackend()
         )
+        tracker = FinalReportCommitTracker()
         graph = create_agent(
             model,
             tools=[],
-            middleware=[FilesystemMiddleware(backend=backend), RequiredOutputFileMiddleware()],
+            middleware=[
+                FilesystemMiddleware(backend=backend),
+                FinalReportCommitMiddleware(backend=backend, tracker=tracker),
+                RequiredOutputFileMiddleware(tracker=tracker),
+            ],
+        )
+        stale_path = "/output.md" if shared_route else "/shared/output.md"
+
+        result = await graph.ainvoke(
+            {
+                "messages": [HumanMessage(content="Write the report")],
+                "files": {stale_path: {"content": "# Planner prose"}},
+            }
         )
 
-        result = await graph.ainvoke({"messages": [HumanMessage(content="Write the report")]})
-
-        expected_path = "/output.md" if shared_route else "/shared/output.md"
-        assert result["files"][expected_path]["content"] == "# Final report"
-        assert [message.content for message in result["messages"]].count(self.marker) == 2
+        assert result["files"][stale_path]["content"] == "# Writer report"
+        assert tracker.committed_text(result["files"]) == "# Writer report"
 
     @pytest.mark.asyncio
     async def test_graph_stops_after_bounded_false_completion_retry(self) -> None:
@@ -390,14 +623,20 @@ class TestRequiredOutputFileMiddleware:
                 AIMessage(content=self.marker),
             ]
         )
+        tracker = FinalReportCommitTracker()
         graph = create_agent(
             model,
             tools=[],
-            middleware=[FilesystemMiddleware(), RequiredOutputFileMiddleware()],
+            middleware=[FilesystemMiddleware(), RequiredOutputFileMiddleware(tracker=tracker)],
         )
 
-        with pytest.raises(RuntimeError, match="^writer_output_missing"):
-            await graph.ainvoke({"messages": [HumanMessage(content="Write the report")]})
+        with pytest.raises(RuntimeError, match="^writer_output_not_committed"):
+            await graph.ainvoke(
+                {
+                    "messages": [HumanMessage(content="Write the report")],
+                    "files": {"/shared/output.md": {"content": "# Planner prose"}},
+                }
+            )
 
 
 class TestToolNameSanitizationMiddleware:

--- a/tests/aiq_agent/agents/deep_researcher/test_factory.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_factory.py
@@ -25,6 +25,9 @@ from langchain_core.tools import tool
 
 from aiq_agent.agents.deep_researcher.custom_middleware import ArtifactHarvestMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import FilesystemToolCallGuardMiddleware
+from aiq_agent.agents.deep_researcher.custom_middleware import FinalReportCommitMiddleware
+from aiq_agent.agents.deep_researcher.custom_middleware import FinalReportCommitTracker
+from aiq_agent.agents.deep_researcher.custom_middleware import FinalReportOwnershipGuardMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import RequiredOutputFileMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import SourceRegistryMiddleware
 from aiq_agent.agents.deep_researcher.custom_middleware import SourceRoutingGuardMiddleware
@@ -109,6 +112,7 @@ def _graph_context(
     state: DeepResearchAgentState | None = None,
     provider: LLMProvider | None = None,
     enable_source_router: bool = True,
+    final_report_tracker: FinalReportCommitTracker | None = None,
 ) -> DeepResearchGraphContext:
     _, tool_set, middleware_set = _tool_set_and_middleware()
     runtime = runtime or DeepAgentsRuntime()
@@ -126,6 +130,7 @@ def _graph_context(
         enable_source_router=enable_source_router,
         backend=runtime.backend,
         visibility_middleware=runtime_visibility_middleware(runtime),
+        final_report_tracker=final_report_tracker or FinalReportCommitTracker(),
     )
 
 
@@ -247,6 +252,30 @@ def test_subagents_route_tools_and_writer_skills():
     assert any(isinstance(item, RequiredOutputFileMiddleware) for item in by_name["writer-agent"]["middleware"])
 
 
+def test_subagents_share_one_run_local_tracker_and_reserve_output_for_writer():
+    """All non-writers are guarded while writer commit and completion share one tracker."""
+    tracker = FinalReportCommitTracker()
+    subagents = build_deep_research_subagents(_graph_context(final_report_tracker=tracker))
+    by_name = {subagent["name"]: subagent for subagent in subagents}
+
+    for name in ("source-router-agent", "planner-agent"):
+        assert any(isinstance(item, FinalReportOwnershipGuardMiddleware) for item in by_name[name]["middleware"])
+        assert not any(isinstance(item, FinalReportCommitMiddleware) for item in by_name[name]["middleware"])
+        assert not any(isinstance(item, RequiredOutputFileMiddleware) for item in by_name[name]["middleware"])
+
+    writer_commit = next(
+        item for item in by_name["writer-agent"]["middleware"] if isinstance(item, FinalReportCommitMiddleware)
+    )
+    writer_completion = next(
+        item for item in by_name["writer-agent"]["middleware"] if isinstance(item, RequiredOutputFileMiddleware)
+    )
+    assert writer_commit.tracker is tracker
+    assert writer_completion.tracker is tracker
+    assert not any(
+        isinstance(item, FinalReportOwnershipGuardMiddleware) for item in by_name["writer-agent"]["middleware"]
+    )
+
+
 def test_skill_filesystem_permissions_filter_unassigned_skill_collections():
     """Filesystem tools only expose skill collections assigned to the current agent."""
     permissions = skill_filesystem_permissions(["/skills/synthesis/"])
@@ -286,6 +315,7 @@ def test_graph_uses_researcher_config_key_for_researcher_skills():
             callbacks=[],
             domain_catalog_path=None,
             max_research_concurrency=6,
+            final_report_tracker=FinalReportCommitTracker(),
         )
 
     researcher_middleware = create_researcher.call_args.kwargs["middleware"]
@@ -302,7 +332,10 @@ def test_graph_wires_filesystem_tool_call_guard_cross_cutting():
 
     with (
         patch("aiq_agent.agents.deep_researcher.factory.create_deep_agent", return_value=fake_graph) as create_graph,
-        patch("aiq_agent.agents.deep_researcher.factory.create_agent", return_value=MagicMock()),
+        patch(
+            "aiq_agent.agents.deep_researcher.factory.create_agent",
+            return_value=MagicMock(),
+        ) as create_researcher,
         patch("aiq_agent.agents.deep_researcher.factory.create_summarization_middleware", return_value=MagicMock()),
     ):
         build_deep_research_graph(
@@ -317,12 +350,27 @@ def test_graph_wires_filesystem_tool_call_guard_cross_cutting():
             callbacks=[],
             domain_catalog_path=None,
             max_research_concurrency=6,
+            final_report_tracker=FinalReportCommitTracker(),
         )
 
     assert any(
         isinstance(middleware, FilesystemToolCallGuardMiddleware)
         for middleware in create_graph.call_args.kwargs["middleware"]
     )
+    assert any(
+        isinstance(middleware, FinalReportOwnershipGuardMiddleware)
+        for middleware in create_graph.call_args.kwargs["middleware"]
+    )
+    assert any(
+        isinstance(middleware, FinalReportOwnershipGuardMiddleware)
+        for middleware in create_researcher.call_args.kwargs["middleware"]
+    )
+    for middleware_stack in (
+        create_graph.call_args.kwargs["middleware"],
+        create_researcher.call_args.kwargs["middleware"],
+    ):
+        assert not any(isinstance(middleware, FinalReportCommitMiddleware) for middleware in middleware_stack)
+        assert not any(isinstance(middleware, RequiredOutputFileMiddleware) for middleware in middleware_stack)
 
 
 def test_subagents_can_disable_source_router():

--- a/tests/aiq_agent/jobs/test_runner.py
+++ b/tests/aiq_agent/jobs/test_runner.py
@@ -70,6 +70,7 @@ from unittest.mock import patch
 
 import pytest
 
+from aiq_agent.agents.deep_researcher.custom_middleware import FinalReportCommitTracker
 from aiq_agent.auth import Principal
 from aiq_api.jobs.callbacks import ArtifactType
 from aiq_api.jobs.callbacks import DeepResearchEventCallback
@@ -2340,7 +2341,7 @@ class TestAsyncJobRunnerAgentFactory:
                     )
                 ]
             )
-            agent._build_orchestrator_agent(state)
+            agent._build_orchestrator_agent(state, final_report_tracker=FinalReportCommitTracker())
 
         kwargs = create.call_args.kwargs
         assert "skills" not in kwargs
@@ -2399,7 +2400,7 @@ class TestAsyncJobRunnerAgentFactory:
                 job_id="async-job-123",
             )
             state = DeepResearchAgentState(messages=[HumanMessage(content="Research without tools")])
-            agent._build_orchestrator_agent(state)
+            agent._build_orchestrator_agent(state, final_report_tracker=FinalReportCommitTracker())
 
         tool_names = [tool.name for tool in create.call_args.kwargs["tools"]]
         assert tool_names == ["think", "get_verified_sources", "run_research_batch"]


### PR DESCRIPTION
#### Overview

Deep-research currently accepts any non-empty `/shared/output.md` as the final report, including stale planner/orchestrator content from the same state. This prerequisite establishes a small writer-owned commit boundary before the broader convergence/artifact work in #373.

- Create one run-local `FinalReportCommitTracker` per `DeepResearcherAgent.run()`.
- Deny non-writer `write_file`/`edit_file` mutations of `/shared/output.md` and its route-local `/output.md` state alias with `final_report_writer_only`.
- Upsert writer `write_file` calls through the existing backend, refresh the exact UTF-8 SHA-256 after successful edits, and sanitize backend failures as `writer_output_commit_failed`.
- Require a successful writer mutation, non-empty current content, and an exact digest match before writer completion or final extraction.
- Preserve the existing one-turn correction, then fail closed with `writer_output_not_committed`.
- Remove production inline-orchestrator report salvage.
- Document that the proof is run-local and byte-exact; it is not persistent across restart and does not claim cross-provider filesystem atomicity.

This changes no API fields, configuration schema, database schema, deployment behavior, or sandbox-provider implementation.

After this prerequisite merges, #373 can rebase onto `release/2.2` and use its validated ResearchNotes fallback when no committed writer report exists.

#### DCO sign-off for the squash commit

Signed-off-by: Kyle Zheng <kyzheng@nvidia.com>

#### Validation

- [x] `uv run ruff check .` — passed
- [x] `uv run ruff format --check .` — passed (372 files)
- [x] Focused deep-research/job-runner regressions — 265 passed
- [x] `uv run pytest` — 1,836 passed, 13 skipped
- [x] `pre-commit run --all-files` — all 13 hooks passed, including secrets, lockfiles, links, and notebook output
- [x] `cd docs && make html` — passed
- [x] Live Modal smoke — `deep_researcher` reached success with a non-empty 12,351-byte report
- [x] Live OpenShell 0.0.80 local-demo smoke — strict readiness passed; job reached success with a non-empty 7,360-byte report; attestation and cleanup events were recorded; no owned sandbox remained
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for contributor-facing architecture behavior.
- [x] I confirmed this PR does not include secrets, credentials, local configs, generated policy files, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed the commit with `git commit -s`.
- [x] I replaced the DCO sign-off placeholder with my GitHub commit identity and kept the required angle brackets.

#### Where should reviewers start?

1. `FinalReportCommitTracker`, `FinalReportOwnershipGuardMiddleware`, and `FinalReportCommitMiddleware` in `custom_middleware.py`.
2. Per-run tracker construction/extraction in `agent.py` and role-specific wiring in `factory.py`.
3. The routed `StateBackend`/`CompositeBackend` stale-planner overwrite regression in `test_custom_middleware.py`.

#### Related Issues

- Prerequisite for #373.
- Independent of #372; no artifact-capture configuration is included here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Final research reports are now accepted only after the writer commits `/shared/output.md` (or the supported backend alias) during the current run.
  - Commit verification is digest-based, rejecting stale/modified/missing/whitespace-only output and detecting any post-write tampering.
  - Only the designated writer can create/update the final report artifact; completion is blocked until the verified commit occurs.
  - Removed inline fallback/salvage behavior—if the commit proof isn’t present, runs fail with `writer_output_not_committed`.
- **Documentation**
  - Updated deep-research architecture docs to describe the stricter writer/output commit contract, ownership guardrails, and failure-closed handoffs.
- **Tests**
  - Expanded coverage for digest-verified commit tracking, writer-only ownership enforcement, and updated failure reason/validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->