### PR TITLE
docs: clarify knowledge collection routing

### DIFF
--- a/docs/source/customization/configuration-reference.md
+++ b/docs/source/customization/configuration-reference.md
@@ -335,7 +335,7 @@ functions:
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `backend` | `str` | `llamaindex` | Backend type: `llamaindex`, `opensearch`, `foundational_rag`, or `azure_ai_search`. |
-| `collection_name` | `str` | `default` | Name of the document collection/index. |
+| `collection_name` | `str` | `default` | Fallback retrieval collection when no conversation or session context is present. Request context takes precedence; ingestion selects its collection explicitly. |
 | `top_k` | `int` | `5` | Number of results to return per query. |
 | `generate_summary` | `bool` | `false` | Generate one-sentence summaries for ingested documents. |
 | `summary_model` | `str` | `None` | LLM reference from `llms` section. Required when `generate_summary: true`. |
@@ -362,8 +362,8 @@ functions:
 | `opensearch_ingestion_mode` | `str` | `local` | Ingestion executor: `local`, `dask`, or `auto`. `auto` uses Dask only when a scheduler address is configured. |
 | `opensearch_dask_scheduler_address` | `str` | `None` | Dask scheduler for distributed ingestion. Also reads `NAT_DASK_SCHEDULER_ADDRESS`. |
 | `opensearch_dask_file_transfer` | `str` | `bytes` | Send uploads to Dask workers as `bytes` or shared filesystem `paths`. |
-| `embed_model` | `str` | `nvidia/llama-nemotron-embed-vl-1b-v2` | Embedding model for OpenSearch ingestion and retrieval. |
-| `embed_base_url` | `str` | `https://integrate.api.nvidia.com/v1` | OpenAI-compatible embeddings endpoint. |
+| `embed_model` | `str` | `nvidia/llama-nemotron-embed-vl-1b-v2` | Embedding model for OpenSearch and Azure AI Search ingestion and retrieval. |
+| `embed_base_url` | `str` | `https://integrate.api.nvidia.com/v1` | OpenAI-compatible embeddings endpoint for OpenSearch and Azure AI Search. |
 
 Refer to [Knowledge Layer](./knowledge-layer.md) for backend selection and the
 [Amazon OpenSearch Serverless](../deployment/aws-opensearch-serverless.md) guide for SigV4, IAM, and AOSS setup.

--- a/docs/source/customization/knowledge-layer.md
+++ b/docs/source/customization/knowledge-layer.md
@@ -15,7 +15,8 @@ A pluggable abstraction for document ingestion and retrieval. Swap backends with
 - **Collection Management** - create/delete/list collections per session or use case
 - **File Management** - upload/delete/list files with status tracking (UPLOADING -> INGESTING -> SUCCESS/FAILED)
 - **Content Typing** - TEXT, TABLE, CHART, IMAGE enums for frontend rendering
-- **Backend Agnostic** - Swap among local LlamaIndex, hosted RAG Blueprint, and OpenSearch without core agent code changes
+- **Backend Agnostic** - Swap among LlamaIndex, hosted RAG Blueprint, Azure AI Search, and OpenSearch without core
+  agent code changes
 
 ---
 
