### PR TITLE
fix(release): complete third-party attributions

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -8,10 +8,11 @@ we list the packages that are distributed under it and include the license text.
 The general inventory below is a curated notice snapshot, not an exhaustive
 or release-specific dependency inventory. Package versions in that inventory
 may differ from the current lock files. The AI-Q 2.2 release-container addendum
-at the end of this file is release-specific for the five distributions named
-there and was prepared from their lock-pinned artifacts. Release processes must
-still generate and review complete target-specific inventories from `uv.lock`,
-`mcp/uv.lock`, and `frontends/ui/package-lock.json`.
+below is release-specific for the six distributions named there and was
+prepared from their lock-pinned artifacts. A separate source-distribution-only
+addendum follows it. Release processes must still generate and review complete
+target-specific inventories from `uv.lock`, `mcp/uv.lock`, and
+`frontends/ui/package-lock.json`.
 
 ------------------------------------------------------------
 MIT License
@@ -221,7 +222,7 @@ and must be validated from upstream repositories:
 AI-Q 2.2 RELEASE CONTAINER ATTRIBUTION ADDENDUM
 ============================================================================
 
-This release-specific addendum covers the five Python distributions identified
+This release-specific addendum covers the six Python distributions identified
 in the AI-Q 2.2 release-container review. It supplements the general curated
 snapshot above. The package versions are pinned by `uv.lock`; loguru,
 nemoguardrails, py-rust-stemmers, and crc32c are also pinned by `mcp/uv.lock`.
@@ -4235,8 +4236,232 @@ Source: https://raw.githubusercontent.com/ICRAR/crc32c/v2.7.1/src/crc32c/ext/crc
 ----------------------------------------------------------------------------
 END VERBATIM: Mark Adler notice and upstream alteration notice
 
