### PR TITLE
feat(gsf): Add tool text_to_pql in GSF data source

### DIFF
--- a/sources/gsf/README.md
+++ b/sources/gsf/README.md
@@ -3,21 +3,19 @@ SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# AI-Q GSF source
+# GSF as a data source
 
-This package exposes NVIDIA Generative Semantic Fabric (GSF) capabilities as a
-NeMo Agent Toolkit function group. The current implementation provides:
+This package connects AI-Q to NVIDIA Generative Semantic Fabric (GSF).
 
-- `gsf__text_to_sql`
-- `gsf__catalog_search`
+## Tools
 
-PQL client and model groundwork remains internal, but no PQL tool is registered
-until its GSF contract and integration behavior are validated.
+- `gsf__catalog_search`: finds relevant semantic objects.
+- `gsf__text_to_sql`: answers analytical questions with SQL and bounded rows.
+- `gsf__text_to_pql`: runs predictive questions through the GSF/Kumo path.
 
-By default, the function group owns one shared HTTP connection pool and keeps
-authentication request-scoped: each tool invocation obtains the current AI-Q
-user token and passes it to GSF without storing it on the client.
-`GSF_BASE_URL` must point to GSF's auth-aware API origin.
+## Configuration
+
+Set `GSF_BASE_URL` to GSF's auth-aware API origin and add the function group to the data-source registry:
 
 ```yaml
 function_groups:
@@ -27,6 +25,7 @@ function_groups:
     include:
       - catalog_search
       - text_to_sql
+      - text_to_pql
 
 functions:
   data_sources:
@@ -43,9 +42,11 @@ functions:
           - gsf
 ```
 
-For local development and automated evaluation without an incoming AI-Q user
-token, explicitly configure a GSF password session. The credentials must come
-from environment variables:
+When `auth` is omitted, each tool invocation obtains the current AI-Q user token and forwards it to GSF without
+storing it on the shared client.
+
+For local development or automated evaluation without an incoming AI-Q user token, explicitly configure password
+authentication using environment variables:
 
 ```yaml
 function_groups:
@@ -56,26 +57,16 @@ function_groups:
       mode: password
       email: ${GSF_EMAIL}
       password: ${GSF_PASSWORD}
-    include:
-      - catalog_search
-      - text_to_sql
 ```
 
-When `auth` is omitted, the existing request-scoped AI-Q user-token flow is
-used. Password mode creates one GSF session when the function group starts,
-reuses its cookie for local development or evaluation calls, and signs out when
-the group closes. The client does not fall back between authentication methods.
+Password mode creates one GSF session when the function group starts, reuses its cookie for all tool calls, and signs
+out when the function group closes. The client does not fall back between authentication methods. Do not put
+credentials directly in the configuration file.
 
-Text-to-SQL uses GSF's `/api/chat/completions` SSE endpoint with
-`prediction: false`. Its optional AI-Q `database_name` input is sent to GSF as
-`target_db`, selecting an existing GSF connection rather than creating one.
-The adapter normalizes GSF's current response fields while preserving optional
-semantic and benchmarking fields as they become available.
-For text-to-SQL, GSF's compatibility prose is discarded; AI-Q consumes the
-generated SQL, bounded rows, and any structured semantic provenance instead.
-GSF's optional `thoughts` summary is retained as diagnostic context, not as
-authoritative evidence.
+## API mapping
 
-Catalog search uses `POST /api/question-entity-coverage` and returns entity
-coverage plus ranked semantic candidates for DS-agent grounding and routing.
-Its optional `database_name` is sent as `target_db`.
+- Catalog search calls `POST /api/question-entity-coverage`.
+- Text-to-SQL calls `POST /api/chat/completions` with `prediction: false`.
+- Text-to-PQL calls `POST /api/chat/completions` with `prediction: true`.
+- Normal AI-Q calls rely on GSF's routing and omit database selection.
+- Automated benchmarks may explicitly set optional `database_name`; AI-Q forwards it to GSF as `target_db`.

--- a/sources/gsf/src/gsf/client.py
+++ b/sources/gsf/src/gsf/client.py
@@ -177,6 +177,7 @@ class GSFClient:
     ) -> TextToPQLResponse:
         """Run the prediction branch of GSF chat completions and normalize its answer."""
 
+        max_rows = min(request.max_rows, self._default_max_rows)
         payload: dict[str, Any] = {
             "question": request.question,
             "prediction": True,
@@ -189,7 +190,7 @@ class GSFClient:
             token=token,
             trace_headers=trace_headers,
         )
