### PR TITLE
fix(knowledge_layer): use source_metadata description instead of raw chunk content

### DIFF
--- a/sources/knowledge_layer/src/foundational_rag/adapter.py
+++ b/sources/knowledge_layer/src/foundational_rag/adapter.py
@@ -491,6 +491,14 @@ class FoundationalRagRetriever(BaseRetriever):
         metadata = result.get("metadata") or {}
         content_metadata = metadata.get("content_metadata") or {}
 
+        # For FRAG table/image chunks the raw content field is base64-encoded binary.
+        # Use the human-readable description from metadata when present.
+        description = metadata.get("description")
+        if isinstance(description, str) and description:
+            content = description
+        elif not isinstance(content, str):
+            content = ""
+
         # Strip temp file prefix (tmp + 8 random chars + _) for display; keep raw for delete ops
         display_name = re.sub(r"^tmp.{8}_", "", document_name_raw)
 


### PR DESCRIPTION

#### Overview

- chunk.content in _format_results was returning raw base64-encoded data for knowledge base chunks, causing garbled and unreadable tool responses
- Fixed by reading description from chunk.metadata["source_metadata"] which contains the correct human-readable text
- Falls back to "No content available." when the field is absent

#### DCO sign-off for the squash commit

<!--
The RAPIDS auto-merger copies this PR description into the generated squash
commit. GitHub may author that commit with a different email than your local
commits. Replace the placeholder below with the exact commit email configured
for your GitHub account. If you keep your email private, copy the
`@users.noreply.github.com` address shown at https://github.com/settings/emails.

If your local/work email differs from your GitHub commit email, you may include
both sign-offs. DCO passes when one sign-off exactly matches the generated
squash commit author:

Signed-off-by: Full Name <work.email@example.com>
Signed-off-by: Full Name <github-email@users.noreply.github.com>

Keep the angle brackets around the email address. They are part of the required
DCO format: `Signed-off-by: Full Name <email@example.com>`.

Do not delete the sign-off line, leave the placeholder unchanged, or remove the
angle brackets.
-->

Signed-off-by: Swapnil Masurekar <smasurekar@nvidia.com>

#### Validation

<!-- List the exact commands, workflows, screenshots, or manual checks used. -->

- [ ] I ran the relevant local checks or explained why they are not applicable.
- [ ] I added or updated tests for behavior changes.
- [ ] I updated documentation for user-facing or contributor-facing changes.
- [ ] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [ ] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.
- [ ] I replaced the DCO sign-off placeholder with my GitHub commit identity and kept the required angle brackets around the email address.

#### Where should reviewers start?

<!-- Point to the most important file, test, or design decision. -->

#### Related Issues

<!-- Use Closes / Fixes / Resolves / Relates to when applicable. -->

- Relates to #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved presentation of table and image chunks in search results by using available human-readable descriptions.
  * Prevented invalid or malformed result text by clearing content when the source payload isn’t plain text.
  * Preserved existing chunk mapping behavior (e.g., identifiers, scoring, and metadata) while refining content normalization for these chunk types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->