+----------------------------------------------------------------------------
+6. en-core-web-lg 3.8.0
+----------------------------------------------------------------------------
+
+Model license: MIT
+Included source/data notices: OntoNotes 5 commercial license (licensed by
+Explosion), ClearNLP citation, WordNet 3.0 License, and CC0.
+
+Wheel:
+  https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.8.0/en_core_web_lg-3.8.0-py3-none-any.whl
+  SHA-256: 293e9547a655b25499198ab15a525b05b9407a75f10255e405e8c3854329ab63
+
+The wheel's complete model license and source/data notices are reproduced
+below. The raw wheel-member digests are recorded before the release-addendum
+normalization described above.
+
+Wheel member: en_core_web_lg-3.8.0.dist-info/LICENSE
+  Raw SHA-256: 3933c176979b68bc6d0bcc902c7d6c130f1d127f476f17ba5cdba8d99cfd0012
+
+BEGIN VERBATIM: en-core-web-lg 3.8.0 LICENSE
+Source: en_core_web_lg-3.8.0-py3-none-any.whl member
+        en_core_web_lg-3.8.0.dist-info/LICENSE
+----------------------------------------------------------------------------
+Copyright 2021 ExplosionAI GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+----------------------------------------------------------------------------
+END VERBATIM: en-core-web-lg 3.8.0 LICENSE
+
+Wheel member: en_core_web_lg-3.8.0.dist-info/LICENSES_SOURCES
+  Raw SHA-256: ea21333cecd2593c1fea842e9362bedf7b556abfb97cd08ce0650f2228b2eb58
+
+BEGIN VERBATIM: en-core-web-lg 3.8.0 LICENSES_SOURCES
+Source: en_core_web_lg-3.8.0-py3-none-any.whl member
+        en_core_web_lg-3.8.0.dist-info/LICENSES_SOURCES
+----------------------------------------------------------------------------
+# OntoNotes 5
+
+* Author: Ralph Weischedel, Martha Palmer, Mitchell Marcus, Eduard Hovy, Sameer Pradhan, Lance Ramshaw, Nianwen Xue, Ann Taylor, Jeff Kaufman, Michelle Franchini, Mohammed El-Bachouti, Robert Belvin, Ann Houston
+* URL: https://catalog.ldc.upenn.edu/LDC2013T19
+* License: commercial (licensed by Explosion)
+
+```
+```
+
+
+
+
+# ClearNLP Constituent-to-Dependency Conversion
+
+* Author: Emory University
+* URL: https://github.com/clir/clearnlp-guidelines/blob/master/md/components/dependency_conversion.md
+* License: Citation provided for reference, no code packaged with model
+
+```
+```
+
+
+
+
+# WordNet 3.0
+
+* Author: Princeton University
+* URL: https://wordnet.princeton.edu/
+* License: WordNet 3.0 License
+
+```
+WordNet Release 3.0
+
+This software and database is being provided to you, the LICENSEE, by
+Princeton University under the following license.  By obtaining, using
+and/or copying this software and database, you agree that you have
+read, understood, and will comply with these terms and conditions.:
+
+Permission to use, copy, modify and distribute this software and
+database and its documentation for any purpose and without fee or
+royalty is hereby granted, provided that you agree to comply with
+the following copyright notice and statements, including the disclaimer,
+and that the same appear on ALL copies of the software, database and
+documentation, including modifications that you make for internal
+use or for distribution.
+
+WordNet 3.0 Copyright 2006 by Princeton University.  All rights reserved.
+
+THIS SOFTWARE AND DATABASE IS PROVIDED "AS IS" AND PRINCETON
+UNIVERSITY MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PRINCETON
+UNIVERSITY MAKES NO REPRESENTATIONS OR WARRANTIES OF MERCHANT-
+ABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE
+OF THE LICENSED SOFTWARE, DATABASE OR DOCUMENTATION WILL NOT
+INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR
+OTHER RIGHTS.
+
+The name of Princeton University or Princeton may not be used in
+advertising or publicity pertaining to distribution of the software
+and/or database.  Title to copyright in this software, database and
+any associated documentation shall at all times remain with
+Princeton University and LICENSEE agrees to preserve same.```
+
+
+
+
+# Explosion Vectors (OSCAR 2109 + Wikipedia + OpenSubtitles + WMT News Crawl)
+
+* Author: Explosion
+* URL: https://github.com/explosion/spacy-vectors-builder
+* License: CC0
+
+```
+The laws of most jurisdictions throughout the world automatically confer exclusive Copyright and Related Rights (defined below) upon the creator and subsequent owner(s) (each and all, an "owner") of an original work of authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for the purpose of contributing to a commons of creative, cultural and scientific works ("Commons") that the public can reliably and without fear of later claims of infringement build upon, modify, incorporate in other works, reuse and redistribute as freely as possible in any form whatsoever and for any purposes, including without limitation commercial purposes. These owners may contribute to the Commons to promote the ideal of a free culture and the further production of creative, cultural and scientific works, or to gain reputation or greater distribution for their Work in part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any expectation of additional consideration or compensation, the person associating CC0 with a Work (the "Affirmer"), to the extent that he or she is an owner of Copyright and Related Rights in the Work, voluntarily elects to apply CC0 to the Work and publicly distribute the Work under its terms, with knowledge of his or her Copyright and Related Rights in the Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be protected by copyright and related or neighboring rights ("Copyright and Related Rights"). Copyright and Related Rights include, but are not limited to, the following:
+
+the right to reproduce, adapt, distribute, perform, display, communicate, and translate a Work;
+moral rights retained by the original author(s) and/or performer(s);
+publicity and privacy rights pertaining to a person's image or likeness depicted in a Work;
+rights protecting against unfair competition in regards to a Work, subject to the limitations in paragraph 4(a), below;
+rights protecting the extraction, dissemination, use and reuse of data in a Work;
+database rights (such as those arising under Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, and under any national implementation thereof, including any amended or successor version of such directive); and
+other similar, equivalent or corresponding rights throughout the world based on applicable law or treaty, and any national implementations thereof.
+2. Waiver. To the greatest extent permitted by, but not in contravention of, applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and unconditionally waives, abandons, and surrenders all of Affirmer's Copyright and Related Rights and associated claims and causes of action, whether now known or unknown (including existing as well as future claims and causes of action), in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each member of the public at large and to the detriment of Affirmer's heirs and successors, fully intending that such Waiver shall not be subject to revocation, rescission, cancellation, termination, or any other legal or equitable action to disrupt the quiet enjoyment of the Work by the public as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason be judged legally invalid or ineffective under applicable law, then the Waiver shall be preserved to the maximum extent permitted taking into account Affirmer's express Statement of Purpose. In addition, to the extent the Waiver is so judged Affirmer hereby grants to each affected person a royalty-free, non transferable, non sublicensable, non exclusive, irrevocable and unconditional license to exercise Affirmer's Copyright and Related Rights in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "License"). The License shall be deemed effective as of the date CC0 was applied by Affirmer to the Work. Should any part of the License for any reason be judged legally invalid or ineffective under applicable law, such partial invalidity or ineffectiveness shall not invalidate the remainder of the License, and in such case Affirmer hereby affirms that he or she will not (i) exercise any of his or her remaining Copyright and Related Rights in the Work or (ii) assert any associated claims and causes of action with respect to the Work, in either case contrary to Affirmer's express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+No trademark or patent rights held by Affirmer are waived, abandoned, surrendered, licensed or otherwise affected by this document.
+Affirmer offers the Work as-is and makes no representations or warranties of any kind concerning the Work, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non infringement, or the absence of latent or other defects, accuracy, or the present or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.
+Affirmer disclaims responsibility for clearing rights of other persons that may apply to the Work or any use thereof, including without limitation any person's Copyright and Related Rights in the Work. Further, Affirmer disclaims responsibility for obtaining any necessary consents, permissions or other rights required for any use of the Work.
+Affirmer understands and acknowledges that Creative Commons is not a party to this document and has no duty or obligation with respect to this CC0 or use of the Work.```
+
+
+
+
+----------------------------------------------------------------------------
+END VERBATIM: en-core-web-lg 3.8.0 LICENSES_SOURCES
+
 ============================================================================
 END OF AI-Q 2.2 RELEASE CONTAINER ATTRIBUTION ADDENDUM