-        return self._normalize_text_to_pql(answer, request_id=request_id)
+        return self._normalize_text_to_pql(answer, request_id=request_id, max_rows=max_rows)
 
     async def _chat_completions(
         self,
@@ -564,24 +565,45 @@ class GSFClient:
             ) from exc
 
     @classmethod
-    def _normalize_text_to_pql(cls, answer: Mapping[str, Any], *, request_id: str | None) -> TextToPQLResponse:
-        """Normalize current and legacy GSF prediction fields into PQL output."""
+    def _normalize_text_to_pql(
+        cls,
+        answer: Mapping[str, Any],
+        *,
+        request_id: str | None,
+        max_rows: int,
+    ) -> TextToPQLResponse:
+        """Normalize GSF's shared chat fields into bounded prediction output."""
 
         # GSF's prediction branch currently returns the PQL in ``sql_code`` so
         # its frontend can render SQL and prediction results with one shape.
         pql = answer.get("pql") or answer.get("pql_code") or answer.get("sql_code")
-        if not isinstance(pql, str) or not pql.strip():
+        pql = pql if isinstance(pql, str) and pql.strip() else None
+        response = answer.get("response")
+        if pql is None and (not isinstance(response, str) or not response.strip()):
             raise GSFError(
                 GSFErrorCode.INVALID_RESPONSE,
-                "GSF did not return validated PQL.",
+                "GSF returned neither PQL nor prediction diagnostics.",
                 request_id=request_id,
             )
+
+        rows = cls._normalize_rows(answer.get("rows") or answer.get("sql_response_from_db"), request_id)
+        upstream_truncated = bool(answer.get("truncated", False))
+        truncated = upstream_truncated or len(rows) > max_rows
+        rows = rows[:max_rows]
+        columns = cls._normalize_columns(answer.get("columns") or answer.get("sql_columns"))
+        if not columns and rows:
+            columns = [ResultColumn(name=str(name)) for name in rows[0]]
 
         try:
             return TextToPQLResponse(
                 request_id=answer.get("request_id") or request_id,
-                response=answer.get("response"),
+                response=response,
+                thoughts=answer.get("thoughts"),
                 pql=pql,
+                columns=columns,
+                rows=rows,
+                truncated=truncated,
+                custom_analyses_used=answer.get("custom_analyses_used"),
                 objects_used=answer.get("objects_used"),
                 semantic_context=answer.get("semantic_context"),
                 assumptions=answer.get("assumptions"),

--- a/sources/gsf/src/gsf/models.py
+++ b/sources/gsf/src/gsf/models.py
@@ -77,10 +77,14 @@ class TextToSQLRequest(GSFRequest):
 
 
 class TextToPQLRequest(GSFRequest):
-    """Generate validated PQL for prediction workflows."""
+    """Run a natural-language question through GSF's PQL prediction path."""
 
     question: str = Field(min_length=1, max_length=4_096)
-    database_name: str | None = None
+    database_name: str | None = Field(
+        default=None,
+        description="Optional benchmark-only database selector; normal AI-Q calls leave this unset.",
+    )
+    max_rows: int = Field(default=1_000, ge=1)
 
 
 class TextToSQLResponse(GSFResponse):
@@ -103,11 +107,16 @@ class TextToSQLResponse(GSFResponse):
 
 
 class TextToPQLResponse(GSFResponse):
-    """Validated PQL and semantic provenance returned by GSF."""
+    """PQL, bounded prediction results, and diagnostic context returned by GSF."""
 
     request_id: str | None = None
     response: str | None = None
-    pql: str
+    thoughts: str | None = None
+    pql: str | None = None
+    columns: list[ResultColumn] = Field(default_factory=list)
+    rows: list[dict[str, Any]] = Field(default_factory=list)
+    truncated: bool = False
+    custom_analyses_used: list[Any] | None = None
     objects_used: list[str] | None = None
     semantic_context: SemanticContext | None = None
     assumptions: list[str] | None = None

--- a/sources/gsf/src/gsf/register.py
+++ b/sources/gsf/src/gsf/register.py
@@ -25,6 +25,7 @@ from .errors import GSFError
 from .errors import GSFErrorCode
 from .errors import GSFToolError
 from .models import CatalogSearchRequest
+from .models import TextToPQLRequest
 from .models import TextToSQLRequest
 
 logger = logging.getLogger(__name__)
@@ -156,6 +157,32 @@ async def gsf_function_group(config: GSFFunctionGroupConfig, _builder: Builder):
                     )
                 )
 