@@ -25,6 +26,7 @@ A pluggable abstraction for document ingestion and retrieval. Swap backends with
 - [Quick Start](#quick-start)
 - [Usage](#usage)
   - [With YAML Config](#with-nemo-agent-toolkit-yaml-config---recommended)
+  - [Collection Routing](#collection-routing)
   - [Multimodal Extraction](#multimodal-extraction-llamaindex-only)
   - [Document Summaries](#document-summaries)
   - [Supported File Types](#supported-file-types)
@@ -105,7 +107,7 @@ functions:
   knowledge_search:
     _type: knowledge_retrieval      # NeMo Agent Toolkit function type
     backend: llamaindex             # Required: which adapter to use
-    collection_name: my_docs        # Required: target collection
+    collection_name: my_docs        # Retrieval fallback when no session context is present
     top_k: 5                        # Results to return
 
     # Summarization options (optional, all backends):
@@ -127,7 +129,7 @@ functions:
     # embed_model: nvidia/llama-nemotron-embed-vl-1b-v2
 ```
 
-You can also use environment variable substitution in YAML for sensitive values:
+You can also use environment variable substitution in YAML for deployment-specific values:
 
 ```yaml
 functions:
@@ -139,6 +141,39 @@ functions:
 ```
 
 > **Note:** Each backend has different config options. Only the options matching your `backend` value are used - others are ignored (a warning will be logged). To add new config fields, edit `KnowledgeRetrievalConfig` in `sources/knowledge_layer/src/register.py`.
+
+### Collection Routing
+
+AI-Q selects ingestion and retrieval collections independently. This routing policy applies consistently to all
+shipped knowledge backends: LlamaIndex, Foundational RAG, Azure AI Search, and OpenSearch.
+
+The storage mapping is backend-specific: LlamaIndex and Foundational RAG use named collections, OpenSearch maps each
+collection to a physical index, and Azure AI Search isolates logical collections with `collection_id` filters inside
+one AI-Q-owned physical index.
+
+| Usage | Ingestion target | Retrieval target |
+|-------|------------------|------------------|
+| Web UI | UI-created session collection (`s_<uuid>`) | Active UI session collection |
+| API with a `conversation-id` header | Collection named in `/v1/collections/{collection_name}/documents` | `conversation-id` header value |
+| API without conversation context | Collection named explicitly by the ingestion operation | Configured `collection_name` fallback |
+
+`collection_name` controls only the retrieval fallback. It does not choose an API ingestion destination, and it does
+not override an active UI session. Shipped profiles commonly populate it with
+`${COLLECTION_NAME:-test_collection}`; the environment value is resolved when the workflow configuration is loaded.
+
+Use `COLLECTION_NAME` for a deployment-wide retrieval default when API or CLI requests do not carry conversation
+context. To select a collection for an individual HTTP request, pass that collection name in the `conversation-id`
+header:
+
+```bash
+curl -X POST http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "conversation-id: research-papers" \
+  -d '{"messages": [{"role": "user", "content": "Summarize the uploaded documents."}], "stream": false}'
+```
+
+For `/v1/chat/completions`, a `conversation_id` field in the JSON body is not used for collection routing. Use the
+`conversation-id` header instead.
 
 ### Switching Backends
 
@@ -381,7 +416,12 @@ Open `http://localhost:3000` in your browser.
 
 ### Session Collections
 
-LlamaIndex, Foundational RAG, and OpenSearch support session-based collections (`s_<uuid>`) created by the UI. Each browser session gets its own logical collection; OpenSearch stores each one in a separate prefixed index.
+All four shipped knowledge backends support session-based collections (`s_<uuid>`) created by the UI. Each UI
+conversation gets its own isolated logical collection; the physical storage mapping differs by backend as described in
+[Collection Routing](#collection-routing).
+
+The active session collection is used for both UI ingestion and retrieval and takes precedence over the configured
+`collection_name` fallback.
 
 ### TTL Cleanup
 
@@ -496,8 +536,8 @@ Configuration values are resolved in the following order (highest to lowest prio
 | `OPENSEARCH_INDEX_PREFIX` | opensearch | Prefix for AI-Q-managed indexes |
 | `OPENSEARCH_INGESTION_MODE` | opensearch | `local`, `dask`, or `auto` |
 | `OPENSEARCH_DASK_SCHEDULER_ADDRESS` | opensearch | Optional Dask scheduler for distributed ingestion |
-| `AIQ_EMBED_MODEL`, `AIQ_EMBED_BASE_URL` | llamaindex, opensearch | Embedding model and endpoint |
-| `COLLECTION_NAME` | All | Default collection name |
+| `AIQ_EMBED_MODEL`, `AIQ_EMBED_BASE_URL` | llamaindex, opensearch, azure_ai_search | Embedding model and endpoint |
+| `COLLECTION_NAME` | All | Default retrieval collection when no conversation or session context is present |
 
 ---
 

--- a/docs/source/integration/rest-api.md
+++ b/docs/source/integration/rest-api.md
@@ -479,6 +479,17 @@ The default agents (`deep_researcher` and `shallow_researcher`) are registered a
 
 The Knowledge API endpoints are **conditionally registered** -- they appear only when a `knowledge_retrieval` function is configured in the workflow. The backend (LlamaIndex, Foundational RAG, etc.) is determined by the knowledge config.
 
+### Collection Routing
+
+Knowledge ingestion and retrieval select collections independently. Collection and document endpoints use the
+collection named in the request path, while retrieval uses the `conversation-id` header when present and otherwise
+falls back to the configured `collection_name`. To query a collection after ingesting into it, reuse the exact
+collection name as the `conversation-id` header. A `conversation_id` field in the `/v1/chat/completions` JSON body is
+not used for collection routing.
+
+For UI behavior, environment-variable usage, and an end-to-end request example, see
+[Collection Routing](../customization/knowledge-layer.md#collection-routing).
+
 ### Collection Endpoints
 
 | Method | Path | Description |

--- a/docs/source/resources/troubleshooting.md
+++ b/docs/source/resources/troubleshooting.md
@@ -78,7 +78,7 @@ llms:
 | Issue | Cause | Fix |
 |-------|-------|-----|
 | `Unknown backend` | Adapter module not imported | Ensure backend package is installed: `uv pip install -e "sources/knowledge_layer[llamaindex]"` |
-| Empty retrieval results | Collection is empty or wrong name | Run ingestion first; verify `collection_name` matches |
+| Empty retrieval results | Ingestion and retrieval resolved different collections | Verify the upload-path collection and active `conversation-id`; without session context, verify the configured `collection_name` fallback |
 | Foundational RAG connection refused | RAG Blueprint not running | Start the RAG Blueprint server; verify `rag_url` and `ingest_url` |
 | `milvus-lite` required | Missing dependency | `uv pip install "pymilvus[milvus_lite]"` |
 

--- a/sources/knowledge_layer/KNOWLEDGE-LAYER-SETUP.md
+++ b/sources/knowledge_layer/KNOWLEDGE-LAYER-SETUP.md
@@ -92,7 +92,7 @@ functions:
   knowledge_search:
     _type: knowledge_retrieval      # NAT function type
     backend: llamaindex             # Required: which adapter to use
-    collection_name: my_docs        # Required: target collection
+    collection_name: my_docs        # Retrieval fallback when no session context is present
     top_k: 5                        # Results to return
 
     # Backend-specific options (each backend uses different fields):
@@ -104,7 +104,7 @@ functions:
     opensearch_auth_type: none                # opensearch only: none, basic, sigv4
 ```
 
-You can also use environment variable substitution in YAML for sensitive values:
+You can also use environment variable substitution in YAML for deployment-specific values:
 
 ```yaml
 functions:
@@ -186,6 +186,23 @@ functions:
 ```
 
 > **Separate Docker stacks:** When AI-Q and RAG run as separate Docker Compose stacks, connect the AI-Q backend to the RAG network: `docker network connect nvidia-rag aiq-agent`. See the [Docker Compose README](../../deploy/compose/README.md#networking-when-aiq-and-rag-run-as-separate-compose-stacks) for details.
+
+**Azure AI Search (Managed Service)**
+
+```yaml
+functions:
+  knowledge_search:
+    _type: knowledge_retrieval
+    backend: azure_ai_search
+    collection_name: ${COLLECTION_NAME:-aiq_default}
+    top_k: 5
+```
+
+Set `AZURE_SEARCH_ENDPOINT` and `NVIDIA_API_KEY`. Set `AZURE_SEARCH_API_KEY` to use key authentication; otherwise,
+Azure `DefaultAzureCredential` is used. Azure stores all logical collections, including UI session collections, in
+one AI-Q-owned physical index and applies `collection_id` filters to isolate ingestion and retrieval. See the
+[Azure AI Search example](../../docs/source/examples/azure-ai-search.md) for authentication, index, and embedding
+configuration.
 
 **OpenSearch (Self-hosted)**
 
@@ -406,42 +423,25 @@ For more details, see the [Docker Compose README](../../deploy/compose/README.md
 
 ### Session Collections
 
-Both LlamaIndex and Foundational RAG support session-based collections (`s_<uuid>`) created by the UI. Each browser session gets its own isolated collection.
+All four shipped knowledge backends—LlamaIndex, Foundational RAG, Azure AI Search, and OpenSearch—support
+session-based collections (`s_<uuid>`) created by the UI. Each UI conversation gets its own isolated logical
+collection.
 
 #### How collection routing works
 
-When a request arrives the `knowledge_search` tool reads `Context.conversation_id` and uses it as the
-collection name, falling back to the static `collection_name` from YAML config when the context value
-is absent.
+Retrieval uses the active conversation or session collection when present and otherwise falls back to the configured
+`collection_name`. UI ingestion and retrieval share the UI-created session collection, while API ingestion selects its
+destination explicitly.
 
-`Context.conversation_id` is populated by the `nat` framework **from the `conversation-id` HTTP
-request header** (see `SessionManager.set_metadata_from_http_request` in the `nat` package).
-The AI-Q UI sets this header automatically for every WebSocket and HTTP request it sends, which is why
-session-isolated uploads work seamlessly through the UI.
+| Usage | Collection selection |
+|-------|----------------------|
+| UI ingestion | Active UI session collection |
+| UI retrieval | Active UI session collection |
+| API ingestion | Collection named by the ingestion operation |
+| API retrieval | `conversation-id`, then configured `collection_name` fallback |
 
-**Known limitation — `/v1/chat/completions` JSON body field is ignored.**
-The OpenAI-compatible `POST /v1/chat/completions` endpoint uses `nat.data_models.api_server.ChatRequest`
-as its request body model.  `ChatRequest` does **not** declare a `conversation_id` field; the model uses
-`extra="allow"`, so any `conversation_id` key in the JSON body is silently accepted and then discarded.
-The framework never reads it back into the context.
-
-Consequence: callers that send `{"messages": [...], "conversation_id": "my-collection"}` in the body
-will have that value silently dropped, and the tool will fall back to the configured `collection_name`
-default instead of routing to `my-collection`.
-
-**Workaround (until upstream `nat` is patched):** pass the collection name as the
-`conversation-id` HTTP header instead of a JSON body field:
-
-```bash
-curl -X POST http://localhost:8000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -H "conversation-id: my-collection" \
-  -d '{"messages": [{"role": "user", "content": "..."}], "stream": false}'
-```
-
-This is tracked as a known gap.  The permanent fix requires adding `conversation_id` to `ChatRequest`
-and wiring it into `Context.conversation_id` inside the `nat` framework — a change that belongs in the
-upstream `nat` / `aiq_api` repository, not in this repo.
+For request-scoped selection, environment-variable usage, and `/v1/chat/completions` header behavior, see
+[Collection Routing](../../docs/source/customization/knowledge-layer.md#collection-routing).
 
 ### TTL Cleanup
 
@@ -557,7 +557,7 @@ The summary system works identically across all backends:
 | `unregister_summary()` | `aiq_agent.knowledge.factory` | Remove summary on file deletion |
 | `get_available_documents()` | `aiq_agent.knowledge.factory` | Retrieve summaries for agents |
 
-Both LlamaIndex and Foundational RAG adapters call these functions, ensuring consistent behavior regardless of backend choice.
+All four shipped adapters call these functions, ensuring consistent behavior regardless of backend choice.
 
 ### Summary Storage
 
@@ -1048,8 +1048,8 @@ Configuration values are resolved in the following order (highest to lowest prio
 | `AZURE_SEARCH_API_KEY` | azure_ai_search | Optional admin key; omit to use `DefaultAzureCredential` |
 | `AZURE_CLIENT_ID` | azure_ai_search | Client ID for the user-assigned managed identity used by `DefaultAzureCredential` |
 | `AIQ_AZURE_SEARCH_INDEX_PREFIX` | azure_ai_search | Deployment-unique prefix for the shared AI-Q index (default: `aiq`) |
-| `AIQ_EMBED_MODEL` | llamaindex, azure_ai_search | Embedding model name |
-| `AIQ_EMBED_BASE_URL` | llamaindex, azure_ai_search | Embedding API base URL |
+| `AIQ_EMBED_MODEL` | llamaindex, opensearch, azure_ai_search | Embedding model name |
+| `AIQ_EMBED_BASE_URL` | llamaindex, opensearch, azure_ai_search | Embedding API base URL |
 | `AIQ_EMBED_DIM` | azure_ai_search | Embedding dimensions (default: `2048`) |
 | `AIQ_SUMMARY_DB` | All | Summary database URL (SQLite or PostgreSQL) |
 | `RAG_SERVER_URL` | foundational_rag | Query server URL (port 8081) |
@@ -1074,7 +1074,7 @@ Configuration values are resolved in the following order (highest to lowest prio
 | `OPENSEARCH_TIMEOUT` | opensearch | Request timeout in seconds (default `120`) |
 | `OPENSEARCH_BULK_BATCH_SIZE` | opensearch | Documents per bulk index request (default `100`) |
 | `OPENSEARCH_EMBEDDING_BATCH_SIZE` | opensearch | Texts per embedding request (default `16`) |
-| `COLLECTION_NAME` | All | Default collection name |
+| `COLLECTION_NAME` | All | Default retrieval collection when no conversation or session context is present |
 
 > **Advanced OpenSearch options:** Additional tuning parameters (kNN index settings `OPENSEARCH_ENGINE`, `OPENSEARCH_SPACE_TYPE`, `OPENSEARCH_M`, `OPENSEARCH_EF_CONSTRUCTION`, `OPENSEARCH_EF_SEARCH`; field name overrides `OPENSEARCH_VECTOR_FIELD`, `OPENSEARCH_TEXT_FIELD`; AOSS delete tuning `OPENSEARCH_AOSS_DELETE_MAX_BATCHES`, `OPENSEARCH_AOSS_DELETE_BACKOFF_SECONDS`; and `OPENSEARCH_MAX_RETRIES`) are available via YAML config or environment variable — see `sources/knowledge_layer/src/register.py` for defaults and descriptions.
 


### PR DESCRIPTION
#### Overview

Clarify how knowledge collections are selected across UI, API, and CLI usage:

- Document `collection_name` and `COLLECTION_NAME` as retrieval fallbacks when no conversation or session context is present.
- Explain that UI ingestion and retrieval use the active session collection, while API ingestion names its destination explicitly.
- Document `conversation-id` header routing for `/v1/chat/completions` and clarify that a JSON-body `conversation_id` does not select the collection.
- Confirm the shared session-routing contract for LlamaIndex, Foundational RAG, OpenSearch, and Azure AI Search, including their different physical storage mappings.
- Add the missing Azure AI Search setup example and align configuration and troubleshooting guidance.

This is a documentation-only change with no runtime, API, configuration-default, or compatibility impact.

#### DCO sign-off for the squash commit

Signed-off-by: Kyle Zheng <126034466+KyleZheng1284@users.noreply.github.com>
Signed-off-by: Kyle Zheng <kyzheng@nvidia.com>

#### Validation

- `sphinx-build -M html docs/source docs/build -W --keep-going`
  - Result: `build succeeded`.
- `git diff --check`
  - Result: passed with no output.
- Relevant pre-commit hooks on all five changed files
  - Merge-conflict, large-file, end-of-file, trailing-whitespace, and secret-detection checks passed.
  - The external Markdown link hook could not complete in the restricted local environment because existing external URLs could not resolve. No external URL was added; Sphinx validated the new internal cross-references and rendered anchor.
- `pytest -q tests/knowledge_layer_tests/test_azure_ai_search.py`
  - Result: `63 passed`.
- `pytest -q tests/knowledge_layer_tests/test_opensearch_adapter.py`
  - Result: `37 passed`.
- Focused UI document-client and session-upload tests
  - Result: `44 passed`.
- All four shipped workflow configs passed the repository config validator with no errors or warnings.
- All four adapters passed quick compliance checks; mocked contract checks confirmed shared session selection plus LlamaIndex and Foundational RAG collection scoping.

- [x] I ran the relevant local checks or explained why they are not applicable.
- [x] No behavior changed; existing focused tests were used to validate the documented contract.
- [x] I updated documentation for user-facing or contributor-facing changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.
- [x] I replaced the DCO sign-off placeholder with my GitHub commit identity and kept the required angle brackets around the email address.

#### Where should reviewers start?

Start with `docs/source/customization/knowledge-layer.md`, especially the new **Collection Routing** section. Then review `sources/knowledge_layer/KNOWLEDGE-LAYER-SETUP.md` for the concise routing table and Azure AI Search setup parity.

#### Related Issues

- None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how knowledge collections are selected for ingestion and retrieval.
  * Documented session-based routing, request context precedence, and fallback collection behavior.
  * Added Azure AI Search configuration guidance and expanded embedding parameter coverage.
  * Updated REST API guidance for collection names and `conversation-id` routing.
  * Improved troubleshooting steps for empty retrieval results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->