+============================================================================
+
+============================================================================
+AI-Q 2.2 SOURCE-DISTRIBUTION-ONLY ATTRIBUTION ADDENDUM
+============================================================================
+
+This addendum applies to the AI-Q source distribution only. The referenced
+documentation template is not installed in the AI-Q release container.
+
+----------------------------------------------------------------------------
+docs/source/_templates/sidebar-nav-bs.html
+----------------------------------------------------------------------------
+
+Licenses: BSD-3-Clause AND Apache-2.0
+Upstream copyright notice: Copyright (c) 2018, pandas
+
+The local template is a modified copy of pydata-sphinx-theme v0.16.1. The
+upstream BSD-3-Clause content and NVIDIA's Apache-2.0 modifications are both
+reflected in the license expression above.
+
+Upstream tag:
+  https://github.com/pydata/pydata-sphinx-theme/releases/tag/v0.16.1
+Upstream commit:
+  https://github.com/pydata/pydata-sphinx-theme/commit/c47786b993c85f0f442cc8d6e6b55e5d4e92b6b9
+Exact upstream template:
+  https://raw.githubusercontent.com/pydata/pydata-sphinx-theme/c47786b993c85f0f442cc8d6e6b55e5d4e92b6b9/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html
+Exact upstream license:
+  https://raw.githubusercontent.com/pydata/pydata-sphinx-theme/c47786b993c85f0f442cc8d6e6b55e5d4e92b6b9/LICENSE
+  Decoded SHA-256: d92fc698623827d7204139dee7874fbd7447f9256b8199acbd71cf8ee53d6f64
+
+BEGIN VERBATIM: pydata-sphinx-theme 0.16.1 BSD-3-Clause LICENSE
+Source: https://raw.githubusercontent.com/pydata/pydata-sphinx-theme/c47786b993c85f0f442cc8d6e6b55e5d4e92b6b9/LICENSE
+----------------------------------------------------------------------------
+BSD 3-Clause License
+
+Copyright (c) 2018, pandas
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+----------------------------------------------------------------------------
+END VERBATIM: pydata-sphinx-theme 0.16.1 BSD-3-Clause LICENSE
+
+============================================================================
+END OF AI-Q 2.2 SOURCE-DISTRIBUTION-ONLY ATTRIBUTION ADDENDUM
 ============================================================================
 
 END OF THIRD-PARTY LICENSES