+        async def text_to_pql(request: TextToPQLRequest) -> str:
+            """Run a prediction question through GSF's Kumo/PQL path.
+
+            Use for questions that ask what is likely to happen, which entities are most likely to experience an
+            outcome, or for a forecast. The result preserves GSF's generated PQL, prediction response, bounded rows,
+            and available diagnostics so callers can distinguish successful execution from a reported failure.
+            """
+
+            try:
+                result = await client.text_to_pql(
+                    request,
+                    token=_resolve_request_token(config),
+                    trace_headers=_request_trace_headers(),
+                )
+                return result.model_dump_json(exclude_none=True)
+            except GSFError as error:
+                return _tool_error(error)
+            except Exception:
+                logger.exception("Unexpected GSF text-to-PQL failure")
+                return _tool_error(
+                    GSFError(
+                        GSFErrorCode.UPSTREAM_ERROR,
+                        "GSF text-to-PQL failed.",
+                    )
+                )
+
         group = FunctionGroup(config=config)
         group.add_function(
             "catalog_search",
@@ -168,5 +195,11 @@ async def gsf_function_group(config: GSFFunctionGroupConfig, _builder: Builder):
             text_to_sql,
             input_schema=TextToSQLRequest,
             description=text_to_sql.__doc__,
+        )
+        group.add_function(
+            "text_to_pql",
+            text_to_pql,
+            input_schema=TextToPQLRequest,
+            description=text_to_pql.__doc__,
         )
         yield group

--- a/sources/gsf/src/gsf/register.py
+++ b/sources/gsf/src/gsf/register.py
@@ -92,8 +92,11 @@ def _request_trace_headers() -> Mapping[str, str]:
     try:
         metadata = Context.get().metadata
         incoming = metadata.headers if metadata else None
-    except Exception:
-        logger.debug("Unable to read request trace headers from NAT context", exc_info=True)
+    except Exception as exc:
+        logger.debug(
+            "Unable to read request trace headers from NAT context (error_type=%s)",
+            type(exc).__name__,
+        )
         return {}
     if not incoming:
         return {}
@@ -122,8 +125,11 @@ async def gsf_function_group(config: GSFFunctionGroupConfig, _builder: Builder):
                 return result.model_dump_json(exclude_none=True)
             except GSFError as error:
                 return _tool_error(error)
