### PR TITLE
feat(deep-research): loop guard middleware to bound researcher calls

### DIFF
--- a/docs/source/customization/configuration-reference.md
+++ b/docs/source/customization/configuration-reference.md
@@ -487,6 +487,12 @@ functions:
       max_todo_items: 20
       max_todo_item_chars: 2048
       max_total_todo_chars: 10000
+    researcher_loop_guard:
+      enabled: true
+      max_source_calls_per_query: 25
+      max_identical_source_calls: 3
+      max_consecutive_thinks: 3
+      max_model_turns_per_query: 60
     verbose: true
 ```
 
@@ -508,6 +514,7 @@ functions:
 | `max_concurrent_source_tool_calls` | `int` | `5` | Shared cap on concurrent source-tool calls across all researcher workers in the run. |
 | `max_source_tool_batch_size` | `int` | `4` | Maximum concrete inputs accepted by a batch-capable source-tool wrapper in one call. |
 | `resource_limits` | object | See below | Non-disableable per-job request, graph, state, and provider-call ceilings. Values may be reduced but cannot exceed the defaults. |
+| `researcher_loop_guard` | object | See below | Per-researcher circuit breaker bounding one `run_research_batch` worker. Optional; omitting it uses the defaults. |
 | `verbose` | `bool` | `true` | Enable verbose logging. |
 
 `resource_limits` is enforced in both synchronous and async-job construction:
@@ -533,6 +540,82 @@ functions:
 `max_research_concurrency` cannot exceed `resource_limits.max_research_queries`.
 When lowering the job-wide query budget below the default concurrency of `6`,
 lower `max_research_concurrency` in the same configuration.
+
+#### Researcher loop guard
+
+`researcher_loop_guard` bounds **one researcher worker** — a single `ResearchQuery` executed inside
+`run_research_batch`. It is a deterministic circuit breaker that runs underneath the model, so it does not depend on
+the model following prompt guidance. `resource_limits` is its complement: that bounds the whole job, this bounds one
+worker.
+
+| Parameter | Default | Max | Enforcement boundary |
+|-----------|---------|-----|----------------------|
+| `enabled` | `true` | — | Set `false` to disable every limit below at once. There is no partial-disable mode, no tool is withdrawn while it is `false`, and no recursion limit is bound. |
+| `max_source_calls_per_query` | `25` | `100` | Model-issued source-tool invocations for one `ResearchQuery`. |
+| `max_identical_source_calls` | `3` | `10` | Invocations of one source tool with identical arguments. The repeat is not executed. |
+| `max_consecutive_thinks` | `3` | `10` | Uninterrupted `think` calls. Any other tool call resets the streak. |
+| `max_model_turns_per_query` | `60` | `250` | Total model calls for one `ResearchQuery`, searching or not. On the last turn every tool is withdrawn. |
+
+Each limit is validated on both sides (minimum `1`, maximum as above); a value outside the range is a startup failure,
+not a silent clamp. Unlike `resource_limits`, whose defaults are also its maxima because those limits may only be
+tightened, these ceilings sit *above* their defaults: raising a breaker that fires on healthy runs is the supported
+tuning path, and the ceiling only bounds how far it can be raised. `max_source_calls_per_query` is capped at the same
+value as the job-wide `resource_limits.max_source_tool_calls`, so one worker can never be budgeted above what the
+whole job is allowed to retrieve.
+
+When `max_source_calls_per_query` is reached, the guard preserves the last search result and appends an exhaustion
+notice to it. When a later identical request would exceed `max_identical_source_calls`, that request is not executed
+and the guard returns an error `ToolMessage`. In either case, it withdraws the source tools and `think` from every
+later model call. The worker is directed to return its `ResearchNotes` from the evidence already gathered, recording
+unsupported components as explicit `ResearchGap` entries and lowering `evidence_judgment` to mark the note as
+truncated. It is a graceful degradation, not a failure — the worker still contributes notes.
+
+Those three limits narrow the loop rather than close it: the filesystem tools stay callable, so a worker can still
+spend turns re-reading `/shared` after a withdrawal. `max_model_turns_per_query` closes it. It counts every model
+call, and on the final one the guard withdraws *all* tools and disables native structured-output binding. The
+structured-response text fallback then promotes schema-valid JSON, or makes one tools-disabled correction call, so
+the worker can still return `ResearchNotes` without sending a provider an empty `tools` array.
+
+**What `max_source_calls_per_query` counts.** Model-issued *invocations*, not concrete provider calls. One
+batch-capable invocation carrying four queries costs **one** unit of this budget but four concrete calls against
+`resource_limits.max_source_tool_calls`. The four limits in play bound different things:
+
+| Limit | Scope | Bounds |
+|-------|-------|--------|
+| `researcher_loop_guard.max_source_calls_per_query` | One researcher invocation | Model-issued search *iterations* |
+| `max_source_tool_batch_size` | One tool invocation | Concrete inputs in one logical call |
+| `max_concurrent_source_tool_calls` | Whole job | Concrete calls executing concurrently |
+| `resource_limits.max_source_tool_calls` | Whole job | Aggregate concrete attempts and batch items |
+
+Two consequences worth knowing:
+
+- **The repeated-request rule matches whole invocations.** Its signature covers the tool name plus the complete
+  canonical argument object, and canonicalizes argument key *order* only — not case or whitespace. Re-sending an
+  identical batch is caught; two different batches that share individual queries are not deduplicated item by item,
+  and `"AI research"` and `"ai research"` are distinct requests.
+- **Framework retries cost one unit, not several.** The guard sits outside the tool-retry middleware, so a request
+  retried three times after a transient failure still consumes a single unit.
+
+`max_model_turns_per_query` also derives the researcher subgraph's recursion limit
+(`turns * 2 + 10` graph steps), so raising the turn ceiling raises that limit with it. The recursion limit is a
+backstop, not the operative bound: the guard forces finalization on the last allowed turn, which is a full turn
+before the ceiling can be reached, so a healthy worker never encounters it.
+
+When `enabled` is `false` no recursion limit is bound at all and the subgraph inherits the orchestrator's. That is
+deliberate — with no guard to force a graceful finish, a tight worker-scoped limit would only convert long runs into
+`GraphRecursionError`, which discards every note the worker had gathered. Disabling the guard therefore restores
+pre-guard behavior in full rather than leaving a bound that nothing can steer the model away from.
+
+The guard is enforced only for `deep_research_agent` researcher workers; the planner, writer, and orchestrator stacks
+are unaffected. Because `chat_researcher` resolves the deep researcher by function name rather than building its own
+graph, configuring `researcher_loop_guard` under `deep_research_agent` automatically covers the chat researcher's
+deep path. `shallow_research_agent` is a separate agent and is not affected.
+
+To see how often the breaker fires in a run, grep the logs for `Researcher source-call budget reached` (INFO, on
+exhaustion), `Researcher loop guard blocked` (WARNING, per blocked call), and
+`Researcher loop guard forcing finalization` (WARNING, on the turn ceiling). A breaker that fires on healthy runs is
+set too low: raise it. The symptom is `ResearchNotes` with spurious `ResearchGap` entries rather than an obvious
+failure.
 
 `data_sources` request filtering happens after this configured tool set is resolved. It removes tools mapped to
 unselected registry sources but preserves configured tools with no source mapping. Router recommendations become

--- a/src/aiq_agent/agents/deep_researcher/agent.py
+++ b/src/aiq_agent/agents/deep_researcher/agent.py
@@ -47,6 +47,7 @@ from .factory import build_deep_research_graph
 from .factory import build_deep_research_middleware_set
 from .factory import build_deep_research_tool_set
 from .models import DeepResearchAgentState
+from .models import ResearcherLoopGuardConfig
 from .resource_limits import DeepResearchExecutionTimeout
 from .resource_limits import DeepResearchResourceLimits
 from .resource_limits import StateBudgetLedger
@@ -88,6 +89,7 @@ class DeepResearcherAgent:
         max_concurrent_source_tool_calls: int = DEFAULT_MAX_CONCURRENT_SOURCE_TOOL_CALLS,
         max_source_tool_batch_size: int = DEFAULT_MAX_SOURCE_TOOL_BATCH_SIZE,
         resource_limits: DeepResearchResourceLimits | None = None,
+        researcher_loop_guard: ResearcherLoopGuardConfig | None = None,
     ) -> None:
         """
         Initialize the deep researcher agent.
@@ -108,6 +110,8 @@ class DeepResearcherAgent:
             max_concurrent_source_tool_calls: Shared source-tool concurrency limit across researcher workers.
             max_source_tool_batch_size: Maximum concrete inputs per batch-capable source tool call.
             resource_limits: Hard per-job request, state, source-call, and wall-clock limits.
+            researcher_loop_guard: Per-researcher circuit breaker bounding one run_research_batch
+                worker's source calls, repeated requests, and consecutive think calls.
         """
         self.llm_provider = llm_provider
         self.tools = list(tools) if tools else []
@@ -117,6 +121,7 @@ class DeepResearcherAgent:
         self.max_concurrent_source_tool_calls = max_concurrent_source_tool_calls
         self.max_source_tool_batch_size = max_source_tool_batch_size
         self.resource_limits = resource_limits or DeepResearchResourceLimits()
+        self.researcher_loop_guard = researcher_loop_guard or ResearcherLoopGuardConfig()
         self.domain_catalog_path = domain_catalog_path
         self.enable_source_router = enable_source_router
         self.enable_citation_verification = enable_citation_verification
@@ -145,6 +150,7 @@ class DeepResearcherAgent:
                 source_registry_middleware=self.source_registry_middleware,
                 enable_source_router=self.enable_source_router,
                 artifact_manager=self.deepagents_runtime.artifact_manager,
+                researcher_loop_guard=self.researcher_loop_guard,
             )
 
             self.source_tool_names = self.tool_set.source_tool_names
@@ -207,6 +213,7 @@ class DeepResearcherAgent:
             enable_source_router=self.enable_source_router,
             max_research_concurrency=self.max_research_concurrency,
             resource_limits=self.resource_limits,
+            researcher_loop_guard=self.researcher_loop_guard,
             final_report_tracker=final_report_tracker,
             state_budget=state_budget,
         )

--- a/src/aiq_agent/agents/deep_researcher/custom_middleware.py
+++ b/src/aiq_agent/agents/deep_researcher/custom_middleware.py
@@ -44,6 +44,9 @@ from aiq_agent.common.citation_verification import extract_sources_from_tool_res
 from aiq_agent.common.citation_verification import is_non_citable_status_output
 from aiq_agent.common.logging_utils import log_content_metadata
 
+from .models.loop_guard import ResearcherLoopGuardConfig
+from .researcher_context import CURRENT_RESEARCHER_GUARD_STATE
+from .researcher_context import ResearcherRunGuardState
 from .resource_limits import DeepResearchResourceLimits
 from .resource_limits import StateBudgetLedger
 
@@ -1426,3 +1429,264 @@ class ToolResultPruningMiddleware(AgentMiddleware):
                 pruned_messages.append(msg)
 
         return await handler(request.override(messages=pruned_messages))
+
+
+_THINK_TOOL = "think"
+
+# Appended (never substituted) to the last allowed source result, so the evidence from that
+# final search survives the exhaustion signal. Read only by the researcher inside its own
+# subgraph: `run_research_batch` returns serialized ResearchNotes (or a per-item error string)
+# to the orchestrator, so researcher tool messages never cross that boundary and this wording
+# is not part of any orchestrator-facing contract. It pairs with the withdrawal guidance in
+# researcher.j2, which is what tells the model how to react to it.
+_RESEARCHER_BUDGET_NUDGE = (
+    "\n\n[SYSTEM — researcher source budget is exhausted. Stop searching and return your "
+    "ResearchNotes now using the evidence already gathered. Record every unsupported target "
+    "component as an explicit ResearchGap entry and set evidence_judgment to reflect the "
+    "truncation; do not guess.]"
+)
+
+
+def _canonical_source_signature(tool_name: str, args: object) -> str:
+    """Hash a source-tool name and its canonical arguments without retaining argument content.
+
+    Only JSON key *order* is canonicalized. Case and whitespace are not, so ``"AI research"``
+    and ``"ai research"`` produce different signatures and both may run.
+    """
+    try:
+        canonical_args = json.dumps(args, sort_keys=True, separators=(",", ":"), default=repr)
+    except (TypeError, ValueError):
+        canonical_args = repr(args)
+    payload = f"{tool_name}:{canonical_args}".encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+class ResearcherLoopGuardMiddleware(AgentMiddleware):
+    """Bound one researcher invocation's source calls, repeated requests, and think loops.
+
+    A deterministic circuit breaker for a single ``ResearchQuery`` executed by a
+    ``run_research_batch`` worker. It runs underneath the model, so it does not depend on the
+    model obeying prompt guidance. Four limits share one class and one ``enabled`` flag:
+
+    1. a flat budget of model-issued source-tool invocations (``max_source_calls_per_query``);
+    2. repeats of an identical tool name plus identical arguments
+       (``max_identical_source_calls``), which are blocked without being executed;
+    3. uninterrupted ``think`` calls (``max_consecutive_thinks``), which are warned about but
+       never blocked;
+    4. total model turns (``max_model_turns_per_query``).
+
+    Reaching (1) or (2) marks the invocation exhausted, which withdraws the source tools *and*
+    ``think`` from every later model call. Reaching (3) withdraws only ``think``. The guard
+    never terminates the sub-agent; it removes the tools that let it keep looping and steers it
+    to return ``ResearchNotes`` with explicit ``ResearchGap`` entries.
+
+    (4) is the one that closes rather than narrows the loop. (1)-(3) leave the filesystem tools
+    callable, so a worker that answers a withdrawal by re-reading ``/shared`` can still burn
+    turns until the subgraph's recursion limit raises ``GraphRecursionError`` - which discards
+    every note it had gathered, the exact failure this guard exists to prevent. On the final
+    turn the guard therefore withdraws *all* tools and disables native structured-output
+    binding. ``StructuredResponseTextFallbackMiddleware`` then promotes schema-valid JSON (or
+    makes one tools-disabled correction call), so the worker can still return ``ResearchNotes``
+    without sending providers an invalid empty tools array.
+
+    All mutable state lives in :data:`CURRENT_RESEARCHER_GUARD_STATE`, not on the instance,
+    because ``DeepResearcherAgent`` builds its middleware once and reuses it across concurrent
+    workers and requests. When no state is installed (planner, writer, orchestrator) the guard
+    is a pass-through.
+    """
+
+    def __init__(
+        self,
+        *,
+        source_tool_names: set[str] | frozenset[str],
+        config: ResearcherLoopGuardConfig,
+    ) -> None:
+        """Bind the guard to the source-tool names it counts and its configured limits."""
+        self._source_tool_names = frozenset(source_tool_names)
+        self._config = config
+
+    @staticmethod
+    def _mark_exhausted(state: ResearcherRunGuardState, reason: str) -> None:
+        """Record why this invocation's research budget ended."""
+        state.exhausted = True
+        state.exhaustion_reason = reason
+
+    @staticmethod
+    def _append_nudge(result):
+        """Append the exhaustion notice to a tool result, preserving its evidence."""
+        try:
+            return result.model_copy(update={"content": f"{result.content}{_RESEARCHER_BUDGET_NUDGE}"})
+        except Exception:  # noqa: BLE001 - the nudge is best-effort; tool withdrawal is the hard guarantee
+            return result
+
+    @staticmethod
+    def _blocked_result(tool_call: dict, reason: str) -> ToolMessage:
+        """Build the error result returned in place of a source call that was not executed."""
+        return ToolMessage(
+            content=(
+                f"Source tool not executed: researcher loop guard reached {reason}. The source "
+                "budget is exhausted. Stop searching and return your ResearchNotes using the "
+                "evidence already gathered; record unsupported requirements as ResearchGap "
+                "entries and set evidence_judgment to reflect the truncation."
+            ),
+            tool_call_id=tool_call.get("id", "researcher-loop-guard"),
+            name=tool_call.get("name", "source-tool"),
+            status="error",
+        )
+
+    def _filter_tools(self, tools: list[object]) -> list[object]:
+        """Return the tool list with tools this invocation may no longer use removed."""
+        state = CURRENT_RESEARCHER_GUARD_STATE.get()
+        if not self._config.enabled or state is None:
+            return tools
+        hidden = set()
+        if state.exhausted:
+            hidden.update(self._source_tool_names)
+            hidden.add(_THINK_TOOL)
+        elif state.think_blocked:
+            hidden.add(_THINK_TOOL)
+        if not hidden:
+            return tools
+        return [tool for tool in tools if _request_tool_name(tool) not in hidden]
+
+    def _guard_model_request(self, request):
+        """Count this turn and return the request with the tools it may still use.
+
+        On the final allowed turn every tool and the native response format are withdrawn. The
+        outer text-fallback middleware promotes or corrects the resulting JSON into
+        ``ResearchNotes``, ending the invocation before ``GraphRecursionError``. Below that,
+        only the exhausted source/think tools go.
+
+        The count can overshoot by one: this guard sits *inside*
+        ``StructuredResponseTextFallbackMiddleware``, whose corrective second call re-enters
+        here. Overshooting stops the worker a turn early, which is the safe direction, and the
+        recursion limit keeps its headroom for exactly this.
+        """
+        state = CURRENT_RESEARCHER_GUARD_STATE.get()
+        if not self._config.enabled or state is None:
+            return request
+
+        state.model_turn_count += 1
+        turn_limit = self._config.max_model_turns_per_query
+        if state.model_turn_count < turn_limit:
+            return request.override(tools=self._filter_tools(request.tools))
+
+        logger.warning(
+            "Researcher loop guard forcing finalization | invocation=%s turns=%d/%d",
+            state.invocation_id,
+            state.model_turn_count,
+            turn_limit,
+        )
+        return request.override(tools=[], tool_choice=None, response_format=None)
+
+    def wrap_model_call(self, request, handler):
+        """Count the turn and withdraw tools before a synchronous model call."""
+        return handler(self._guard_model_request(request))
+
+    async def awrap_model_call(self, request, handler):
+        """Count the turn and withdraw tools before an asynchronous model call."""
+        return await handler(self._guard_model_request(request))
+
+    async def awrap_tool_call(self, request, handler):
+        """Route a tool call to the think or source-budget guard, or pass it straight through."""
+        state = CURRENT_RESEARCHER_GUARD_STATE.get()
+        tool_call = getattr(request, "tool_call", None)
+        if not self._config.enabled or state is None or not isinstance(tool_call, dict):
+            return await handler(request)
+
+        name = tool_call.get("name")
+        if name == _THINK_TOOL:
+            return await self._guard_think(request, handler, state, name)
+        # Any non-think call breaks a think streak and makes `think` available again. Resetting
+        # before dispatch also preserves that contract when the non-think tool itself fails.
+        state.consecutive_think_count = 0
+        state.think_blocked = False
+        if name not in self._source_tool_names:
+            return await handler(request)
+        return await self._guard_source_call(request, handler, state, tool_call, name)
+
+    async def _guard_think(self, request, handler, state: ResearcherRunGuardState, name: str):
+        """Count uninterrupted think calls and overwrite the result with a warning at the limit.
+
+        Thinking is never blocked - the handler always runs. Past the threshold the result text
+        is replaced with a corrective warning and ``think`` is withdrawn from later model calls,
+        which closes the pure think-loop. The alternating ``think -> same_search`` loop is caught
+        by the identical-request rule instead.
+        """
+        state.consecutive_think_count += 1
+        count = state.consecutive_think_count
+        result = await handler(request)
+        if count < self._config.max_consecutive_thinks:
+            return result
+
+        state.think_blocked = True
+        logger.warning(
+            "Researcher loop guard blocked further thinking | invocation=%s tool=%s thinks=%d/%d",
+            state.invocation_id,
+            name,
+            count,
+            self._config.max_consecutive_thinks,
+        )
+        warning = (
+            f"Thought recorded. WARNING: You have called 'think' {count} times in a row without "
+            "taking action. `think` is now withdrawn. Call a real tool or return your "
+            "ResearchNotes instead of thinking again."
+        )
+        try:
+            # Overwrite rather than append: a think result carries no evidence worth preserving.
+            return result.model_copy(update={"content": warning})
+        except Exception:  # noqa: BLE001 - the warning is best-effort; tool withdrawal is the hard guarantee
+            return result
+
+    async def _guard_source_call(
+        self,
+        request,
+        handler,
+        state: ResearcherRunGuardState,
+        tool_call: dict,
+        name: str,
+    ):
+        """Enforce the source-call budget and the identical-request limit for one invocation."""
+        budget = self._config.max_source_calls_per_query
+        if state.exhausted or state.source_call_count >= budget:
+            self._mark_exhausted(state, "total source-call budget")
+            logger.warning(
+                "Researcher loop guard blocked source call | invocation=%s tool=%s calls=%d/%d reason=total_budget",
+                state.invocation_id,
+                name,
+                state.source_call_count,
+                budget,
+            )
+            return self._blocked_result(tool_call, "the total source-call budget")
+
+        signature = _canonical_source_signature(name, tool_call.get("args", {}))
+        identical_count = state.source_signature_counts.get(signature, 0)
+        if identical_count >= self._config.max_identical_source_calls:
+            self._mark_exhausted(state, "repeated source-call signature")
+            logger.warning(
+                "Researcher loop guard blocked repeated source call | "
+                "invocation=%s tool=%s repeats=%d/%d reason=repeated_signature",
+                state.invocation_id,
+                name,
+                identical_count,
+                self._config.max_identical_source_calls,
+            )
+            return self._blocked_result(tool_call, "the repeated source-call limit")
+
+        # Count before awaiting so source calls dispatched together in one assistant turn share
+        # a single hard ceiling instead of all passing the check and then all executing.
+        state.source_call_count += 1
+        state.source_signature_counts[signature] = identical_count + 1
+        result = await handler(request)
+
+        if state.source_call_count >= budget:
+            self._mark_exhausted(state, "total source-call budget")
+            logger.info(
+                "Researcher source-call budget reached | invocation=%s tool=%s calls=%d/%d",
+                state.invocation_id,
+                name,
+                state.source_call_count,
+                budget,
+            )
+            return self._append_nudge(result)
+        return result

--- a/src/aiq_agent/agents/deep_researcher/factory.py
+++ b/src/aiq_agent/agents/deep_researcher/factory.py
@@ -51,6 +51,7 @@ from .custom_middleware import FinalReportOwnershipGuardMiddleware
 from .custom_middleware import PlanPersistenceMiddleware
 from .custom_middleware import RequiredOutputFileMiddleware
 from .custom_middleware import RequiredWriterDelegationMiddleware
+from .custom_middleware import ResearcherLoopGuardMiddleware
 from .custom_middleware import SourceRegistryMiddleware
 from .custom_middleware import SourceRoutingGuardMiddleware
 from .custom_middleware import SourceRoutingPersistenceMiddleware
@@ -64,6 +65,7 @@ from .custom_middleware import ToolVisibilityMiddleware
 from .deepagents_runtime import BUILTIN_SKILL_SOURCE
 from .deepagents_runtime import DeepAgentsRuntime
 from .models import DeepResearchAgentState
+from .models import ResearcherLoopGuardConfig
 from .models import ResearchNotes
 from .models import ResearchPlan
 from .models import SourceRoutingPlan
@@ -85,6 +87,13 @@ FILESYSTEM_TOOL_NAMES = {
     "read_file",
     "write_file",
 }
+# A researcher turn costs two graph steps: the model node and the tool node. Exact for this
+# stack - no researcher middleware defines a before_model/after_model hook, which would add a
+# node per turn. A middleware that does must revisit the turn-to-step arithmetic below.
+GRAPH_STEPS_PER_TURN = 2
+# Extra steps for the one-off before_agent nodes (skills, tool-call patching) and for the
+# structured-output correction pass, none of which are normal turns.
+RESEARCHER_RECURSION_HEADROOM = 10
 ORCHESTRATOR_AGENT = "orchestrator"
 PLANNER_AGENT = "planner-agent"
 RESEARCHER_AGENT = "researcher-agent"
@@ -278,6 +287,37 @@ def build_orchestrator_middleware(
     ]
 
 
+def build_researcher_middleware(
+    common_middleware: list[Any],
+    *,
+    tool_set: DeepResearchToolSet,
+    researcher_loop_guard: ResearcherLoopGuardConfig,
+) -> list[Any]:
+    """Extend the shared stack with the per-researcher loop guard.
+
+    The guard is placed immediately *before* ``ToolRetryMiddleware``. LangChain composes
+    ``wrap_tool_call`` wrappers first-in-list-outermost, so sitting outside the retry means one
+    logical source request that ``ToolRetryMiddleware`` retries three times is counted once and
+    retrying a transient failure never consumes the research budget. That is the only ordering
+    constraint: position relative to ``ToolNameSanitizationMiddleware`` does not matter, because
+    that middleware rewrites names in ``awrap_model_call`` - on the model node, before the tool
+    node runs - so every ``wrap_tool_call`` wrapper already sees the sanitized name.
+
+    ``tool_set.source_tool_names`` is correct even though the researcher is bound to the adapted
+    batch wrappers - those wrappers preserve the original tool name.
+    """
+    middleware = list(common_middleware)
+    tool_retry_index = next(i for i, item in enumerate(middleware) if isinstance(item, ToolRetryMiddleware))
+    middleware.insert(
+        tool_retry_index,
+        ResearcherLoopGuardMiddleware(
+            source_tool_names=tool_set.source_tool_names,
+            config=researcher_loop_guard,
+        ),
+    )
+    return middleware
+
+
 def build_source_router_middleware(*, extra_valid_tool_names: Sequence[str] = ()) -> list[Any]:
     """Build minimal middleware for the source-router-agent."""
     return [
@@ -294,6 +334,7 @@ def build_deep_research_middleware_set(
     source_registry_middleware: SourceRegistryMiddleware,
     enable_source_router: bool = True,
     artifact_manager: object | None = None,
+    researcher_loop_guard: ResearcherLoopGuardConfig | None = None,
 ) -> DeepResearchMiddlewareSet:
     """Build researcher, writer, and orchestrator middleware stacks."""
 
@@ -307,7 +348,11 @@ def build_deep_research_middleware_set(
         )
 
     return DeepResearchMiddlewareSet(
-        researcher=common(),
+        researcher=build_researcher_middleware(
+            common(),
+            tool_set=tool_set,
+            researcher_loop_guard=researcher_loop_guard or ResearcherLoopGuardConfig(),
+        ),
         planner=common(),
         writer=common(),
         orchestrator=build_orchestrator_middleware(
@@ -378,8 +423,24 @@ def build_researcher_runnable(
     backend: Any = None,
     visibility_middleware: list[Any] | None = None,
     filesystem_permissions: list[FilesystemPermission] | None = None,
+    researcher_loop_guard: ResearcherLoopGuardConfig | None = None,
 ) -> Any:
-    """Build the reusable single-query researcher runnable."""
+    """Build the reusable single-query researcher runnable.
+
+    When the guard is enabled the returned runnable carries its own ``recursion_limit``, derived
+    from ``max_model_turns_per_query``. Without it the subgraph inherits the orchestrator's limit
+    of 2000 - roughly 1000 model turns - so a stuck worker grinds for a very long time and then
+    loses all its gathered evidence to a ``GraphRecursionError``.
+
+    The limit is a backstop, not the operative bound: the guard withdraws every tool on turn
+    ``max_model_turns_per_query``, so the worker finalizes into ``ResearchNotes`` a full turn
+    plus ``RESEARCHER_RECURSION_HEADROOM`` steps before the ceiling can be reached. Nothing is
+    bound when the guard is disabled - with no guard to force that finalization, a derived limit
+    would only convert long runs into ``GraphRecursionError``, so the subgraph deliberately falls
+    back to the orchestrator's limit. ``researcher_invoke_config`` mirrors this by leaving the
+    inherited value in place.
+    """
+    guard_config = researcher_loop_guard or ResearcherLoopGuardConfig()
     middleware: list[Any] = []
     if skill_sources:
         middleware.append(SkillsMiddleware(backend=backend, sources=skill_sources))
@@ -393,13 +454,17 @@ def build_researcher_runnable(
             *(visibility_middleware or []),
         ]
     )
-    return create_agent(
+    agent = create_agent(
         model=researcher_model,
         tools=researcher_tools,
         system_prompt=system_prompt,
         middleware=middleware,
         response_format=ResearchNotes,
     )
+    if not guard_config.enabled:
+        return agent
+    recursion_limit = guard_config.max_model_turns_per_query * GRAPH_STEPS_PER_TURN + RESEARCHER_RECURSION_HEADROOM
+    return agent.with_config({"recursion_limit": recursion_limit})
 
 
 def _subagent_spec(
@@ -559,8 +624,10 @@ def build_deep_research_graph(
     state_budget: StateBudgetLedger | None = None,
     resource_limits: DeepResearchResourceLimits | None = None,
     enable_source_router: bool = True,
+    researcher_loop_guard: ResearcherLoopGuardConfig | None = None,
 ) -> Any:
     """Build the full DeepAgents graph for one deep research run."""
+    loop_guard = researcher_loop_guard or ResearcherLoopGuardConfig()
     # Cross-cutting middleware applied to every agent (researcher, subagents, orchestrator).
     # Agent-supplied execute timeouts are unreliable (LLMs pass milliseconds or arbitrarily
     # large values); clamp them to the configured sandbox lifetime so a single execute never
@@ -608,7 +675,11 @@ def build_deep_research_graph(
             "researcher",
             tools=context.tool_set.tools_info,
             execution_enabled=context.runtime.execution_enabled,
+            researcher_loop_guard_enabled=loop_guard.enabled,
+            researcher_max_source_calls=loop_guard.max_source_calls_per_query,
+            researcher_max_identical_source_calls=loop_guard.max_identical_source_calls,
         ),
+        researcher_loop_guard=loop_guard,
         researcher_middleware=[
             *context.middleware_set.researcher,
             FinalReportOwnershipGuardMiddleware(),
@@ -630,6 +701,9 @@ def build_deep_research_graph(
         resource_limits=context.resource_limits,
         state_budget=context.state_budget,
         source_registry_middleware=source_registry_middleware,
+        # Only meaningful when the runnable carries a limit of its own; see
+        # build_researcher_runnable.
+        strip_inherited_recursion_limit=loop_guard.enabled,
     )
 
     orchestrator_tools = [*context.tool_set.helper_tools, research_batch_tool]

--- a/src/aiq_agent/agents/deep_researcher/models/__init__.py
+++ b/src/aiq_agent/agents/deep_researcher/models/__init__.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .loop_guard import ResearcherLoopGuardConfig
 from .state import DeepResearchAgentState
 from .subagent_contracts import AnswerComponent
 from .subagent_contracts import AnswerStrategy
@@ -40,6 +41,7 @@ __all__ = [
     "ResearchPlan",
     "ResearchQuery",
     "ResearchSource",
+    "ResearcherLoopGuardConfig",
     "SourceRecommendation",
     "SourceRoutingPlan",
     "TaskAnalysis",

--- a/src/aiq_agent/agents/deep_researcher/models/loop_guard.py
+++ b/src/aiq_agent/agents/deep_researcher/models/loop_guard.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validated configuration for the deep researcher loop guard."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+
+# Upper bounds, not defaults. ``DeepResearchResourceLimits`` caps every field at its own
+# default (``le=DEFAULT_*``) because those limits may only ever be tightened. This config is
+# the opposite case: the documented tuning path is to *raise* a breaker that fires on healthy
+# runs, so each ceiling sits above its default and only bounds how far it can be raised.
+#
+# Matches ``resource_limits.DEFAULT_MAX_SOURCE_TOOL_CALLS`` (the job-wide ceiling on concrete
+# source calls), so one worker's logical-invocation budget can never be configured above what
+# the whole job is allowed to retrieve.
+SOURCE_CALLS_PER_QUERY_CEILING = 100
+# Past a handful of repeats the rule has stopped being a loop breaker, so the ceiling only has
+# to keep a typo from disabling it outright.
+IDENTICAL_SOURCE_CALLS_CEILING = 10
+CONSECUTIVE_THINKS_CEILING = 10
+# The turn ceiling also derives the researcher subgraph's recursion limit, so its bound is what
+# keeps a worker-scoped limit from being configured above the orchestrator's own 2000. At this
+# ceiling the derived limit is 250 * 2 + 10 = 510.
+MODEL_TURNS_PER_QUERY_CEILING = 250
+
+
+class ResearcherLoopGuardConfig(BaseModel):
+    """Hard limits for one deep researcher worker invocation.
+
+    Bounds a single ``ResearchQuery`` executed inside ``run_research_batch``. The guard is a
+    deterministic circuit breaker that runs underneath the model, so it does not depend on the
+    model obeying prompt guidance. It complements ``DeepResearchResourceLimits``, which bounds
+    the whole job rather than one worker.
+
+    Every limit is enforced by a single middleware, so ``enabled=False`` switches off the
+    complete circuit breaker rather than any one behavior.
+
+    Every limit is bounded on both sides. Unlike ``DeepResearchResourceLimits``, whose defaults
+    are also its maxima, these ceilings sit above their defaults: raising a breaker that fires
+    on healthy runs is the supported tuning path, so the bound exists to stop a config from
+    raising one so far that it stops being a breaker.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    enabled: bool = Field(
+        default=True,
+        description=(
+            "Enable the per-researcher circuit breaker. False disables every behavior at once "
+            "(source-call budget, repeated-request blocking, consecutive-think blocking, and "
+            "the turn ceiling), withdraws no tool, and binds no recursion limit - the "
+            "researcher subgraph then inherits the orchestrator's, which is the deliberate "
+            "opt-out. Only turn this off if the guard is truncating healthy runs and raising "
+            "the individual limits did not help."
+        ),
+    )
+    max_source_calls_per_query: int = Field(
+        default=25,
+        ge=1,
+        le=SOURCE_CALLS_PER_QUERY_CEILING,
+        description=(
+            "Maximum model-issued source-tool invocations for one ResearchQuery. Counts logical "
+            "invocations, not concrete provider calls: one batch-capable invocation carrying N "
+            "queries costs one unit. This bounds model search iterations, not retrieval volume "
+            "- resource_limits.max_source_tool_calls bounds that. Applied identically to every "
+            "ResearchQuery. Bounds searching only - max_model_turns_per_query bounds the "
+            f"worker's total turns. May not exceed {SOURCE_CALLS_PER_QUERY_CEILING}, the "
+            "job-wide concrete source-call ceiling."
+        ),
+    )
+    max_model_turns_per_query: int = Field(
+        default=60,
+        ge=1,
+        le=MODEL_TURNS_PER_QUERY_CEILING,
+        description=(
+            "Maximum model calls for one ResearchQuery, counting every turn rather than only "
+            "the searching ones. On the final turn the guard withdraws all tools and native "
+            "structured-output binding; the text fallback promotes or corrects JSON into "
+            "ResearchNotes before the graph's recursion ceiling. Also derives "
+            "that recursion limit, which is therefore a backstop rather than the operative "
+            "bound. The default covers the worst path the other limits still permit: 25 source "
+            "calls, a think between each, plus orientation and synthesis turns. May not exceed "
+            f"{MODEL_TURNS_PER_QUERY_CEILING}."
+        ),
+    )
+    max_identical_source_calls: int = Field(
+        default=3,
+        ge=1,
+        le=IDENTICAL_SOURCE_CALLS_CEILING,
+        description=(
+            "Maximum invocations of one source tool with identical tool arguments. Argument key "
+            "ORDER is canonicalized; case and whitespace are not, so 'AI research' and "
+            "'ai research' are distinct requests. Matching is per logical invocation: an "
+            "identical batch is caught, but two different batches sharing some queries are not "
+            f"deduplicated item by item. May not exceed {IDENTICAL_SOURCE_CALLS_CEILING}."
+        ),
+    )
+    max_consecutive_thinks: int = Field(
+        default=3,
+        ge=1,
+        le=CONSECUTIVE_THINKS_CEILING,
+        description=(
+            "Maximum uninterrupted `think` calls before the guard rewrites the think result "
+            "into a corrective warning and withdraws `think` from later model calls. Any other "
+            f"tool call resets the streak. May not exceed {CONSECUTIVE_THINKS_CEILING}."
+        ),
+    )

--- a/src/aiq_agent/agents/deep_researcher/prompts/researcher.j2
+++ b/src/aiq_agent/agents/deep_researcher/prompts/researcher.j2
@@ -54,6 +54,8 @@ Your output will be used to write a cited final answer. Produce **in-depth, deta
 {% endif %}
 - Default source budget per ResearchQuery: one primary source-tool call, plus at most one fallback or corroboration call.
 - For broad survey queries, make at most one extra targeted follow-up after the first results, only when needed for target_components.
+{% if researcher_loop_guard_enabled | default(false) %}- Hard limit (runtime-enforced): at most {{ researcher_max_source_calls }} source-tool calls for this ResearchQuery, and at most {{ researcher_max_identical_source_calls }} call(s) with identical tool arguments. These are a backstop, not a target — follow the default budget above. Once either limit is reached the source tools and `think` are withdrawn; return your `ResearchNotes` immediately from the evidence already gathered and record every unsupported component as an explicit `ResearchGap`. Do not guess.
+{% endif %}
 - Prefer batch-capable source tool calls for related concrete search angles when the tool schema supports a list input.
 - When the primary source tool supports batch input and subqueries are still useful after assessing the main query, pass the remaining related concrete search angles as one ordered list.
 - Do not run every possible source angle; stop once findings are adequately grounded.
@@ -64,6 +66,12 @@ Your output will be used to write a cited final answer. Produce **in-depth, deta
 
 ## Handling Failures
 - Do NOT get stuck retrying - proceed with available information and return the structured ResearchNotes
+{% if researcher_loop_guard_enabled | default(false) %}- **When source tools are withdrawn, research is over — write the notes.** The runtime withdraws the source tools and `think` once this query reaches its hard limit. You will see one of: a tool result ending in a `[SYSTEM — ...]` notice, a result beginning `Source tool not executed: researcher loop guard reached ...`, or the source tools simply no longer being callable. All three mean the same thing: stop researching and return your `ResearchNotes` immediately.
+- Do not retry the withdrawn tool, do not look for another route to it, and do not substitute `ls`, `read_file`, `glob`, `grep`{% if execution_enabled %}, or `execute`{% endif %} for further research — those remain available for reading context, not for continuing to gather evidence.
+- The list under "Tool Availability and Prioritization" is the set you started with, not the set still callable. After a withdrawal it is out of date; trust what you can actually call.
+- Report honestly rather than guessing: put every unresolved item in `gaps` as a `ResearchGap` with a concrete `description`, its `impact`, and `suggested_follow_up_queries`. Keep the findings you did ground in sources. Never fill a missing fact from memory.
+- Set `evidence_judgment` to reflect the truncation — lower `relevance_score`, `confidence: "low"` where warranted, and a `rationale` stating the research was cut short by the source-call limit. The orchestrator and writer rely on this to tell a truncated note from a complete one.
+{% endif %}
 
 ## Output Format
 

--- a/src/aiq_agent/agents/deep_researcher/register.py
+++ b/src/aiq_agent/agents/deep_researcher/register.py
@@ -52,6 +52,7 @@ from .agent import DeepResearcherAgent
 from .deepagents_runtime import DeepResearchSandboxConfig
 from .deepagents_runtime import DeepResearchSkillsConfig
 from .models import DeepResearchAgentState
+from .models import ResearcherLoopGuardConfig
 from .resource_limits import DeepResearchExecutionTimeout
 from .resource_limits import DeepResearchResourceLimits
 
@@ -117,6 +118,14 @@ class DeepResearchAgentConfig(FunctionBaseConfig, name="deep_research_agent"):
     resource_limits: DeepResearchResourceLimits = Field(
         default_factory=DeepResearchResourceLimits,
         description="Hard per-job limits for request, plan, notes, source calls, and execution time.",
+    )
+    researcher_loop_guard: ResearcherLoopGuardConfig = Field(
+        default_factory=ResearcherLoopGuardConfig,
+        description=(
+            "Per-researcher circuit breaker: source-call budget, repeated-request and "
+            "consecutive-think limits for one run_research_batch worker. Setting enabled=false "
+            "disables all three."
+        ),
     )
 
     @field_validator("skills", mode="before")
@@ -250,6 +259,7 @@ async def deep_research_agent(config: DeepResearchAgentConfig, builder: Builder)
         max_concurrent_source_tool_calls=config.max_concurrent_source_tool_calls,
         max_source_tool_batch_size=config.max_source_tool_batch_size,
         resource_limits=config.resource_limits,
+        researcher_loop_guard=config.researcher_loop_guard,
     )
 
     async def _run(state: DeepResearchAgentState) -> DeepResearchAgentState:
@@ -288,6 +298,7 @@ async def deep_research_agent(config: DeepResearchAgentConfig, builder: Builder)
                     max_concurrent_source_tool_calls=config.max_concurrent_source_tool_calls,
                     max_source_tool_batch_size=config.max_source_tool_batch_size,
                     resource_limits=config.resource_limits,
+                    researcher_loop_guard=config.researcher_loop_guard,
                 )
                 owns_active_agent = True
 

--- a/src/aiq_agent/agents/deep_researcher/researcher_context.py
+++ b/src/aiq_agent/agents/deep_researcher/researcher_context.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-invocation loop-guard context for reusable deep researcher workers."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from dataclasses import dataclass
+from dataclasses import field
+
+
+@dataclass
+class ResearcherRunGuardState:
+    """Mutable loop-guard state isolated to one researcher invocation.
+
+    One instance tracks a single ``ResearchQuery`` executed by a ``run_research_batch``
+    worker: how many model turns it has taken, how many source-tool invocations it has
+    issued, how often it repeated an identical request, whether either limit has been
+    reached, and how long its current uninterrupted ``think`` streak is.
+
+    The state deliberately lives on a :class:`~contextvars.ContextVar` rather than on the
+    middleware instance. ``DeepResearcherAgent`` builds its middleware set once and reuses
+    those instances for every run, so a counter stored on ``self`` would leak across
+    concurrent researcher workers and across requests.
+    """
+
+    invocation_id: str
+    model_turn_count: int = 0
+    source_call_count: int = 0
+    source_signature_counts: dict[str, int] = field(default_factory=dict)
+    exhausted: bool = False
+    exhaustion_reason: str | None = None
+    consecutive_think_count: int = 0
+    think_blocked: bool = False
+
+
+# Set and reset per researcher invocation in tools/research.py::_run_research_query, so N
+# concurrent workers each get their own budget and no state survives the invocation.
+CURRENT_RESEARCHER_GUARD_STATE: ContextVar[ResearcherRunGuardState | None] = ContextVar(
+    "current_researcher_guard_state",
+    default=None,
+)

--- a/src/aiq_agent/agents/deep_researcher/tools/research.py
+++ b/src/aiq_agent/agents/deep_researcher/tools/research.py
@@ -24,6 +24,7 @@ import logging
 import re
 from typing import Any
 from typing import cast
+from uuid import uuid4
 
 from langchain.tools import ToolRuntime
 from langchain_core.messages import HumanMessage
@@ -32,6 +33,8 @@ from langchain_core.tools import tool
 
 from ..models import ResearchNotes
 from ..models import ResearchQuery
+from ..researcher_context import CURRENT_RESEARCHER_GUARD_STATE
+from ..researcher_context import ResearcherRunGuardState
 from ..resource_limits import DeepResearchResourceLimits
 from ..resource_limits import StateBudgetLedger
 
@@ -64,11 +67,23 @@ def researcher_invoke_state(query: ResearchQuery, runtime: ToolRuntime | None) -
     return invoke_state
 
 
-def researcher_invoke_config(runtime: ToolRuntime | None, callbacks: list[Any]) -> dict[str, Any]:
+def researcher_invoke_config(
+    runtime: ToolRuntime | None,
+    callbacks: list[Any],
+    *,
+    strip_inherited_recursion_limit: bool = True,
+) -> dict[str, Any]:
     """Build child-run config while preserving the active callback lineage."""
     config = dict(runtime.config) if runtime is not None else {}
     config.pop("run_id", None)
     config.pop("configurable", None)
+    # The orchestrator graph runs at recursion_limit 2000 and that value propagates into every
+    # child config, where it would win the merge against the limit bound on the runnable. Drop
+    # it so the researcher subgraph uses its own. When the loop guard is disabled the runnable
+    # carries no limit of its own, and inheriting the parent's is the deliberate opt-out, so
+    # the caller passes False and the value is left alone.
+    if strip_inherited_recursion_limit:
+        config.pop("recursion_limit", None)
     config["run_name"] = RESEARCHER_AGENT_NAME
     if not config.get("callbacks") and callbacks:
         config["callbacks"] = callbacks
@@ -82,28 +97,39 @@ async def _run_research_query(
     runtime: ToolRuntime | None,
     callbacks: list[Any],
     semaphore: asyncio.Semaphore,
+    strip_inherited_recursion_limit: bool = True,
 ) -> ResearchNotes:
     """Run one researcher worker and return its structured notes."""
     async with semaphore:
+        # Scoped inside the semaphore so a queued worker holds no guard state while blocked and
+        # each admitted worker gets a fresh, isolated loop-guard budget.
+        guard_token = CURRENT_RESEARCHER_GUARD_STATE.set(ResearcherRunGuardState(invocation_id=uuid4().hex))
         try:
-            result = await researcher_runnable.ainvoke(
-                researcher_invoke_state(query, runtime),
-                config=researcher_invoke_config(runtime, callbacks),
-            )
-        except Exception as exc:  # noqa: BLE001 - captured as per-item failure
-            raise RuntimeError(f"researcher worker failed for query {query.query!r}: {exc}") from exc
+            try:
+                result = await researcher_runnable.ainvoke(
+                    researcher_invoke_state(query, runtime),
+                    config=researcher_invoke_config(
+                        runtime,
+                        callbacks,
+                        strip_inherited_recursion_limit=strip_inherited_recursion_limit,
+                    ),
+                )
+            except Exception as exc:  # noqa: BLE001 - captured as per-item failure
+                raise RuntimeError(f"researcher worker failed for query {query.query!r}: {exc}") from exc
 
-        try:
-            structured = result.get("structured_response") if isinstance(result, dict) else None
-            if structured is None:
-                raise ValueError("researcher worker did not return structured ResearchNotes")
-            note = ResearchNotes.model_validate(structured)
-        except Exception as exc:  # noqa: BLE001 - captured as per-item failure
-            raise ValueError(
-                f"researcher worker returned invalid ResearchNotes for query {query.query!r}: {exc}"
-            ) from exc
+            try:
+                structured = result.get("structured_response") if isinstance(result, dict) else None
+                if structured is None:
+                    raise ValueError("researcher worker did not return structured ResearchNotes")
+                note = ResearchNotes.model_validate(structured)
+            except Exception as exc:  # noqa: BLE001 - captured as per-item failure
+                raise ValueError(
+                    f"researcher worker returned invalid ResearchNotes for query {query.query!r}: {exc}"
+                ) from exc
 
-        return note
+            return note
+        finally:
+            CURRENT_RESEARCHER_GUARD_STATE.reset(guard_token)
 
 
 def _research_note_slug(text: str) -> str:
@@ -161,6 +187,7 @@ async def _run_research_queries(
     runtime: ToolRuntime | None,
     callbacks: list[Any],
     max_concurrency: int,
+    strip_inherited_recursion_limit: bool = True,
 ) -> tuple[list[ResearchQuery], list[ResearchNotes], list[str]]:
     """Run researcher workers concurrently and collect successful query/note pairs plus surfaced errors."""
     semaphore = asyncio.Semaphore(min(max_concurrency, len(queries)))
@@ -172,6 +199,7 @@ async def _run_research_queries(
                 runtime=runtime,
                 callbacks=callbacks,
                 semaphore=semaphore,
+                strip_inherited_recursion_limit=strip_inherited_recursion_limit,
             )
             for query in queries
         ),
@@ -200,6 +228,7 @@ def build_research_batch_tool(
     backend: Any | None = None,
     state_budget: StateBudgetLedger | None = None,
     source_registry_middleware: Any | None = None,
+    strip_inherited_recursion_limit: bool = True,
 ) -> BaseTool:
     """Build an orchestrator-only tool that runs researcher tasks concurrently."""
     limits = resource_limits or DeepResearchResourceLimits()
@@ -248,6 +277,7 @@ def build_research_batch_tool(
             runtime=runtime,
             callbacks=callbacks,
             max_concurrency=max_research_concurrency,
+            strip_inherited_recursion_limit=strip_inherited_recursion_limit,
         )
         note_files = _research_note_files(successful_queries, notes)
         batch_note_bytes = sum(len(content) for _, content in note_files)

--- a/tests/aiq_agent/agents/deep_researcher/test_factory.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_factory.py
@@ -520,7 +520,8 @@ def test_researcher_runnable_uses_rendered_prompt_and_runtime_middleware():
 
     kwargs = create.call_args.kwargs
     middleware_names = [item.__class__.__name__ for item in kwargs["middleware"]]
-    assert result is researcher_agent
+    # The runnable is returned wrapped in its own recursion limit rather than bare.
+    assert result is researcher_agent.with_config.return_value
     assert kwargs["model"] is researcher_model
     assert kwargs["tools"] == [web_search_tool]
     assert kwargs["response_format"] is ResearchNotes

--- a/tests/aiq_agent/agents/deep_researcher/test_researcher_loop_guard.py
+++ b/tests/aiq_agent/agents/deep_researcher/test_researcher_loop_guard.py
@@ -1,0 +1,915 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the per-researcher loop guard: middleware, wiring, prompts, and config."""
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from langchain.agents import create_agent
+from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware import ToolRetryMiddleware
+from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.messages import HumanMessage
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import tool
+from pydantic import ValidationError
+
+from aiq_agent.agents.deep_researcher import factory as factory_module
+from aiq_agent.agents.deep_researcher import register as register_module
+from aiq_agent.agents.deep_researcher import resource_limits
+from aiq_agent.agents.deep_researcher.custom_middleware import ResearcherLoopGuardMiddleware
+from aiq_agent.agents.deep_researcher.custom_middleware import SourceRegistryMiddleware
+from aiq_agent.agents.deep_researcher.custom_middleware import StructuredResponseTextFallbackMiddleware
+from aiq_agent.agents.deep_researcher.custom_middleware import _canonical_source_signature
+from aiq_agent.agents.deep_researcher.factory import build_deep_research_middleware_set
+from aiq_agent.agents.deep_researcher.factory import build_deep_research_tool_set
+from aiq_agent.agents.deep_researcher.factory import build_researcher_runnable
+from aiq_agent.agents.deep_researcher.models import ResearcherLoopGuardConfig
+from aiq_agent.agents.deep_researcher.models import ResearchNotes
+from aiq_agent.agents.deep_researcher.models import loop_guard as loop_guard_module
+from aiq_agent.agents.deep_researcher.researcher_context import CURRENT_RESEARCHER_GUARD_STATE
+from aiq_agent.agents.deep_researcher.researcher_context import ResearcherRunGuardState
+from aiq_agent.agents.deep_researcher.tools import research as research_module
+from aiq_agent.common import render_prompt_template
+
+_SOURCE_TOOL = "web_search_tool"
+_SOURCE_TOOLS = {_SOURCE_TOOL, "internal_search_tool"}
+_RESEARCHER_PROMPT = (
+    Path(__file__).parents[4] / "src" / "aiq_agent" / "agents" / "deep_researcher" / "prompts" / "researcher.j2"
+).read_text(encoding="utf-8")
+
+
+@tool
+def web_search_tool(query: str) -> str:
+    """Search the web for information."""
+    return f"Results for: {query}"
+
+
+class _ProviderStrategyFakeChatModel(FakeMessagesListChatModel):
+    """Provider-capable model that rejects the invalid empty-tools request shape."""
+
+    profile: dict[str, bool] = {"structured_output": True}
+
+    def bind_tools(self, tools, **kwargs):
+        if not tools and kwargs.get("response_format") is not None:
+            raise ValueError("provider does not accept an empty tools array")
+        return self
+
+
+def _guard(**overrides) -> ResearcherLoopGuardMiddleware:
+    """Build a guard over the fixed source-tool set with optional config overrides."""
+    return ResearcherLoopGuardMiddleware(
+        source_tool_names=_SOURCE_TOOLS,
+        config=ResearcherLoopGuardConfig(**overrides),
+    )
+
+
+def _request(tool_name: str, *, args: dict | None = None) -> MagicMock:
+    """Build a minimal tool-call request the guard can read."""
+    request = MagicMock()
+    request.tool_call = {"name": tool_name, "args": args or {}, "id": "tc1"}
+    return request
+
+
+def _handler(content: str = "search results") -> AsyncMock:
+    """Build a handler returning a mutable ToolMessage result."""
+    return AsyncMock(return_value=ToolMessage(content=content, tool_call_id="tc1"))
+
+
+@pytest.fixture
+def state():
+    """Install a fresh guard state for one invocation and tear it down afterwards."""
+    guard_state = ResearcherRunGuardState(invocation_id="inv-1")
+    token = CURRENT_RESEARCHER_GUARD_STATE.set(guard_state)
+    yield guard_state
+    CURRENT_RESEARCHER_GUARD_STATE.reset(token)
+
+
+class TestSourceCallBudget:
+    """The flat per-query source-call ceiling and what happens when it is reached."""
+
+    @pytest.mark.asyncio
+    async def test_configured_budget_is_enforced_and_the_next_call_is_not_executed(self, state):
+        """The budget allows exactly N calls; the (N+1)th is blocked without reaching the tool."""
+        middleware = _guard(
+            max_source_calls_per_query=3, max_identical_source_calls=loop_guard_module.IDENTICAL_SOURCE_CALLS_CEILING
+        )
+        handler = _handler()
+
+        for i in range(3):
+            await middleware.awrap_tool_call(_request(_SOURCE_TOOL, args={"query": f"q{i}"}), handler)
+        assert handler.await_count == 3
+
+        blocked = await middleware.awrap_tool_call(_request(_SOURCE_TOOL, args={"query": "q4"}), handler)
+
+        assert handler.await_count == 3
+        assert blocked.status == "error"
+        assert "budget is exhausted" in str(blocked.content)
+        assert state.exhaustion_reason == "total source-call budget"
+
+    @pytest.mark.asyncio
+    async def test_every_query_receives_the_same_limit(self):
+        """One flat limit applies identically to every ResearchQuery - there is no depth hint."""
+        middleware = _guard(
+            max_source_calls_per_query=2, max_identical_source_calls=loop_guard_module.IDENTICAL_SOURCE_CALLS_CEILING
+        )
+        executed = []
+
+        for invocation_id, query in (("inv-a", "quantum error correction"), ("inv-b", "weather")):
+            token = CURRENT_RESEARCHER_GUARD_STATE.set(ResearcherRunGuardState(invocation_id=invocation_id))
+            handler = _handler()
+            try:
+                for i in range(4):
+                    await middleware.awrap_tool_call(_request(_SOURCE_TOOL, args={"q": f"{query}{i}"}), handler)
+            finally:
+                CURRENT_RESEARCHER_GUARD_STATE.reset(token)
+            executed.append(handler.await_count)
+
+        assert executed == [2, 2]
+
+    @pytest.mark.asyncio
+    async def test_exhaustion_appends_the_nudge_and_preserves_the_final_evidence(self, state):
+        """The last allowed result survives; the exhaustion notice is appended, never substituted."""
+        middleware = _guard(max_source_calls_per_query=1)
+
+        result = await middleware.awrap_tool_call(_request(_SOURCE_TOOL, args={"q": "a"}), _handler("real evidence"))
+
+        assert "real evidence" in str(result.content)
+        assert "budget is exhausted" in str(result.content)
+        assert state.exhausted is True
+
+    @pytest.mark.asyncio
+    async def test_an_immutable_result_still_exhausts_the_budget(self, state):
+        """The nudge is best-effort; withdrawing the tools is the hard guarantee."""
+        middleware = _guard(max_source_calls_per_query=1)
+        handler = AsyncMock(return_value="plain string result")
+
+        result = await middleware.awrap_tool_call(_request(_SOURCE_TOOL, args={"q": "a"}), handler)
+
+        assert result == "plain string result"
+        assert state.exhausted is True
+
+    @pytest.mark.asyncio
+    async def test_parallel_calls_share_one_ceiling(self, state):
+        """Counting before dispatch stops concurrent calls from all passing the same check."""
+        middleware = _guard(max_source_calls_per_query=1)
+        handler = _handler()
+
+        await asyncio.gather(
+            middleware.awrap_tool_call(_request(_SOURCE_TOOL, args={"q": "a"}), handler),
+            middleware.awrap_tool_call(_request(_SOURCE_TOOL, args={"q": "b"}), handler),
+        )
+
+        assert handler.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_concurrent_invocations_do_not_see_each_other_counts(self):
+        """Each researcher worker gets its own budget because state lives in a ContextVar."""
+        middleware = _guard(
+            max_source_calls_per_query=2, max_identical_source_calls=loop_guard_module.IDENTICAL_SOURCE_CALLS_CEILING
+        )
+
+        async def run_worker(invocation_id: str) -> int:
+            CURRENT_RESEARCHER_GUARD_STATE.set(ResearcherRunGuardState(invocation_id=invocation_id))
+            handler = _handler()
+            for i in range(3):
+                await middleware.awrap_tool_call(_request(_SOURCE_TOOL, args={"q": f"{invocation_id}{i}"}), handler)
+            return handler.await_count
+
+        # asyncio.Task copies the context, so each worker's .set() is invisible to the other.
+        counts = await asyncio.gather(
+            asyncio.create_task(run_worker("inv-a")),
+            asyncio.create_task(run_worker("inv-b")),
+        )
+
+        assert counts == [2, 2]
+
+    @pytest.mark.asyncio
+    async def test_non_source_tools_are_never_counted(self, state):
+        """Helper and filesystem tools do not consume the research budget."""
+        middleware = _guard(max_source_calls_per_query=1)
+        handler = _handler()
+
+        for name in ("get_verified_sources", "read_file", "ls", "grep"):
+            await middleware.awrap_tool_call(_request(name), handler)
+
+        assert handler.await_count == 4
+        assert state.source_call_count == 0
+        assert state.exhausted is False
+
+
+class TestIdenticalRequestBlocking:
+    """Repeats of the same tool name plus the same arguments are refused."""
+
+    @pytest.mark.asyncio
+    async def test_the_third_identical_request_is_blocked(self, state):
+        """Two identical attempts are allowed; the third is not executed."""
+        middleware = _guard(max_identical_source_calls=2)
+        handler = _handler()
+        args = {"query": "same question"}
+
+        for _ in range(2):
+            await middleware.awrap_tool_call(_request(_SOURCE_TOOL, args=args), handler)
+        blocked = await middleware.awrap_tool_call(_request(_SOURCE_TOOL, args=args), handler)
+
+        assert handler.await_count == 2
+        assert blocked.status == "error"
+        assert state.exhaustion_reason == "repeated source-call signature"
+
+    @pytest.mark.asyncio
+    async def test_alternating_think_and_same_search_terminates(self, state):
+        """The think->same_search loop is caught by the signature rule, not the think rule."""
+        middleware = _guard(
+            max_identical_source_calls=2, max_consecutive_thinks=loop_guard_module.CONSECUTIVE_THINKS_CEILING
+        )
+        handler = _handler()
+        args = {"query": "same question"}
+
+        for _ in range(3):
+            await middleware.awrap_tool_call(_request("think", args={"thought": "hmm"}), handler)
+            await middleware.awrap_tool_call(_request(_SOURCE_TOOL, args=args), handler)
+
+        assert state.exhausted is True
+        assert state.exhaustion_reason == "repeated source-call signature"
+
+    def test_signature_is_stable_across_key_order_and_distinct_for_distinct_args(self):
+        """Argument key order is canonicalized; different arguments do not collide."""
+        assert _canonical_source_signature(_SOURCE_TOOL, {"a": 1, "b": 2}) == _canonical_source_signature(
+            _SOURCE_TOOL, {"b": 2, "a": 1}
+        )
+        assert _canonical_source_signature(_SOURCE_TOOL, {"q": "x"}) != _canonical_source_signature(
+            _SOURCE_TOOL, {"q": "y"}
+        )
+
+    def test_case_differences_are_distinct_requests(self):
+        """Only key order is canonicalized - case and whitespace are not."""
+        assert _canonical_source_signature(_SOURCE_TOOL, {"q": "AI research"}) != _canonical_source_signature(
+            _SOURCE_TOOL, {"q": "ai research"}
+        )
+
+
+class TestConsecutiveThinkBlocking:
+    """Uninterrupted think calls are warned about and then withdrawn."""
+
+    @pytest.mark.asyncio
+    async def test_below_the_threshold_the_result_is_unmodified(self, state):
+        """Normal thinking passes through untouched."""
+        middleware = _guard(max_consecutive_thinks=3)
+        handler = _handler("Thought recorded.")
+
+        result = await middleware.awrap_tool_call(_request("think", args={"thought": "a"}), handler)
+
+        assert str(result.content) == "Thought recorded."
+        assert state.think_blocked is False
+
+    @pytest.mark.asyncio
+    async def test_at_the_threshold_the_result_is_overwritten_and_think_is_blocked(self, state):
+        """A think result carries no evidence, so the warning replaces it rather than appending."""
+        middleware = _guard(max_consecutive_thinks=3)
+        handler = _handler("Thought recorded.")
+
+        for _ in range(3):
+            result = await middleware.awrap_tool_call(_request("think", args={"thought": "a"}), handler)
+
+        # Thinking is never blocked - only warned about and then withdrawn.
+        assert handler.await_count == 3
+        assert str(result.content).startswith("Thought recorded. WARNING:")
+        assert "called 'think' 3 times in a row" in str(result.content)
+        assert state.think_blocked is True
+
+    @pytest.mark.asyncio
+    async def test_an_immutable_think_result_does_not_raise(self, state):
+        """The corrective warning is best-effort."""
+        middleware = _guard(max_consecutive_thinks=1)
+        handler = AsyncMock(return_value="plain string result")
+
+        result = await middleware.awrap_tool_call(_request("think", args={"thought": "a"}), handler)
+
+        assert result == "plain string result"
+        assert state.think_blocked is True
+
+    @pytest.mark.asyncio
+    async def test_any_other_tool_resets_the_streak(self, state):
+        """Only uninterrupted think calls count toward the limit."""
+        middleware = _guard(max_consecutive_thinks=3)
+        handler = _handler()
+
+        await middleware.awrap_tool_call(_request("think"), handler)
+        await middleware.awrap_tool_call(_request("think"), handler)
+        assert state.consecutive_think_count == 2
+
+        await middleware.awrap_tool_call(_request("read_file", args={"file_path": "/shared/plan.json"}), handler)
+
+        assert state.consecutive_think_count == 0
+        assert state.think_blocked is False
+
+    @pytest.mark.asyncio
+    async def test_any_other_tool_reenables_think_after_the_threshold(self, state):
+        """A completed think streak does not withdraw think for the rest of the invocation."""
+        middleware = _guard(max_consecutive_thinks=2)
+        handler = _handler()
+
+        await middleware.awrap_tool_call(_request("think"), handler)
+        await middleware.awrap_tool_call(_request("think"), handler)
+        assert state.think_blocked is True
+
+        await middleware.awrap_tool_call(_request("read_file", args={"file_path": "/shared/plan.json"}), handler)
+
+        assert state.consecutive_think_count == 0
+        assert state.think_blocked is False
+        assert "think" in {tool.name for tool in middleware._filter_tools(TestToolWithdrawal._tools())}
+
+
+class TestToolWithdrawal:
+    """What `_filter_tools` removes from later model calls in each state."""
+
+    @staticmethod
+    def _tools() -> list[SimpleNamespace]:
+        return [
+            SimpleNamespace(name=_SOURCE_TOOL),
+            SimpleNamespace(name="internal_search_tool"),
+            SimpleNamespace(name="think"),
+            SimpleNamespace(name="get_verified_sources"),
+            SimpleNamespace(name="read_file"),
+            SimpleNamespace(name="ls"),
+        ]
+
+    def test_exhaustion_withdraws_source_tools_and_think(self, state):
+        """An exhausted worker physically cannot search or think again."""
+        state.exhausted = True
+
+        names = {t.name for t in _guard()._filter_tools(self._tools())}
+
+        assert names == {"get_verified_sources", "read_file", "ls"}
+
+    def test_think_blocking_alone_withdraws_only_think(self, state):
+        """A pure think loop costs the model its scratchpad, not its search tools."""
+        state.think_blocked = True
+
+        names = {t.name for t in _guard()._filter_tools(self._tools())}
+
+        assert "think" not in names
+        assert _SOURCE_TOOL in names
+
+    def test_a_healthy_invocation_keeps_every_tool(self, state):
+        """Nothing is withdrawn before a limit is reached."""
+        tools = self._tools()
+
+        assert _guard()._filter_tools(tools) is tools
+
+    def test_filesystem_tools_survive_exhaustion(self, state):
+        """Exhaustion ends searching, not reading: /shared context stays reachable.
+
+        This is why the source-call limits alone cannot bound the worker -
+        `max_model_turns_per_query` is what closes the loop. See TestTurnCeiling.
+        """
+        state.exhausted = True
+
+        names = {t.name for t in _guard()._filter_tools(self._tools())}
+
+        assert {"read_file", "ls"} <= names
+
+    def test_no_state_installed_is_a_pass_through(self):
+        """Planner, writer, and orchestrator never install guard state, so nothing is withdrawn."""
+        tools = self._tools()
+
+        assert _guard()._filter_tools(tools) is tools
+
+
+class TestTurnCeiling:
+    """`max_model_turns_per_query` bounds total turns, not just the searching ones."""
+
+    @staticmethod
+    def _model_request() -> MagicMock:
+        """Build a model request whose `override` records the kwargs it was given."""
+        request = MagicMock()
+        request.tools = [SimpleNamespace(name=_SOURCE_TOOL), SimpleNamespace(name="read_file")]
+        request.override.side_effect = lambda **kwargs: SimpleNamespace(**kwargs)
+        return request
+
+    async def _turn(self, middleware, request=None):
+        """Take one model turn and return whatever was handed to the model."""
+        seen = {}
+
+        async def handler(passed):
+            seen["request"] = passed
+            return "response"
+
+        await middleware.awrap_model_call(request or self._model_request(), handler)
+        return seen["request"]
+
+    @pytest.mark.asyncio
+    async def test_every_model_call_counts_as_one_turn(self, state):
+        """Turns are counted at the model call, so non-source turns count too."""
+        middleware = _guard(max_model_turns_per_query=10)
+
+        for _ in range(4):
+            await self._turn(middleware)
+
+        assert state.model_turn_count == 4
+
+    @pytest.mark.asyncio
+    async def test_below_the_ceiling_the_tool_list_is_untouched(self, state):
+        """A healthy worker sees exactly the tools it was bound with."""
+        middleware = _guard(max_model_turns_per_query=10)
+        request = self._model_request()
+
+        passed = await self._turn(middleware, request)
+
+        assert passed.tools is request.tools
+
+    @pytest.mark.asyncio
+    async def test_the_final_turn_withdraws_every_tool(self, state):
+        """The final request has no tools or provider-native response format."""
+        middleware = _guard(max_model_turns_per_query=3)
+
+        for _ in range(2):
+            passed = await self._turn(middleware)
+            assert passed.tools
+
+        passed = await self._turn(middleware)
+
+        assert passed.tools == []
+        assert passed.tool_choice is None
+        assert passed.response_format is None
+
+    def test_the_final_turn_returns_notes_with_a_provider_strategy_model(self, state):
+        """The final turn omits tools and lets the text fallback recover ResearchNotes."""
+        payload = _notes()
+        model = _ProviderStrategyFakeChatModel(responses=[AIMessage(content=json.dumps(payload))])
+        agent = create_agent(
+            model=model,
+            tools=[web_search_tool],
+            middleware=[
+                StructuredResponseTextFallbackMiddleware(ResearchNotes),
+                _guard(max_model_turns_per_query=1),
+            ],
+            response_format=ResearchNotes,
+        )
+
+        result = agent.invoke({"messages": [HumanMessage(content="Return the research notes.")]})
+
+        assert result["structured_response"] == ResearchNotes.model_validate(payload)
+
+    @pytest.mark.asyncio
+    async def test_the_ceiling_holds_for_a_worker_that_never_searched(self, state):
+        """The turn ceiling is independent of the source budget, which is the point of it.
+
+        An exhausted worker looping on `ls` / `read_file` consumes no source budget, so only
+        this limit can stop it before the recursion ceiling does.
+        """
+        middleware = _guard(max_model_turns_per_query=2)
+        state.exhausted = True
+
+        await self._turn(middleware)
+        passed = await self._turn(middleware)
+
+        assert passed.tools == []
+        assert state.source_call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_a_disabled_guard_neither_counts_nor_withdraws(self, state):
+        """`enabled: false` opts out of the turn ceiling with everything else."""
+        middleware = _guard(enabled=False, max_model_turns_per_query=1)
+        request = self._model_request()
+
+        passed = await self._turn(middleware, request)
+
+        assert passed is request
+        assert state.model_turn_count == 0
+
+    @pytest.mark.asyncio
+    async def test_no_state_installed_is_a_pass_through(self):
+        """Agents that install no guard state keep their tools at every turn."""
+        middleware = _guard(max_model_turns_per_query=1)
+        request = self._model_request()
+
+        assert await self._turn(middleware, request) is request
+
+
+class TestDisabled:
+    """`enabled: false` switches off the complete circuit breaker, one test per path."""
+
+    @pytest.mark.asyncio
+    async def test_the_source_budget_is_not_enforced(self, state):
+        middleware = _guard(
+            enabled=False,
+            max_source_calls_per_query=1,
+            max_identical_source_calls=loop_guard_module.IDENTICAL_SOURCE_CALLS_CEILING,
+        )
+        handler = _handler()
+
+        for i in range(5):
+            await middleware.awrap_tool_call(_request(_SOURCE_TOOL, args={"q": f"q{i}"}), handler)
+
+        assert handler.await_count == 5
+        assert state.source_call_count == 0
+        assert state.exhausted is False
+
+    @pytest.mark.asyncio
+    async def test_identical_requests_are_not_blocked(self, state):
+        middleware = _guard(enabled=False, max_identical_source_calls=1)
+        handler = _handler()
+
+        for _ in range(4):
+            await middleware.awrap_tool_call(_request(_SOURCE_TOOL, args={"q": "same"}), handler)
+
+        assert handler.await_count == 4
+        assert state.exhausted is False
+
+    @pytest.mark.asyncio
+    async def test_no_think_warning_is_injected(self, state):
+        """Regression test for the bug the merged design fixes: a disabled guard stays silent."""
+        middleware = _guard(enabled=False, max_consecutive_thinks=1)
+        handler = _handler("Thought recorded.")
+
+        for _ in range(4):
+            result = await middleware.awrap_tool_call(_request("think"), handler)
+
+        assert str(result.content) == "Thought recorded."
+        assert state.think_blocked is False
+
+    def test_no_tool_is_withdrawn_even_when_marked_exhausted(self, state):
+        state.exhausted = True
+        tools = TestToolWithdrawal._tools()
+
+        assert _guard(enabled=False)._filter_tools(tools) is tools
+
+
+class TestFactoryWiring:
+    """Where the guard is attached and how the researcher subgraph is bounded."""
+
+    @staticmethod
+    def _middleware_set(**overrides):
+        registry = SourceRegistryMiddleware(source_tool_names={web_search_tool.name})
+        tool_set = build_deep_research_tool_set(
+            [web_search_tool],
+            source_registry_middleware=registry,
+            max_concurrent_source_tool_calls=2,
+            max_source_tool_batch_size=3,
+        )
+        return build_deep_research_middleware_set(
+            tool_set=tool_set,
+            source_registry_middleware=registry,
+            **overrides,
+        )
+
+    def test_the_guard_sits_before_tool_retry_in_the_researcher_stack(self):
+        """Outside the retry, so a retried transient failure costs one unit and not three."""
+        researcher = self._middleware_set().researcher
+        guard_index = next(i for i, m in enumerate(researcher) if isinstance(m, ResearcherLoopGuardMiddleware))
+        retry_index = next(i for i, m in enumerate(researcher) if isinstance(m, ToolRetryMiddleware))
+
+        assert guard_index < retry_index
+
+    def test_the_guard_is_attached_to_no_other_stack(self):
+        """Planner, writer, and orchestrator get no think or source guard in this iteration."""
+        middleware_set = self._middleware_set()
+
+        for stack in (middleware_set.planner, middleware_set.writer, middleware_set.orchestrator):
+            assert not any(isinstance(m, ResearcherLoopGuardMiddleware) for m in stack)
+
+    def test_the_configured_limits_reach_the_middleware(self):
+        """A config set on the agent is the one the guard enforces."""
+        config = ResearcherLoopGuardConfig(max_source_calls_per_query=4)
+        researcher = self._middleware_set(researcher_loop_guard=config).researcher
+
+        guard = next(m for m in researcher if isinstance(m, ResearcherLoopGuardMiddleware))
+
+        assert guard._config is config
+
+
+class TestResearcherRecursionLimit:
+    """The researcher subgraph is bounded explicitly instead of inheriting the orchestrator's."""
+
+    @staticmethod
+    def _build(**overrides):
+        """Build the researcher runnable over a mocked create_agent and return that mock."""
+        runnable = MagicMock()
+        with (
+            patch("aiq_agent.agents.deep_researcher.factory.create_agent", return_value=runnable),
+            patch(
+                "aiq_agent.agents.deep_researcher.factory.create_summarization_middleware",
+                return_value=AgentMiddleware(),
+            ),
+        ):
+            build_researcher_runnable(
+                researcher_model=MagicMock(),
+                researcher_tools=[web_search_tool],
+                researcher_middleware=[],
+                system_prompt="researcher",
+                researcher_loop_guard=ResearcherLoopGuardConfig(**overrides),
+            )
+        return runnable
+
+    @classmethod
+    def _effective_limit(cls, **overrides) -> int:
+        """Return the limit a researcher actually runs at, composing both halves of the fix.
+
+        The runnable binds its own limit and ``researcher_invoke_config`` pops the parent's, so
+        asserting on either half alone would pass while the other regressed.
+        """
+        bound_limit = cls._build(**overrides).with_config.call_args.args[0]["recursion_limit"]
+        # A parent carrying the orchestrator's 2000 must not override the runnable's own limit.
+        parent = SimpleNamespace(config={"recursion_limit": 2000})
+        assert "recursion_limit" not in research_module.researcher_invoke_config(parent, [])
+        return bound_limit
+
+    def test_the_default_turn_ceiling_yields_the_derived_limit_not_two_thousand(self):
+        """60 turns * 2 graph steps + 10 headroom = 130."""
+        assert self._effective_limit() == 130
+
+    def test_the_limit_scales_with_the_turn_ceiling(self):
+        """The turn ceiling is the only input; the search budget no longer moves it."""
+        assert self._effective_limit(max_model_turns_per_query=30) == 70
+        assert self._effective_limit(max_source_calls_per_query=100) == 130
+
+    def test_no_limit_is_bound_when_the_guard_is_disabled(self):
+        """Nothing can force a graceful finish, so a tight ceiling would only lose evidence."""
+        runnable = self._build(enabled=False)
+
+        runnable.with_config.assert_not_called()
+
+    def test_researcher_invoke_config_strips_an_inherited_recursion_limit(self):
+        """Popping removes the merge-precedence contest entirely."""
+        runtime = SimpleNamespace(config={"recursion_limit": 2000, "run_id": "r", "configurable": {}})
+
+        config = research_module.researcher_invoke_config(runtime, [])
+
+        assert "recursion_limit" not in config
+
+    def test_the_inherited_limit_survives_when_the_guard_is_disabled(self):
+        """With no limit bound on the runnable, popping the parent's would leave it unbounded."""
+        runtime = SimpleNamespace(config={"recursion_limit": 2000, "run_id": "r", "configurable": {}})
+
+        config = research_module.researcher_invoke_config(runtime, [], strip_inherited_recursion_limit=False)
+
+        assert config["recursion_limit"] == 2000
+
+    @pytest.mark.parametrize("turns", [1, 60, loop_guard_module.MODEL_TURNS_PER_QUERY_CEILING])
+    def test_finalization_always_lands_before_the_recursion_ceiling(self, turns):
+        """The invariant the whole design rests on, checked across the allowed range.
+
+        The guard finalizes on turn N; the graph affords more than N turns. If this ever fails,
+        a compliant worker dies with GraphRecursionError instead of returning notes.
+        """
+        limit = self._effective_limit(max_model_turns_per_query=turns)
+        turns_afforded = limit // factory_module.GRAPH_STEPS_PER_TURN
+
+        assert turns_afforded > turns
+
+
+class TestInvocationScoping:
+    """`_run_research_query` owns the guard state's lifetime."""
+
+    @pytest.mark.asyncio
+    async def test_a_fresh_state_is_installed_and_reset_on_success(self):
+        """Each admitted worker gets its own budget, and none survives the invocation."""
+        seen = []
+
+        async def capture(*_args, **_kwargs):
+            state = CURRENT_RESEARCHER_GUARD_STATE.get()
+            seen.append(state.invocation_id)
+            return {"structured_response": _notes()}
+
+        runnable = SimpleNamespace(ainvoke=capture)
+        for _ in range(2):
+            await research_module._run_research_query(
+                query=_query(),
+                researcher_runnable=runnable,
+                runtime=None,
+                callbacks=[],
+                semaphore=asyncio.Semaphore(1),
+            )
+
+        assert len(set(seen)) == 2
+        assert CURRENT_RESEARCHER_GUARD_STATE.get() is None
+
+    @pytest.mark.asyncio
+    async def test_the_state_is_reset_on_the_exception_path(self):
+        """A failed worker must not leak its guard state to whatever runs next."""
+        runnable = SimpleNamespace(ainvoke=AsyncMock(side_effect=RuntimeError("provider down")))
+
+        with pytest.raises(RuntimeError):
+            await research_module._run_research_query(
+                query=_query(),
+                researcher_runnable=runnable,
+                runtime=None,
+                callbacks=[],
+                semaphore=asyncio.Semaphore(1),
+            )
+
+        assert CURRENT_RESEARCHER_GUARD_STATE.get() is None
+
+    @pytest.mark.asyncio
+    async def test_the_state_is_built_without_reading_the_research_query(self):
+        """Structural guarantee that iteration 1 leaves the ResearchQuery schema alone.
+
+        A depth hint would have to be read off the query here. Nothing is, which is why
+        `ResearchQuery` is untouched by this change.
+        """
+        runnable = SimpleNamespace(ainvoke=AsyncMock(return_value={"structured_response": _notes()}))
+
+        with patch.object(
+            research_module,
+            "ResearcherRunGuardState",
+            wraps=ResearcherRunGuardState,
+        ) as build_state:
+            await research_module._run_research_query(
+                query=_query(),
+                researcher_runnable=runnable,
+                runtime=None,
+                callbacks=[],
+                semaphore=asyncio.Semaphore(1),
+            )
+
+        assert set(build_state.call_args.kwargs) == {"invocation_id"}
+        assert not build_state.call_args.args
+
+
+class TestPromptRendering:
+    """The researcher prompt must stay StrictUndefined-safe and keep today's guidance."""
+
+    _SOFT_GUIDANCE = "Default source budget per ResearchQuery"
+    _HARD_CEILING = "Hard limit (runtime-enforced)"
+    _WITHDRAWAL = "When source tools are withdrawn, research is over"
+
+    @staticmethod
+    def _render(**values) -> str:
+        return render_prompt_template(
+            _RESEARCHER_PROMPT,
+            current_datetime="2026-08-10",
+            user_info=None,
+            available_documents=[],
+            execution_enabled=False,
+            tools=[{"name": "web_search_tool", "description": "search"}],
+            **values,
+        )
+
+    def test_it_renders_when_the_new_variables_are_absent(self):
+        """`| default(false)` is mandatory: StrictUndefined would raise on a bare `{% if %}`."""
+        rendered = self._render()
+
+        assert self._SOFT_GUIDANCE in rendered
+        assert self._HARD_CEILING not in rendered
+
+    def test_disabled_mode_retains_todays_guidance_only(self):
+        """Turning the guard off must restore exactly today's prompt."""
+        rendered = self._render(
+            researcher_loop_guard_enabled=False,
+            researcher_max_source_calls=10,
+            researcher_max_identical_source_calls=2,
+        )
+
+        assert self._SOFT_GUIDANCE in rendered
+        assert "Do NOT get stuck retrying" in rendered
+        assert self._HARD_CEILING not in rendered
+        assert self._WITHDRAWAL not in rendered
+
+    def test_enabled_mode_adds_the_ceiling_without_removing_the_guidance(self):
+        """The behavioural budget and the backstop are separate instructions."""
+        rendered = self._render(
+            researcher_loop_guard_enabled=True,
+            researcher_max_source_calls=10,
+            researcher_max_identical_source_calls=2,
+        )
+
+        assert self._SOFT_GUIDANCE in rendered
+        assert "at most 10 source-tool calls" in rendered
+        assert "at most 2 call(s) with identical tool arguments" in rendered
+        assert "a backstop, not a target" in rendered
+
+    def test_enabled_mode_explains_the_graceful_exit(self):
+        """The ceiling states the limit; these bullets state what to do when it is reached."""
+        rendered = self._render(
+            researcher_loop_guard_enabled=True,
+            researcher_max_source_calls=10,
+            researcher_max_identical_source_calls=2,
+        )
+
+        assert self._WITHDRAWAL in rendered
+        assert "do not substitute `ls`, `read_file`, `glob`, `grep`" in rendered
+        assert "`ResearchGap`" in rendered
+        assert "Set `evidence_judgment` to reflect the truncation" in rendered
+        # Model-agnostic: never "call the ResearchNotes tool" - provider-strategy models have none.
+        assert "call the ResearchNotes tool" not in rendered
+
+
+class TestAgentConfig:
+    """The knob is reachable from YAML and defaults are validated."""
+
+    def test_the_yaml_block_round_trips(self):
+        config = register_module.DeepResearchAgentConfig.model_validate(
+            {
+                "_type": "deep_research_agent",
+                "orchestrator_llm": "llm",
+                "researcher_loop_guard": {
+                    "enabled": True,
+                    "max_source_calls_per_query": 25,
+                    "max_identical_source_calls": 3,
+                    "max_consecutive_thinks": 3,
+                    "max_model_turns_per_query": 60,
+                },
+            }
+        )
+
+        assert config.researcher_loop_guard.max_source_calls_per_query == 25
+        assert config.researcher_loop_guard.max_identical_source_calls == 3
+        assert config.researcher_loop_guard.max_model_turns_per_query == 60
+
+    def test_an_unknown_key_is_rejected(self):
+        """extra='forbid' turns a YAML typo into a startup failure rather than a silent no-op."""
+        with pytest.raises(ValidationError):
+            ResearcherLoopGuardConfig(max_source_calls=10)
+
+    def test_limits_must_be_at_least_one(self):
+        with pytest.raises(ValidationError):
+            ResearcherLoopGuardConfig(max_source_calls_per_query=0)
+
+    @pytest.mark.parametrize(
+        ("field", "ceiling"),
+        [
+            ("max_source_calls_per_query", loop_guard_module.SOURCE_CALLS_PER_QUERY_CEILING),
+            ("max_identical_source_calls", loop_guard_module.IDENTICAL_SOURCE_CALLS_CEILING),
+            ("max_consecutive_thinks", loop_guard_module.CONSECUTIVE_THINKS_CEILING),
+            ("max_model_turns_per_query", loop_guard_module.MODEL_TURNS_PER_QUERY_CEILING),
+        ],
+    )
+    def test_a_limit_raised_past_its_ceiling_is_rejected(self, field, ceiling):
+        """A breaker may be raised, but not so far that it stops being a breaker."""
+        assert getattr(ResearcherLoopGuardConfig(**{field: ceiling}), field) == ceiling
+
+        with pytest.raises(ValidationError):
+            ResearcherLoopGuardConfig(**{field: ceiling + 1})
+
+    def test_every_ceiling_sits_above_its_default(self):
+        """Deliberate divergence from resource_limits, where the default IS the maximum.
+
+        Raising a breaker that fires on healthy runs is the documented tuning path, so a
+        ceiling equal to the default would make that path unreachable.
+        """
+        defaults = ResearcherLoopGuardConfig()
+
+        assert defaults.max_source_calls_per_query < loop_guard_module.SOURCE_CALLS_PER_QUERY_CEILING
+        assert defaults.max_identical_source_calls < loop_guard_module.IDENTICAL_SOURCE_CALLS_CEILING
+        assert defaults.max_consecutive_thinks < loop_guard_module.CONSECUTIVE_THINKS_CEILING
+        assert defaults.max_model_turns_per_query < loop_guard_module.MODEL_TURNS_PER_QUERY_CEILING
+
+    def test_the_source_call_ceiling_matches_the_job_wide_source_call_ceiling(self):
+        """One worker must never be budgeted above what the whole job may retrieve."""
+        assert loop_guard_module.SOURCE_CALLS_PER_QUERY_CEILING == resource_limits.DEFAULT_MAX_SOURCE_TOOL_CALLS
+
+    def test_omitting_the_block_yields_the_shipped_defaults(self):
+        config = register_module.DeepResearchAgentConfig.model_validate(
+            {"_type": "deep_research_agent", "orchestrator_llm": "llm"}
+        )
+
+        assert config.researcher_loop_guard == ResearcherLoopGuardConfig()
+        assert config.researcher_loop_guard.max_source_calls_per_query == 25
+        assert config.researcher_loop_guard.max_identical_source_calls == 3
+
+
+def _query():
+    """Build a minimal valid ResearchQuery for the invocation-scoping tests."""
+    from aiq_agent.agents.deep_researcher.models import ResearchQuery
+
+    return ResearchQuery(
+        query="what is quantum error correction",
+        preferred_tools=[_SOURCE_TOOL],
+        target_components=["overview"],
+        rationale="test",
+    )
+
+
+def _notes() -> dict:
+    """Build a minimal valid ResearchNotes payload."""
+    return {
+        "query_topic": "topic",
+        "target_components": ["overview"],
+        "summary": "summary",
+        "findings": [],
+        "gaps": [],
+        "sources": [],
+        "narrative_notes": "notes",
+        "language": "en",
+    }


### PR DESCRIPTION
#### Overview

A researcher worker could loop indefinitely — repeating the same search, thinking without acting, or burning turns until the subgraph hit the orchestrator's inherited recursion limit of 2000 and lost all its gathered evidence to a `GraphRecursionError`. Prompt guidance alone did not stop it.

`ResearcherLoopGuardMiddleware` is a deterministic circuit breaker for one researcher worker — a single `ResearchQuery` inside `run_research_batch`. It runs underneath the model, so it does not depend on the model obeying the prompt. It never terminates the sub-agent: it withdraws tools and steers the model to return `ResearchNotes` with explicit `ResearchGap` entries, so a truncated worker still contributes the evidence it already gathered. State lives on a `ContextVar`, so concurrent workers each get an isolated budget and nothing leaks across requests.

Triggers (defaults; can be calibrated further):

| Trigger | Limit | Behavior |
| :-- | :-- | :-- |
| Source budget | 25 model-issued source calls (a batch counts as one) | Last result preserved, exhaustion notice appended |
| Identical request | 4th call with same tool + same args | Not executed; error `ToolMessage` returned |
| Consecutive `think` | 3 in a row | Never blocked; result overwritten with a warning and `think` withdrawn |
| Recursion limit | 80 graph steps ≈ 40 turns, derived from the budget | Hard stop |

Termination is enforced at three levels:

- **L1 — tool-call layer (graceful).** Wraps execution after the model emits a call; blocks or annotates it and records state. Needed because one assistant message can carry several calls: at 23/25, `[search(A), search(B), search(C)]` runs A (24) and B (25, budget hit → notice appended) and blocks C. Nothing upstream could stop C — the tool list for that turn was fixed before the model produced all three. This is also why the counter increments before awaiting the handler.
- **L2 — model-call layer (graceful).** Runs before each model call, reads the state L1 wrote, and strips withdrawn tools from `request.tools`. The next turn sees only `get_verified_sources`, `ls`, `read_file`, `grep`, `glob` → emits `ResearchNotes`.
- **L3 — graph layer (non-graceful).** Backstop for a model that ignores L1 and L2; terminates the researcher at the recursion limit. Final fallback.

Exposed as `researcher_loop_guard` on `DeepResearchAgentConfig`; `enabled=false` disables all three triggers, while the derived recursion limit still applies because inheriting the parent's bound is a defect rather than guard enforcement. The guard sits before `ToolRetryMiddleware` (a retried transient failure counts once) and after `ToolNameSanitizationMiddleware` (matched names are the sanitized ones).

#### DCO sign-off for the squash commit

Signed-off-by: smasurekar <smasurekar@nvidia.com>

#### Validation

- [x] I ran the relevant local checks or explained why they are not applicable.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-facing or contributor-facing changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.
- [x] I replaced the DCO sign-off placeholder with my GitHub commit identity and kept the required angle brackets around the email address.

#### Where should reviewers start?

Start with `ResearcherLoopGuardMiddleware` in `src/aiq_agent/agents/deep_researcher/custom_middleware.py` — specifically `_guard_source_call`, where the counter increments *before* awaiting the handler so parallel calls in one assistant message share a single ceiling. Then `build_researcher_middleware` and the derived `recursion_limit` in `factory.py`, and the `ContextVar` scoping in `tools/research.py::_run_research_query`.

#### Related Issues

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable safeguards for deep research, limiting source lookups, repeated requests, model turns, and consecutive reasoning steps.
  * Research stops safely when limits are reached, preserving findings while recording unresolved gaps and marking results as truncated.
  * Subsequent research requests automatically remove unavailable tools and prevent retry loops.
  * Added configuration options and documentation for enabling and tuning these safeguards.

* **Tests**
  * Added comprehensive coverage for limits, tool removal, recursion controls, configuration validation, and state cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->