--- a/docs/source/_templates/sidebar-nav-bs.html
+++ b/docs/source/_templates/sidebar-nav-bs.html
@@ -1,9 +1,44 @@
 {#
 SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: Copyright (c) 2018, pandas
+SPDX-License-Identifier: BSD-3-Clause AND Apache-2.0
 
-Modified from pydata-sphinx-theme sidebar-nav-bs.html (BSD-3-Clause).
-Removes the "Table of Contents" title from the sidebar navigation.
+Modified by NVIDIA from pydata-sphinx-theme v0.16.1 sidebar-nav-bs.html:
+https://github.com/pydata/pydata-sphinx-theme/blob/v0.16.1/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html
+
+The NVIDIA modifications remove the "Section Navigation" title, use a "Table
+of Contents" accessibility label, and generate the navigation tree from depth
+zero.
+
+BSD 3-Clause License
+
+Copyright (c) 2018, pandas
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #}
 
 <nav class="bd-docs-nav bd-links" aria-label="{{ _('Table of Contents') }}">

--- a/mcp/tests/test_deployment_assets.py
+++ b/mcp/tests/test_deployment_assets.py
@@ -22,6 +22,7 @@ _INIT_SQL = _REPO_ROOT / "mcp" / "deploy" / "init-mcp-db.sql"
 _DOCKERIGNORE = _REPO_ROOT / ".dockerignore"
 _SMOKE_SCRIPT = _REPO_ROOT / "mcp" / "scripts" / "protocol_smoke.py"
 _THIRD_PARTY_LICENSE = _REPO_ROOT / "LICENSE-THIRD-PARTY"
+_SIDEBAR_TEMPLATE = _REPO_ROOT / "docs" / "source" / "_templates" / "sidebar-nav-bs.html"
 
 _RELEASE_NOTICE_COMPONENTS = (
     "loguru 0.7.3",
@@ -30,6 +31,7 @@ _RELEASE_NOTICE_COMPONENTS = (
     "py-rust-stemmers 0.1.8",
     "pathspec 1.1.1",
     "crc32c 2.7.1",
+    "en-core-web-lg 3.8.0",
     "crossbeam-deque 0.8.6",
     "crossbeam-epoch 0.9.18",
     "crossbeam-utils 0.8.21",
@@ -92,6 +94,9 @@ _EXPECTED_VERBATIM_LABELS = (
     "crc32c 2.7.1 AUTHORS.google-crc32c",
     "Intel slicing-by-8 BSD-2-Clause notice and full terms",
     "Mark Adler notice and upstream alteration notice",
+    "en-core-web-lg 3.8.0 LICENSE",
+    "en-core-web-lg 3.8.0 LICENSES_SOURCES",
+    "pydata-sphinx-theme 0.16.1 BSD-3-Clause LICENSE",
 )
 _EXPECTED_VERBATIM_SHA256 = (
     "e0affae8:4147849a:9e507840:ebed9ac8:1e5f9ec0:f781f855:85e4a359:41a627a7",
@@ -130,6 +135,9 @@ _EXPECTED_VERBATIM_SHA256 = (
     "5d01d648:d5dd8271:6aac655a:4ab793a5:d56a0d4f:e357f1ba:71d4751f:41b47c15",
     "f8de74b6:c268ec04:e433d410:273a4075:fc506825:d4002485:a88a1157:55a9bb42",
     "3b9af289:61ab403a:b9005f0e:2cb6ec41:3564ce47:d15d2511:839fa061:9efb03e9",
+    "4a923943:099e2d38:13d7d282:ebb9d29f:089b7da:9ffc007b:c929ab50:f57555ee3",
+    "03737400:64971302:ab8882af:3ba85776:8da2e50c:de7486ec:936b3a00:7f49c4e1",
+    "618a8cd0:4f2e0c95:634f616a:1ced3584:dbbe7854:ce0037b9:e78bed0f:ca19ae59",
 )
 
 _EXPECTED_SQL_HASH = "05c27bca7385f6127017bee72ae067d02a49849db73b483d42868aaaf90341c7"  # pragma: allowlist secret
@@ -191,7 +199,16 @@ def _release_notice_section(text: str, section_number: int) -> str:
     section_marker = f"{separator}{section_number}. "
     section_start = text.index(section_marker, addendum_start) + len(separator)
     next_section = text.find(f"{separator}{section_number + 1}. ", section_start)
-    return text[section_start:] if next_section == -1 else text[section_start:next_section]
+    if next_section == -1:
+        end_marker = (
+            "\n============================================================================\nEND OF AI-Q 2.2 RELEASE"
+        )
+        next_section = text.index(end_marker, section_start)
+    return text[section_start:next_section]
+
+
+def _verbatim_payload(text: str, label: str) -> str:
+    return text.split(f"BEGIN VERBATIM: {label}\n", 1)[1].split(f"\nEND VERBATIM: {label}", 1)[0]
 
 
 def test_release_dockerfile_is_public_reproducible_and_non_root() -> None:
@@ -242,14 +259,18 @@ def test_aiq_final_images_include_project_and_third_party_licenses() -> None:
 
 def test_release_third_party_notice_contains_reviewed_payloads() -> None:
     text = _THIRD_PARTY_LICENSE.read_text()
-    sections = {number: _release_notice_section(text, number) for number in range(1, 6)}
-    rust_components = _RELEASE_NOTICE_COMPONENTS[6:]
+    sections = {number: _release_notice_section(text, number) for number in range(1, 7)}
+    rust_components = _RELEASE_NOTICE_COMPONENTS[7:]
+    assert "release-specific for the six distributions named there" in text
+    assert "A separate source-distribution-only\naddendum follows it." in text
+    assert "This release-specific addendum covers the six Python distributions identified" in text
     expected_components_by_section = {
         1: ("loguru 0.7.3",),
         2: ("nemoguardrails 0.21.0", "Inter 3.019"),
         3: ("py-rust-stemmers 0.1.8", *rust_components),
         4: ("pathspec 1.1.1",),
         5: ("crc32c 2.7.1",),
+        6: ("en-core-web-lg 3.8.0",),
     }
     for section_number, components in expected_components_by_section.items():
         missing_components = [component for component in components if component not in sections[section_number]]
@@ -296,6 +317,31 @@ def test_release_third_party_notice_contains_reviewed_payloads() -> None:
             "Copyright (C) 2013 Mark Adler",
             "GNU LESSER GENERAL PUBLIC LICENSE",
         ),
+        6: (
+            (
+                "https://github.com/explosion/spacy-models/releases/download/"
+                "en_core_web_lg-3.8.0/en_core_web_lg-3.8.0-py3-none-any.whl"
+            ),
+            "SHA-256: 293e9547a655b25499198ab15a525b05b9407a75f10255e405e8c3854329ab63",
+            "Wheel member: en_core_web_lg-3.8.0.dist-info/LICENSE",
+            "Raw SHA-256: 3933c176979b68bc6d0bcc902c7d6c130f1d127f476f17ba5cdba8d99cfd0012",
+            "Wheel member: en_core_web_lg-3.8.0.dist-info/LICENSES_SOURCES",
+            "Raw SHA-256: ea21333cecd2593c1fea842e9362bedf7b556abfb97cd08ce0650f2228b2eb58",
+            "Copyright 2021 ExplosionAI GmbH",
+            "# OntoNotes 5",
+            "* License: commercial (licensed by Explosion)",
+            "# ClearNLP Constituent-to-Dependency Conversion",
+            "* License: Citation provided for reference, no code packaged with model",
+            "# WordNet 3.0",
+            "Permission to use, copy, modify and distribute this software and",
+            "WordNet 3.0 Copyright 2006 by Princeton University.  All rights reserved.",
+            'THIS SOFTWARE AND DATABASE IS PROVIDED "AS IS" AND PRINCETON',
+            "The name of Princeton University or Princeton may not be used in",
+            "Title to copyright in this software, database and",
+            "# Explosion Vectors (OSCAR 2109 + Wikipedia + OpenSubtitles + WMT News Crawl)",
+            "* License: CC0",
+            "1. Copyright and Related Rights.",
+        ),
     }
     for section_number, notices in expected_notices_by_section.items():
         missing_notices = [notice for notice in notices if notice not in sections[section_number]]
@@ -311,9 +357,68 @@ def test_release_third_party_notice_contains_reviewed_payloads() -> None:
     assert end_labels == begin_labels
     assert len(_EXPECTED_VERBATIM_LABELS) == len(_EXPECTED_VERBATIM_SHA256)
     for label, expected_sha256 in zip(_EXPECTED_VERBATIM_LABELS, _EXPECTED_VERBATIM_SHA256, strict=True):
-        payload = text.split(f"BEGIN VERBATIM: {label}\n", 1)[1].split(f"\nEND VERBATIM: {label}", 1)[0]
+        payload = _verbatim_payload(text, label)
         assert hashlib.sha256(payload.encode()).hexdigest() == expected_sha256.replace(":", "")
     assert "/licenses/LICENSE-THIRD-PARTY" in text
+
+
+def test_source_only_pydata_notice_and_local_template_preserve_bsd_terms() -> None:
+    notices = _THIRD_PARTY_LICENSE.read_text()
+    source_addendum = notices.split("AI-Q 2.2 SOURCE-DISTRIBUTION-ONLY ATTRIBUTION ADDENDUM", 1)[1]
+    source_addendum = source_addendum.split("END OF AI-Q 2.2 SOURCE-DISTRIBUTION-ONLY ATTRIBUTION ADDENDUM", 1)[0]
+    template = _SIDEBAR_TEMPLATE.read_text()
+
+    assert _SIDEBAR_TEMPLATE.is_file()
+    assert "docs/source/_templates/sidebar-nav-bs.html" in source_addendum
+    assert (
+        "This addendum applies to the AI-Q source distribution only. The referenced\n"
+        "documentation template is not installed in the AI-Q release container."
+    ) in source_addendum
+    assert "pydata-sphinx-theme v0.16.1" in source_addendum
+    upstream_commit = "c47786b993c85f0f442cc8d6e6b55e5d4e92b6b9"  # pragma: allowlist secret
+    expected_urls = (
+        "https://github.com/pydata/pydata-sphinx-theme/releases/tag/v0.16.1",
+        f"https://github.com/pydata/pydata-sphinx-theme/commit/{upstream_commit}",
+        (
+            "https://raw.githubusercontent.com/pydata/pydata-sphinx-theme/"
+            f"{upstream_commit}/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html"
+        ),
+        f"https://raw.githubusercontent.com/pydata/pydata-sphinx-theme/{upstream_commit}/LICENSE",
+    )
+    for url in expected_urls:
+        assert url in source_addendum
+    assert "Decoded SHA-256: d92fc698623827d7204139dee7874fbd7447f9256b8199acbd71cf8ee53d6f64" in source_addendum
+    assert "Copyright (c) 2018, pandas" in source_addendum
+    assert "Licenses: BSD-3-Clause AND Apache-2.0" in source_addendum
+
+    license_payload = _verbatim_payload(notices, "pydata-sphinx-theme 0.16.1 BSD-3-Clause LICENSE")
+    separator = "----------------------------------------------------------------------------"
+    bsd_license = license_payload.split(f"{separator}\n", 1)[1]
+    bsd_license = bsd_license.rsplit(f"\n{separator}", 1)[0]
+    template_license = "BSD 3-Clause License" + template.split("BSD 3-Clause License", 1)[1].split("\n#}", 1)[0]
+    assert template_license == bsd_license
+    assert "* Redistributions of source code must retain the above copyright notice" in bsd_license
+    assert "* Redistributions in binary form must reproduce the above copyright notice" in bsd_license
+    assert "* Neither the name of the copyright holder nor the names of its" in bsd_license
+    assert 'THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"' in bsd_license
+
+    assert "SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES." in template
+    assert "SPDX-FileCopyrightText: Copyright (c) 2018, pandas" in template
+    assert "SPDX-License-Identifier: BSD-3-Clause AND Apache-2.0" in template
+    assert (
+        "Modified by NVIDIA from pydata-sphinx-theme v0.16.1 sidebar-nav-bs.html:\n"
+        "https://github.com/pydata/pydata-sphinx-theme/blob/v0.16.1/"
+        "src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html"
+    ) in template
+    assert (
+        'The NVIDIA modifications remove the "Section Navigation" title, use a "Table\n'
+        'of Contents" accessibility label, and generate the navigation tree from depth\n'
+        "zero."
+    ) in template
+    rendered_template = template.split("#}", 1)[1]
+    assert "Section Navigation" not in rendered_template
+    assert "aria-label=\"{{ _('Table of Contents') }}\"" in rendered_template
+    assert "startdepth=0" in rendered_template
 
 
 def test_init_sql_preserves_reference_schema_and_upgrade_history() -> None:


### PR DESCRIPTION
#### Overview

- Add the complete lock-pinned `en-core-web-lg 3.8.0` model notice payload to the AI-Q 2.2 release-container attribution addendum, including its MIT license, source/data notices, and the full WordNet 3.0 terms.
- Preserve the copied `pydata-sphinx-theme v0.16.1` template's pandas copyright and complete BSD-3-Clause conditions and disclaimer, alongside NVIDIA's Apache-2.0 modifications.
- Add regression coverage for the reviewed component metadata, immutable artifact digests, verbatim notice hashes, source-only attribution scope, and dual-license template header.

This is a focused follow-up to #438 and targets `release/2.2` at the Open Source Review Board's request. It changes attribution material and tests only; dependency resolution and container behavior are unchanged.

#### DCO sign-off for the squash commit

Signed-off-by: Tanner Leach <tleach@nvidia.com>

#### Validation

```text
mcp/.venv/bin/pytest -q mcp/tests/test_deployment_assets.py
19 passed in 0.31s

mcp/.venv/bin/pytest -q mcp/tests
242 passed, 18 skipped in 3.23s

.venv/bin/ruff check mcp/tests/test_deployment_assets.py
All checks passed!

.venv/bin/ruff format --check mcp/tests/test_deployment_assets.py
1 file already formatted

uv run pre-commit run --files LICENSE-THIRD-PARTY docs/source/_templates/sidebar-nav-bs.html mcp/tests/test_deployment_assets.py
All applicable hooks passed, including Ruff, merge-conflict and large-file checks, trailing-whitespace, and detect-secrets.

/home/tleach/workspaces/AIQ/aiq/.venv/bin/sphinx-build -M html docs/source /tmp/aiq-docs-attribution-follow-up-canonical --keep-going
Build succeeded with three pre-existing missing-document warnings for KNOWLEDGE-LAYER-SETUP and mcp/SECURITY.

git diff --check
Passed
```

Additionally, the embedded model `LICENSE` and `LICENSES_SOURCES` blocks were byte-compared with the lock-pinned wheel members after the notice file's documented trailing-whitespace normalization. The copied BSD-3-Clause block was byte-compared with the upstream `pydata-sphinx-theme v0.16.1` license.

- [x] I ran the relevant local checks or explained why they are not applicable.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-facing or contributor-facing changes.
- [x] I confirmed this PR does not include secrets, credentials, or internal-only data.
- [x] I certify this contribution under the Developer Certificate of Origin (DCO) and signed my commits with `git commit -s` or an equivalent sign-off.
- [x] I replaced the DCO sign-off placeholder with my GitHub commit identity and kept the required angle brackets around the email address.

#### Where should reviewers start?

Start with section 6 and the source-distribution-only addendum in `LICENSE-THIRD-PARTY`, then review the dual-license header in `docs/source/_templates/sidebar-nav-bs.html` and the hash-locked assertions in `mcp/tests/test_deployment_assets.py`.

#### Related Issues

- Relates to #438


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated third-party license inventory to include the `en-core-web-lg` 3.8.0 distribution and its associated attribution notices.
  - Added source-distribution licensing details for the customized navigation template.
  - Expanded license and provenance information for the sidebar template, including applicable BSD-3-Clause and Apache-2.0 terms.
  - Clarified the distinction between the general license snapshot, release addendum, and source-only notices.
  - Navigation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->