-            except Exception:
-                logger.exception("Unexpected GSF catalog-search failure")
+            except Exception as exc:
+                logger.error(
+                    "Unexpected GSF catalog-search failure (error_type=%s)",
+                    type(exc).__name__,
+                )
                 return _tool_error(
                     GSFError(
                         GSFErrorCode.UPSTREAM_ERROR,
@@ -148,8 +154,11 @@ async def gsf_function_group(config: GSFFunctionGroupConfig, _builder: Builder):
                 return result.model_dump_json(exclude_none=True)
             except GSFError as error:
                 return _tool_error(error)
-            except Exception:
-                logger.exception("Unexpected GSF text-to-SQL failure")
+            except Exception as exc:
+                logger.error(
+                    "Unexpected GSF text-to-SQL failure (error_type=%s)",
+                    type(exc).__name__,
+                )
                 return _tool_error(
                     GSFError(
                         GSFErrorCode.UPSTREAM_ERROR,
@@ -174,8 +183,11 @@ async def gsf_function_group(config: GSFFunctionGroupConfig, _builder: Builder):
                 return result.model_dump_json(exclude_none=True)
             except GSFError as error:
                 return _tool_error(error)
-            except Exception:
-                logger.exception("Unexpected GSF text-to-PQL failure")
+            except Exception as exc:
+                logger.error(
+                    "Unexpected GSF text-to-PQL failure (error_type=%s)",
+                    type(exc).__name__,
+                )
                 return _tool_error(
                     GSFError(
                         GSFErrorCode.UPSTREAM_ERROR,

--- a/sources/gsf/tests/conftest.py
+++ b/sources/gsf/tests/conftest.py
@@ -70,7 +70,11 @@ def chat_pql_answer() -> dict:
 
     return {
         "response": "A churn prediction query was generated.",
+        "thoughts": "- Constructing PQL: Predicted customer churn over 30 days.",
         "sql_code": "PREDICT churn FOR customers NEXT 30 DAYS",
+        "sql_columns": [{"name": "customer_id"}, {"name": "score"}],
+        "sql_response_from_db": ['[{"customer_id":"customer-1","score":0.9}]'],
+        "custom_analyses_used": [],
         "objects_used": ["prediction:churn"],
         "semantic_context": {
             "metrics": [{"id": "prediction:churn"}],
@@ -119,7 +123,12 @@ def text_to_pql_response() -> dict:
     return {
         "request_id": "gsf-request-2",
         "response": "A churn prediction query was generated.",
+        "thoughts": "- Constructing PQL: Predicted customer churn over 30 days.",
         "pql": "PREDICT churn FOR customers NEXT 30 DAYS",
+        "columns": [{"name": "customer_id"}, {"name": "score"}],
+        "rows": [{"customer_id": "customer-1", "score": 0.9}],
+        "truncated": False,
+        "custom_analyses_used": [],
         "objects_used": ["prediction:churn"],
         "semantic_context": {
             "metrics": [{"id": "prediction:churn"}],

--- a/sources/gsf/tests/test_client.py
+++ b/sources/gsf/tests/test_client.py
@@ -224,8 +224,8 @@ async def test_text_to_sql_skips_malformed_intermediate_sse_event(chat_sql_answe
 
 
 @pytest.mark.asyncio
-async def test_text_to_pql_maps_database_to_target_db(chat_pql_answer: dict) -> None:
-    """Map prediction database scope to the GSF target_db field."""
+async def test_text_to_pql_uses_prediction_routing_without_database_scope(chat_pql_answer: dict) -> None:
+    """Route predictions without selecting a database in the AI-Q tool call."""
 
     seen_payload: dict | None = None
 
@@ -237,6 +237,36 @@ async def test_text_to_pql_maps_database_to_target_db(chat_pql_answer: dict) -> 
     client = GSFClient(base_url="https://gsf.example", transport=httpx.MockTransport(handler))
     async with client:
         result = await client.text_to_pql(
+            TextToPQLRequest(question="Predict churn risk"),
+            token="user-token",
+        )
+
+    assert seen_payload == {
+        "question": "Predict churn risk",
+        "prediction": True,
+    }
+    assert result.pql == "PREDICT churn FOR customers NEXT 30 DAYS"
+    assert result.response == "A churn prediction query was generated."
+    assert result.thoughts == "- Constructing PQL: Predicted customer churn over 30 days."
+    assert [column.name for column in result.columns] == ["customer_id", "score"]
+    assert result.rows == [{"customer_id": "customer-1", "score": 0.9}]
+    assert result.truncated is False
+
+
+@pytest.mark.asyncio
+async def test_text_to_pql_supports_optional_benchmark_database_scope(chat_pql_answer: dict) -> None:
+    """Forward an explicitly configured benchmark database without making it the default path."""
+
+    seen_payload: dict | None = None
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal seen_payload
+        seen_payload = json.loads(request.content)
+        return _sse_response(chat_pql_answer)
+
+    client = GSFClient(base_url="https://gsf.example", transport=httpx.MockTransport(handler))
+    async with client:
+        await client.text_to_pql(
             TextToPQLRequest(question="Predict churn risk", database_name="benchmark_db"),
             token="user-token",
         )
@@ -246,8 +276,30 @@ async def test_text_to_pql_maps_database_to_target_db(chat_pql_answer: dict) -> 
         "prediction": True,
         "target_db": "benchmark_db",
     }
-    assert result.pql == "PREDICT churn FOR customers NEXT 30 DAYS"
-    assert result.response == "A churn prediction query was generated."
+
+
+@pytest.mark.asyncio
+async def test_text_to_pql_preserves_failure_diagnostics_without_pql() -> None:
+    """Return GSF's prediction failure explanation even when it produced no PQL."""
+
+    answer = {
+        "response": "Prediction could not be completed because no valid entity was found.",
+        "thoughts": "- Preparing candidates: No primary-key entity matched the question.",
+        "sql_code": None,
+        "sql_columns": [],
+        "sql_response_from_db": None,
+    }
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return _sse_response(answer)
+
+    client = GSFClient(base_url="https://gsf.example", transport=httpx.MockTransport(handler))
+    async with client:
+        result = await client.text_to_pql(TextToPQLRequest(question="Predict demand"), token="user-token")
+
+    assert result.pql is None
+    assert result.response == "Prediction could not be completed because no valid entity was found."
+    assert result.rows == []
 
 
 @pytest.mark.asyncio

--- a/sources/gsf/tests/test_models.py
+++ b/sources/gsf/tests/test_models.py
@@ -78,12 +78,14 @@ def test_text_to_sql_request_supports_optional_database_name() -> None:
     assert request.max_rows == 1_000
 
 
-def test_text_to_pql_request_supports_optional_database_name() -> None:
-    """Accept an optional database scope for prediction requests."""
+def test_text_to_pql_request_omits_database_selector_by_default() -> None:
+    """Leave prediction routing unscoped for normal AI-Q calls."""
 
-    request = TextToPQLRequest(question="Predict churn", database_name="benchmark_db")
+    request = TextToPQLRequest(question="Predict churn")
 
-    assert request.database_name == "benchmark_db"
+    assert request.database_name is None
+    assert request.max_rows == 1_000
+    assert "database_name" not in request.model_dump(exclude_none=True)
 
 
 def test_query_context_request_omits_optional_database_name() -> None:
@@ -123,6 +125,10 @@ def test_text_to_pql_response_accepts_missing_future_enrichments() -> None:
     result = TextToPQLResponse.model_validate({"pql": "PREDICT churn FOR customers NEXT 30 DAYS"})
 
     assert result.request_id is None
+    assert result.thoughts is None
+    assert result.columns == []
+    assert result.rows == []
+    assert result.truncated is False
     assert result.semantic_context is None
     assert result.warnings is None
 

--- a/sources/gsf/tests/test_register.py
+++ b/sources/gsf/tests/test_register.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import pytest
 from gsf.models import CatalogSearchResponse
+from gsf.models import TextToPQLResponse
 from gsf.models import TextToSQLResponse
 from gsf.register import GSFFunctionGroupConfig
 from gsf.register import GSFPasswordAuthConfig
@@ -91,6 +92,21 @@ async def test_group_exposes_only_requested_tools(text_to_sql_response: dict) ->
             tools = await group.get_accessible_functions()
 
     assert set(tools) == {"gsf__text_to_sql"}
+
+
+@pytest.mark.asyncio
+async def test_group_exposes_text_to_pql_when_requested(text_to_pql_response: dict) -> None:
+    """Expose the prediction tool only when selected by the function-group include list."""
+
+    client = MagicMock()
+    client.text_to_pql = AsyncMock(return_value=TextToPQLResponse.model_validate(text_to_pql_response))
+    config = GSFFunctionGroupConfig(base_url="https://gsf.example", include=["text_to_pql"])
+
+    with patch("gsf.register.GSFClient.from_config", return_value=FakeClientContext(client)):
+        async with gsf_function_group(config, MagicMock()) as group:
+            tools = await group.get_accessible_functions()
+
+    assert set(tools) == {"gsf__text_to_pql"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
#### Overview

Adds the `gsf__text_to_pql` tool to the existing GSF function group. The tool calls `POST /api/chat/completions` with `prediction: true` and returns generated PQL, bounded prediction rows, response text, thoughts, and available diagnostics.

Normal AI-Q calls rely on GSF routing without specifying a database. Automated benchmarks may optionally provide `database_name`, which is forwarded as `target_db`.

The README documents the tool, API mapping, request-scoped user-token forwarding, and password-session lifecycle for development and evaluation.

#### DCO sign-off for the squash commit

Signed-off-by: Soumili Nandi <soumilin@nvidia.com>

#### Validation

- `.venv/bin/pytest sources/gsf/tests` — 43 passed
- `.venv/bin/ruff check sources/gsf` — passed
- `.venv/bin/ruff format --check sources/gsf` — passed
- `git diff --check` — passed
- Pre-commit hooks, including secret detection and Markdown link checking — passed

- [x] I ran the relevant local checks or explained why they are not applicable.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-facing or contributor-facing changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.
- [x] I replaced the DCO sign-off placeholder with my GitHub commit identity and kept the required angle brackets around the email address.

#### Where should reviewers start?

Start with `text_to_pql` in `sources/gsf/src/gsf/client.py`, its registration in `sources/gsf/src/gsf/register.py`, and the default versus benchmark-scoped request tests in `sources/gsf/tests/test_client.py`.

#### Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added text-to-PQL support for generating queries from natural-language requests.
  * Added optional result limits, normalized columns and rows, truncation status, and analysis metadata.
  * Preserved diagnostic details when predictions fail to produce PQL.
  * Added optional database targeting and request-scoped authentication.

* **Documentation**
  * Updated GSF documentation with text-to-PQL usage, configuration, authentication behavior, and API mappings.

* **Tests**
  * Expanded coverage for routing, result normalization, truncation, diagnostics, and tool registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->